### PR TITLE
Add unified client layer and native SDK scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,61 @@ jobs:
       - name: Test
         run: dotnet test CSharpDB.slnx -c Release --no-build --verbosity minimal
 
+  native-aot:
+    name: NativeAOT (${{ matrix.os }} ${{ matrix.rid }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+            lib: CSharpDB.Native.so
+          - os: windows-latest
+            rid: win-x64
+            lib: CSharpDB.Native.dll
+          - os: macos-latest
+            rid: osx-arm64
+            lib: CSharpDB.Native.dylib
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install native toolchain (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish NativeAOT library
+        run: dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r ${{ matrix.rid }}
+
+      - name: Verify exported symbols (Linux)
+        if: runner.os == 'Linux'
+        run: nm -D src/CSharpDB.Native/bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.lib }} | grep -c csharpdb_
+
+      - name: Verify exported symbols (macOS)
+        if: runner.os == 'macOS'
+        run: nm -gU src/CSharpDB.Native/bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.lib }} | grep -c csharpdb_
+
+      - name: Verify exported symbols (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: dumpbin /exports src\CSharpDB.Native\bin\Release\net10.0\${{ matrix.rid }}\publish\${{ matrix.lib }} | Select-String "csharpdb_"
+
+      - name: Upload native library
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.rid }}
+          path: |
+            src/CSharpDB.Native/bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.lib }}
+            src/CSharpDB.Native/csharpdb.h
+          if-no-files-found: error
+
   pack:
     name: Pack NuGet Artifacts
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -68,6 +123,7 @@ jobs:
           dotnet pack src/CSharpDB.Engine/CSharpDB.Engine.csproj -c Release -o artifacts/nuget
           dotnet pack src/CSharpDB.Data/CSharpDB.Data.csproj -c Release -o artifacts/nuget
           dotnet pack src/CSharpDB.Storage.Diagnostics/CSharpDB.Storage.Diagnostics.csproj -c Release -o artifacts/nuget
+          dotnet pack src/CSharpDB.Client/CSharpDB.Client.csproj -c Release -o artifacts/nuget
           dotnet pack src/CSharpDB.Service/CSharpDB.Service.csproj -c Release -o artifacts/nuget
 
       - name: Upload NuGet artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,20 @@ jobs:
       - name: Verify exported symbols (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: dumpbin /exports src\CSharpDB.Native\bin\Release\net10.0\${{ matrix.rid }}\publish\${{ matrix.lib }} | Select-String "csharpdb_"
+        run: |
+          $dumpbin = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+            -latest `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -find 'VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe' |
+            Select-Object -First 1
+
+          if (-not $dumpbin) {
+            throw "Could not locate dumpbin.exe from the installed Visual Studio toolchain."
+          }
+
+          & $dumpbin /exports src\CSharpDB.Native\bin\Release\net10.0\${{ matrix.rid }}\publish\${{ matrix.lib }} |
+            Select-String "csharpdb_"
 
       - name: Upload native library
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,20 @@ jobs:
       - name: Verify exported symbols (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: dumpbin /exports src\CSharpDB.Native\bin\Release\net10.0\${{ matrix.rid }}\publish\${{ matrix.lib }} | Select-String "csharpdb_"
+        run: |
+          $dumpbin = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+            -latest `
+            -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -find 'VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe' |
+            Select-Object -First 1
+
+          if (-not $dumpbin) {
+            throw "Could not locate dumpbin.exe from the installed Visual Studio toolchain."
+          }
+
+          & $dumpbin /exports src\CSharpDB.Native\bin\Release\net10.0\${{ matrix.rid }}\publish\${{ matrix.lib }} |
+            Select-String "csharpdb_"
 
       - name: Upload native library
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
           dotnet pack src/CSharpDB.Engine/CSharpDB.Engine.csproj -c Release -o artifacts/nuget -p:Version="$version"
           dotnet pack src/CSharpDB.Data/CSharpDB.Data.csproj -c Release -o artifacts/nuget -p:Version="$version"
           dotnet pack src/CSharpDB.Storage.Diagnostics/CSharpDB.Storage.Diagnostics.csproj -c Release -o artifacts/nuget -p:Version="$version"
+          dotnet pack src/CSharpDB.Client/CSharpDB.Client.csproj -c Release -o artifacts/nuget -p:Version="$version"
           dotnet pack src/CSharpDB.Service/CSharpDB.Service.csproj -c Release -o artifacts/nuget -p:Version="$version"
 
       - name: Push packages to NuGet.org
@@ -112,9 +113,65 @@ jobs:
           path: artifacts/nuget/*.nupkg
           if-no-files-found: error
 
+  native-aot:
+    name: NativeAOT (${{ matrix.os }} ${{ matrix.rid }})
+    needs: build-and-test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+            lib: CSharpDB.Native.so
+          - os: windows-latest
+            rid: win-x64
+            lib: CSharpDB.Native.dll
+          - os: macos-latest
+            rid: osx-arm64
+            lib: CSharpDB.Native.dylib
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install native toolchain (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish NativeAOT library
+        run: dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r ${{ matrix.rid }}
+
+      - name: Verify exported symbols (Linux)
+        if: runner.os == 'Linux'
+        run: nm -D src/CSharpDB.Native/bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.lib }} | grep -c csharpdb_
+
+      - name: Verify exported symbols (macOS)
+        if: runner.os == 'macOS'
+        run: nm -gU src/CSharpDB.Native/bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.lib }} | grep -c csharpdb_
+
+      - name: Verify exported symbols (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: dumpbin /exports src\CSharpDB.Native\bin\Release\net10.0\${{ matrix.rid }}\publish\${{ matrix.lib }} | Select-String "csharpdb_"
+
+      - name: Upload native library
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.rid }}
+          path: |
+            src/CSharpDB.Native/bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.lib }}
+            src/CSharpDB.Native/csharpdb.h
+          if-no-files-found: error
+
   create-release:
     name: Create GitHub Release
-    needs: publish-nuget
+    needs: [publish-nuget, native-aot]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -128,6 +185,13 @@ jobs:
         with:
           name: nuget-packages
           path: artifacts/nuget
+
+      - name: Download native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: native-*
+          path: artifacts/native
+          merge-multiple: false
 
       - name: Resolve release notes
         id: notes
@@ -160,7 +224,9 @@ jobs:
         with:
           name: CSharpDB v${{ needs.publish-nuget.outputs.version }}
           body_path: ${{ steps.notes.outputs.path }}
-          files: artifacts/nuget/*.nupkg
+          files: |
+            artifacts/nuget/*.nupkg
+            artifacts/native/**/*
 
       - name: Create release (auto-generated notes)
         if: steps.notes.outputs.has_notes == 'false'
@@ -168,4 +234,6 @@ jobs:
         with:
           name: CSharpDB v${{ needs.publish-nuget.outputs.version }}
           generate_release_notes: true
-          files: artifacts/nuget/*.nupkg
+          files: |
+            artifacts/nuget/*.nupkg
+            artifacts/native/**/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,15 @@ Thanks for your interest in contributing.
 
 ## Development Setup
 
-Prerequisite: .NET 10 SDK
+Prerequisite: [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 
 ```bash
 dotnet --version
 dotnet restore CSharpDB.slnx
 dotnet build CSharpDB.slnx
 ```
+
+> **Note:** The default `dotnet build` excludes `CSharpDB.Native` because it requires a native C++ toolchain (see below). Everything else builds with just the .NET SDK.
 
 ## Running Tests
 
@@ -39,6 +41,79 @@ dotnet run --project tests/CSharpDB.Tests/CSharpDB.Tests.csproj --
 dotnet run --project tests/CSharpDB.Data.Tests/CSharpDB.Data.Tests.csproj --
 dotnet run --project tests/CSharpDB.Cli.Tests/CSharpDB.Cli.Tests.csproj --
 ```
+
+## Working with CSharpDB.Native (NativeAOT)
+
+The `CSharpDB.Native` project produces a standalone C-compatible shared library via NativeAOT. It is **excluded from the default solution build** because it requires a platform-specific C/C++ toolchain.
+
+### Prerequisites
+
+In addition to the .NET 10 SDK, you need a native linker:
+
+| Platform | Requirement |
+|----------|-------------|
+| **Windows** | Visual Studio with **"Desktop development with C++"** workload, or VS Build Tools with C++ component |
+| **Linux** | `clang` and `zlib1g-dev` (Ubuntu/Debian) or `clang` and `zlib-devel` (Fedora/RHEL) |
+| **macOS** | Xcode command-line tools (`xcode-select --install`) |
+
+### Building the native library
+
+```bash
+# Windows
+dotnet publish src/CSharpDB.Native -c Release -r win-x64
+
+# Linux
+dotnet publish src/CSharpDB.Native -c Release -r linux-x64
+
+# macOS (Apple Silicon)
+dotnet publish src/CSharpDB.Native -c Release -r osx-arm64
+```
+
+Output goes to `src/CSharpDB.Native/bin/Release/net10.0/<rid>/publish/`:
+- Windows: `CSharpDB.Native.dll`
+- Linux: `CSharpDB.Native.so`
+- macOS: `CSharpDB.Native.dylib`
+
+The library is fully self-contained — no .NET runtime dependency at the call site.
+
+### Including in solution build
+
+To include the native project in a full solution build:
+
+```bash
+dotnet build CSharpDB.slnx -p:BuildNative=true
+```
+
+### Verifying exports
+
+After publishing, verify the library exports the expected C symbols:
+
+```bash
+# Linux
+nm -D src/CSharpDB.Native/bin/Release/net10.0/linux-x64/publish/CSharpDB.Native.so | grep csharpdb_
+
+# macOS
+nm -gU src/CSharpDB.Native/bin/Release/net10.0/osx-arm64/publish/CSharpDB.Native.dylib | grep csharpdb_
+
+# Windows (Developer Command Prompt or PowerShell)
+dumpbin /exports src\CSharpDB.Native\bin\Release\net10.0\win-x64\publish\CSharpDB.Native.dll | Select-String "csharpdb_"
+```
+
+You should see 20 exported functions prefixed with `csharpdb_`.
+
+### Node.js client
+
+The `clients/node/` directory contains a TypeScript package that wraps the native library via [koffi](https://koffi.dev/). To work with it:
+
+```bash
+cd clients/node
+npm install
+npm test
+```
+
+The client automatically locates the native library in `clients/node/native/`, the `CSHARPDB_NATIVE_PATH` environment variable, or the current working directory.
+
+For more details, see the [Native Library Reference](src/CSharpDB.Native/README.md).
 
 ## Failure-Path Regression Checklist
 

--- a/CSharpDB.slnx
+++ b/CSharpDB.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/CSharpDB/CSharpDB.csproj" />
     <Project Path="src/CSharpDB.Core/CSharpDB.Core.csproj" />
+    <Project Path="src/CSharpDB.Client/CSharpDB.Client.csproj" />
     <Project Path="src/CSharpDB.Core.Compatibility/CSharpDB.Core.Compatibility.csproj" />
     <Project Path="src/CSharpDB.Engine/CSharpDB.Engine.csproj" />
     <Project Path="src/CSharpDB.Execution/CSharpDB.Execution.csproj" />

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A lightweight, embedded SQL database engine written from scratch in C#. Single-f
 [![.NET 10](https://img.shields.io/badge/.NET-10-512bd4)](https://dotnet.microsoft.com/download/dotnet/10.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/MaxAkbar/CSharpDB?display_name=tag&label=Release)](https://github.com/MaxAkbar/CSharpDB/releases/latest)
+[![NuGet](https://img.shields.io/nuget/v/CSharpDB.Service)](https://www.nuget.org/packages/CSharpDB.Service)
 
 ---
 
@@ -17,7 +18,7 @@ CSharpDB is a fully self-contained database engine that runs inside your .NET ap
 - Embedded databases for desktop, CLI, or IoT applications
 - Prototyping and local development without setting up a database server
 - Educational reference for understanding database internals (storage engines, B+trees, WAL, query planning)
-- Cross-language interoperability via the built-in REST API
+- Cross-language interoperability via the native C library, REST API, or Node.js package
 
 ## Features
 
@@ -29,11 +30,14 @@ CSharpDB is a fully self-contained database engine that runs inside your .NET ap
 | **SQL** | DDL, DML, JOINs, aggregates, GROUP BY, HAVING, CTEs, views, triggers, indexes, and `sys.*` catalog queries |
 | **NoSQL** | Typed `Collection<T>` with Put/Get/Delete/Scan/Find — 1.44M reads/sec |
 | **ADO.NET** | Standard `DbConnection`/`DbCommand`/`DbDataReader` provider |
+| **Client SDK** | `CSharpDB.Client` — unified API with pluggable transports (Direct, HTTP, gRPC, TCP, Named Pipes) |
+| **Native FFI** | NativeAOT-compiled C library (`.dll`/`.so`/`.dylib`) — use CSharpDB from Python, Node.js, Go, Rust, Swift, Kotlin, Dart, and more |
+| **Node.js Client** | TypeScript/JavaScript package (`csharpdb`) wrapping the native library via koffi |
 | **REST API** | ASP.NET Core Minimal API with 33 endpoints, OpenAPI/Scalar UI |
 | **MCP Server** | Model Context Protocol server — let AI assistants query and modify your database |
 | **Admin UI** | Blazor Server dashboard for browsing tables, views, indexes, triggers |
 | **Procedures** | Table-backed stored procedure catalog (`__procedures`) with typed params and transactional execution |
-| **CLI** | Interactive REPL with meta-commands, file execution, snapshot mode |
+| **CLI** | Interactive REPL with meta-commands, file execution, snapshot mode, remote connectivity |
 | **Dependencies** | Zero — pure .NET 10, nothing else |
 
 ## Admin UI Preview
@@ -125,7 +129,11 @@ curl http://localhost:61818/api/tables/users/rows
 ### CLI
 
 ```bash
+# Local database
 dotnet run --project src/CSharpDB.Cli -- mydata.db
+
+# Connect to a remote CSharpDB server
+dotnet run --project src/CSharpDB.Cli -- --endpoint http://localhost:61818
 
 csdb> CREATE TABLE demo (id INTEGER PRIMARY KEY, name TEXT);
 csdb> INSERT INTO demo VALUES (1, 'Hello');
@@ -165,6 +173,66 @@ args = ["run", "--project", "path/to/src/CSharpDB.Mcp", "--", "--database", "myd
 
 The MCP server exposes 15 tools for schema inspection, data browsing, row mutations, and SQL execution. See the [MCP Server Reference](docs/mcp-server.md) for the full tool list and configuration options for all supported clients.
 
+### Client SDK
+
+The unified `CSharpDB.Client` SDK provides a single `ICSharpDbClient` interface with pluggable transports:
+
+```csharp
+using CSharpDB.Client;
+
+// Direct (in-process) — default
+var client = CSharpDbClient.Create(new CSharpDbClientOptions
+{
+    DataSource = "mydata.db"
+});
+
+// All database operations go through the client
+var tables = await client.GetTableNamesAsync();
+var result = await client.ExecuteSqlAsync("SELECT * FROM users WHERE age > 25");
+await client.InsertRowAsync("users", new Dictionary<string, object?>
+{
+    ["id"] = 3, ["name"] = "Charlie", ["age"] = 28
+});
+
+// DI registration
+services.AddCSharpDbClient(new CSharpDbClientOptions { DataSource = "mydata.db" });
+```
+
+The transport layer supports Direct (in-process), HTTP, gRPC, TCP, and Named Pipes. Direct is fully implemented; network transports are part of the public API contract and planned for the service daemon milestone.
+
+### Cross-Language Interop (Native FFI)
+
+CSharpDB compiles to a standalone native library via NativeAOT — no .NET runtime required at the call site. Any language with C FFI support can use it.
+
+**Node.js (via `csharpdb` package):**
+
+```javascript
+import { Database } from 'csharpdb';
+
+const db = new Database('mydata.db');
+db.execute('CREATE TABLE demo (id INTEGER PRIMARY KEY, name TEXT)');
+db.execute("INSERT INTO demo VALUES (1, 'Alice')");
+
+for (const row of db.query('SELECT * FROM demo'))
+  console.log(row);
+
+db.close();
+```
+
+**Python (via ctypes — zero dependencies):**
+
+```python
+from csharpdb import Database
+
+with Database("mydata.db") as db:
+    db.execute("CREATE TABLE demo (id INTEGER PRIMARY KEY, name TEXT)")
+    db.execute("INSERT INTO demo VALUES (1, 'Alice')")
+    for row in db.query("SELECT * FROM demo"):
+        print(row)
+```
+
+The native library exports 20 C functions covering database lifecycle, SQL execution, result iteration, transactions, and error handling. See the [Native Library Reference](src/CSharpDB.Native/README.md) for the full API, build instructions, and examples for C, Go, Rust, Swift, Kotlin, and Dart.
+
 ## Architecture
 
 ```
@@ -194,26 +262,30 @@ The SQL path goes through tokenizer → parser → planner → operators → B+t
 ```
 CSharpDB.slnx
 ├── src/
-│   ├── CSharpDB.Core/        Primitives package source (DbValue, Schema, ErrorCodes)
+│   ├── CSharpDB.Core/        Primitives (DbValue, Schema, ErrorCodes)
 │   ├── CSharpDB/             All-in-one NuGet package metadata
 │   ├── CSharpDB.Storage/     Pager, B+tree, WAL, file I/O
-│   ├── CSharpDB.Sql/         Tokenizer, parser, AST
+│   ├── CSharpDB.Sql/         Tokenizer, parser, AST, script splitter
 │   ├── CSharpDB.Execution/   Query planner, operators, expression evaluator
 │   ├── CSharpDB.Engine/      Top-level Database API + Collection<T> (NoSQL)
+│   ├── CSharpDB.Client/      Unified client SDK with transport abstraction
 │   ├── CSharpDB.Data/        ADO.NET provider (DbConnection, DbCommand, DbDataReader)
+│   ├── CSharpDB.Native/      NativeAOT C FFI library for cross-language interop
 │   ├── CSharpDB.Storage.Diagnostics/ Storage diagnostics and integrity checking
-│   ├── CSharpDB.Cli/         Interactive REPL
-│   ├── CSharpDB.Service/     Shared service layer for Admin and API
+│   ├── CSharpDB.Cli/         Interactive REPL with remote connectivity
+│   ├── CSharpDB.Service/     Compatibility facade over CSharpDB.Client
 │   ├── CSharpDB.Admin/       Blazor Server admin dashboard
 │   ├── CSharpDB.Api/         REST API (ASP.NET Core Minimal API)
 │   └── CSharpDB.Mcp/         MCP server for AI assistant integration
+├── clients/
+│   └── node/                  Node.js/TypeScript client package (csharpdb)
 ├── tests/
 │   ├── CSharpDB.Tests/       Engine unit + integration tests
 │   ├── CSharpDB.Data.Tests/  ADO.NET provider tests
-│   ├── CSharpDB.Cli.Tests/   CLI smoke tests
+│   ├── CSharpDB.Cli.Tests/   CLI smoke + integration tests
 │   └── CSharpDB.Benchmarks/  Performance benchmarks (BenchmarkDotNet + custom)
 ├── samples/                   Sample SQL datasets
-└── docs/                      Documentation
+└── docs/                      Documentation + FFI tutorials
 ```
 
 ## Supported SQL
@@ -286,18 +358,24 @@ Each script creates 7 tables with sample data, indexes, views, and triggers. See
 
 See [docs/roadmap.md](docs/roadmap.md) for the full roadmap and status.
 
-**Recently completed (Near-term)**
-- `SELECT DISTINCT` support
-- Composite (multi-column) indexes
-- Prepared statement and SELECT plan caching
-- In-memory next-rowid caching for inserts
+**Recently completed**
+- Unified Client SDK (`CSharpDB.Client`) with transport abstraction
+- NativeAOT C FFI library (`CSharpDB.Native`) for cross-language interop
+- Node.js/TypeScript client package (`csharpdb`)
+- CLI remote connectivity (`--endpoint`, `--transport`)
+- SQL script splitter and statement classifier (`CSharpDB.Sql`)
+- Service layer refactor to facade over `CSharpDB.Client`
+- CI pipeline for cross-platform native library builds
+- `SELECT DISTINCT`, composite indexes, prepared statement caching
 
 **In progress**
-- Broader index range-scan planning (`<`, `>`, `<=`, `>=`, `BETWEEN`) beyond current ordered index path optimizations
+- Broader index range-scan planning (`<`, `>`, `<=`, `>=`, `BETWEEN`)
+- Service daemon for persistent background hosting (HTTP/gRPC/TCP/Named Pipes)
+- Network transport implementations for `CSharpDB.Client`
 
 **Still planned**
 - B+tree delete rebalancing
-- Architecture enforcement (single API gateway + HTTP client SDK)
+- Python and Go client packages
 
 **Mid-term**
 - Subqueries and `EXISTS`
@@ -317,10 +395,15 @@ See [docs/roadmap.md](docs/roadmap.md) for the full roadmap and status.
 | [Getting Started Tutorial](docs/getting-started.md) | Step-by-step walkthrough from opening a database to transactions |
 | [Architecture Guide](docs/architecture.md) | Layer-by-layer deep dive into the engine design |
 | [Internals & Contributing](docs/internals.md) | How to extend the engine, testing strategy, project layout |
+| [Client SDK](src/CSharpDB.Client/README.md) | Unified client API, transport model, and DI integration |
+| [Native Library Reference](src/CSharpDB.Native/README.md) | C FFI API, build instructions, and cross-language examples |
+| [Node.js Client](clients/node/README.md) | TypeScript/JavaScript package documentation |
 | [REST API Reference](docs/rest-api.md) | All 33 API endpoints with request/response examples |
 | [MCP Server Reference](docs/mcp-server.md) | AI assistant integration via Model Context Protocol |
 | [CLI Reference](docs/cli.md) | Interactive REPL commands and meta-commands |
 | [Storage Inspector](docs/storage-inspector.md) | Read-only DB/WAL integrity diagnostics and page-level inspection |
+| [Service Daemon Design](docs/service-daemon/README.md) | Background service architecture and roadmap |
+| [FFI Tutorials](docs/tutorials/native-ffi/) | Step-by-step JavaScript and Python interop guides |
 | [FAQ](docs/faq.md) | Common setup, SQL, Admin UI, and troubleshooting questions |
 | [Roadmap](docs/roadmap.md) | Near-term, mid-term, and long-term project goals |
 | [Benchmark Suite](tests/CSharpDB.Benchmarks/README.md) | Full benchmark results and comparison with 11 other databases |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,56 +1,25 @@
 # What's New
 
-## v1.5.0 (2026-03-07)
+## v1.6.0 (2026-03-08)
 
-### Insert Performance and Batching
-- Added a reusable engine batch API via `Database.PrepareInsertBatch()` and `InsertBatch` for low-allocation transactional inserts.
-- Added simple SQL insert fast paths for `INSERT INTO ... VALUES (...)`, including multi-row value lists.
-- Deferred table and index root persistence inside explicit transactions so batched inserts do not pay that work per row.
-- Added a prepared ADO.NET simple-insert path so compatible `CSharpDbCommand` executions can bypass the full SQL parser and planner.
+### Unified Client and Host Migration
+- Added `CSharpDB.Client` as the authoritative public database API with transport-selecting `CSharpDbClientOptions`, `ICSharpDbClient`, and DI registration helpers.
+- Added direct engine-backed client execution as the default behavior, with explicit transport selection for `Direct`, `Http`, `Grpc`, `Tcp`, and named pipes; non-direct network transports are recognized for future expansion.
+- Migrated the CLI, Web API, Admin UI, MCP host, and umbrella `CSharpDB` package to use the new client surface.
+- Reduced `CSharpDB.Service` to a compatibility facade so hosts no longer need a separate authoritative service API.
 
-### Storage Engine Allocation Reductions
-- Added zero-copy internal lookup paths for hot read callers to avoid unnecessary payload copies on primary-key and index hits.
-- Reworked slotted-page defragmentation and related B+tree rebalance paths to use span-based copies instead of per-cell heap allocations.
-- Tightened split-buffer sizing during leaf splits to reduce temporary pooled-buffer pressure.
+### SQL Ownership and Tooling Consistency
+- Moved SQL script splitting, statement completeness checks, and read/write classification into `CSharpDB.Sql`.
+- Updated the CLI REPL and direct client execution paths to share the same trigger-aware SQL parsing behavior.
+- Added transport-neutral client result shaping for schema, browsing, saved queries, procedures, diagnostics, and metadata flows used by host applications.
 
-### Benchmark Highlights
-- SQL batched insert throughput improved to about **605K rows/sec** in the macro benchmark median-of-3 run, up from the previously published **~294K rows/sec**.
-- SQL single-row insert throughput now measures about **22.2K ops/sec** in the same macro run.
-- SQL concurrent reader throughput at 8 readers now measures about **250K ops/sec**.
-- Prepared ADO.NET insert batches reduce managed allocation by about **43%** for `Batch100` while improving throughput by about **11%**.
+### Documentation and Packaging
+- Updated architecture, API, MCP, service, and package documentation to reflect the client-first design.
+- Added a dedicated `CSharpDB.Client` README and included the client in the `CSharpDB` metapackage.
+- Documented the API Scalar UI and MCP client-target configuration for local testing and integration.
+- Added `CSharpDB.Native`, a Node client package scaffold, and native FFI tutorials for JavaScript and Python consumers.
 
 ### Validation and Coverage
-- Added parser, integration, and ADO.NET tests for prepared inserts, reusable insert batches, schema invalidation, and reopen persistence.
-- Expanded micro and macro benchmark coverage for prepared ADO.NET insert execution and engine-level prepared insert batches.
-
-## v1.4.0 (2026-03-06)
-
-### SQL Completeness and Schema Metadata
-- Added first-class `IDENTITY` and `AUTOINCREMENT` column modifiers for `INTEGER` primary key columns.
-- Identity metadata is now persisted and surfaced across SQL/system metadata and tooling.
-- `sys.columns` now includes `is_identity` (0/1).
-- REST API, CLI, and MCP schema/table introspection now expose identity flags.
-- Backward compatibility preserved: legacy schemas without identity flags still surface `INTEGER PRIMARY KEY` columns as identity.
-
-### Query and Insert Path Improvements
-- Expanded integer ordered-index fast path for range predicates (`<`, `<=`, `>`, `>=`) and `BETWEEN`.
-- `next rowid` high-water mark is now stored in table schema metadata and reused across sessions.
-- Insert rowid allocation still accepts explicit values and advances the high-water mark when explicit values are higher.
-
-### Storage Engine
-- Implemented B+tree delete rebalancing with sibling borrow/merge for underflowed leaf pages.
-- Added interior-child collapse handling after delete rebalancing to keep tree structure valid.
-
-### Saved Queries and Admin UX
-- Added internal saved query catalog table (`__saved_queries`) with unique query names and UTC audit timestamps.
-- Added system virtual catalog projection for saved queries via `sys.saved_queries` (and `sys_saved_queries` alias).
-- Added Admin Object Explorer grouping for `System (Virtual)` items including `sys.saved_queries`.
-- Added Admin Query tab `Save`/`Load` UX for named SQL snippets with refreshable saved-query list.
-- Saved query catalog remains hidden from regular user table listings and table endpoints.
-
-### Validation and Test Coverage
-- Added parser/tokenizer coverage for `IDENTITY`/`AUTOINCREMENT` syntax and validation rules.
-- Added integration tests for identity insert behavior and persisted next-rowid continuity.
-- Added schema serializer compatibility tests for legacy metadata payloads.
-- Added B+tree delete rebalancing tests to validate merge/borrow behavior.
-- Added service/system/API tests for saved-query catalog behavior and virtual catalog projection.
+- Added CLI integration coverage for startup, `.info`, positional database paths, and `.read` script execution.
+- Added SQL-layer tests for script splitting, trigger-aware statement handling, and statement classification.
+- Added direct-client regression coverage for multi-statement execution and CLI/client file-handle reuse.

--- a/clients/node/.gitignore
+++ b/clients/node/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.db

--- a/clients/node/.gitignore
+++ b/clients/node/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+native/
 *.db

--- a/clients/node/README.md
+++ b/clients/node/README.md
@@ -1,0 +1,166 @@
+# csharpdb — Node.js Client
+
+TypeScript/JavaScript client for [CSharpDB](https://github.com/MaxAkbar/CSharpDB) embedded database, powered by the NativeAOT shared library via FFI.
+
+## Prerequisites
+
+1. **Publish the native library** (requires .NET 10 SDK + C++ toolchain):
+
+   ```bash
+   # Windows
+   dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r win-x64
+
+   # Linux
+   dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r linux-x64
+
+   # macOS
+   dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r osx-arm64
+   ```
+
+2. **Place the library** where the client can find it:
+
+   ```bash
+   mkdir native
+   # Copy the published library to ./native/
+   # Windows: CSharpDB.Native.dll
+   # Linux:   CSharpDB.Native.so
+   # macOS:   CSharpDB.Native.dylib
+   ```
+
+   Or set the `CSHARPDB_NATIVE_PATH` environment variable to the full path.
+
+## Install
+
+```bash
+npm install csharpdb
+```
+
+## Quick Start
+
+```ts
+import { Database } from 'csharpdb';
+
+const db = new Database('myapp.db');
+
+// Create tables
+db.execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
+
+// Insert data
+db.execute("INSERT INTO users VALUES (1, 'Alice', 'alice@example.com')");
+
+// Query rows (returns objects with typed values)
+const users = db.query('SELECT * FROM users');
+console.log(users);
+// [{ id: 1n, name: 'Alice', email: 'alice@example.com' }]
+
+// Query single row
+const user = db.queryOne('SELECT * FROM users WHERE id = 1');
+console.log(user?.name); // 'Alice'
+
+db.close();
+```
+
+## API Reference
+
+### `new Database(path, options?)`
+
+Open or create a database file.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | `string` | Database file path |
+| `options.nativeLibraryPath` | `string?` | Explicit path to the native library |
+
+### `db.execute(sql): ExecResult`
+
+Execute a non-query statement (INSERT, UPDATE, DELETE, CREATE TABLE, etc.).
+
+Returns `{ rowsAffected: number }`.
+
+### `db.query(sql): Row[]`
+
+Execute a SELECT and return all rows as an array of objects.
+
+**Value type mapping:**
+
+| CSharpDB Type | JavaScript Type |
+|---------------|-----------------|
+| INTEGER | `bigint` |
+| REAL | `number` |
+| TEXT | `string` |
+| BLOB | `Buffer` |
+| NULL | `null` |
+
+### `db.queryOne(sql): Row | null`
+
+Execute a SELECT and return the first row, or `null` if empty.
+
+### `db.iterate(sql): Generator<Row>`
+
+Execute a SELECT and yield rows one at a time via a generator. More memory-efficient for large result sets.
+
+```ts
+for (const row of db.iterate('SELECT * FROM large_table')) {
+  process.stdout.write(`${row.id}\n`);
+}
+```
+
+### `db.columns(sql): ColumnInfo[]`
+
+Get column metadata without consuming rows.
+
+### `db.transaction<T>(fn: () => T): T`
+
+Run a function inside an explicit transaction. Commits on success, rolls back on error.
+
+```ts
+db.transaction(() => {
+  db.execute("INSERT INTO orders VALUES (1, 'pending')");
+  db.execute("INSERT INTO items VALUES (1, 1, 'Widget', 2)");
+});
+```
+
+### `db.close()`
+
+Close the database. Safe to call multiple times.
+
+### `db.isOpen: boolean`
+
+Returns `true` if the database connection is open.
+
+## Error Handling
+
+All errors throw `CSharpDBError` with a `code` property:
+
+```ts
+import { CSharpDBError } from 'csharpdb';
+
+try {
+  db.execute('INVALID SQL');
+} catch (err) {
+  if (err instanceof CSharpDBError) {
+    console.error(`Error ${err.code}: ${err.message}`);
+  }
+}
+```
+
+## Native Library Search Order
+
+1. Explicit path via `options.nativeLibraryPath`
+2. `CSHARPDB_NATIVE_PATH` environment variable
+3. `./native/CSharpDB.Native.{dll,so,dylib}`
+4. Current working directory
+
+## Building from Source
+
+```bash
+cd clients/node
+npm install
+npm run build    # Compile TypeScript
+npm test         # Run tests (requires native library)
+npm run example  # Run basic example
+```
+
+## License
+
+MIT

--- a/clients/node/examples/basic.mjs
+++ b/clients/node/examples/basic.mjs
@@ -1,0 +1,78 @@
+/**
+ * Basic CSharpDB usage from Node.js.
+ *
+ * Prerequisites:
+ *   1. Publish the native library:
+ *      dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r win-x64
+ *
+ *   2. Copy the library to ./native/:
+ *      mkdir -p native
+ *      cp src/CSharpDB.Native/bin/Release/net10.0/win-x64/publish/CSharpDB.Native.dll native/
+ *
+ *   3. npm install && npm run build && node examples/basic.mjs
+ */
+
+import { Database } from "../dist/index.js";
+import { unlinkSync } from "node:fs";
+
+const DB_PATH = "example.db";
+
+// Clean up from previous runs
+try { unlinkSync(DB_PATH); } catch { /* ok */ }
+
+// Open a database
+const db = new Database(DB_PATH);
+console.log("Opened database:", DB_PATH);
+
+// Create a table
+db.execute(`
+  CREATE TABLE products (
+    id    INTEGER PRIMARY KEY,
+    name  TEXT,
+    price REAL,
+    stock INTEGER
+  )
+`);
+console.log("Created products table");
+
+// Insert rows inside a transaction
+db.transaction(() => {
+  db.execute("INSERT INTO products VALUES (1, 'Widget', 9.99, 100)");
+  db.execute("INSERT INTO products VALUES (2, 'Gadget', 24.95, 50)");
+  db.execute("INSERT INTO products VALUES (3, 'Doohickey', 3.50, 200)");
+});
+console.log("Inserted 3 products");
+
+// Query all rows
+console.log("\n--- All products ---");
+const rows = db.query("SELECT * FROM products ORDER BY id");
+for (const row of rows) {
+  console.log(`  ${row.id}: ${row.name} - $${row.price} (${row.stock} in stock)`);
+}
+
+// Query one row
+const cheapest = db.queryOne(
+  "SELECT name, price FROM products ORDER BY price LIMIT 1"
+);
+console.log(`\nCheapest product: ${cheapest?.name} at $${cheapest?.price}`);
+
+// Update with affected count
+const result = db.execute("UPDATE products SET stock = stock - 10 WHERE price > 5");
+console.log(`\nUpdated ${result.rowsAffected} products`);
+
+// Iterate using generator (memory efficient for large result sets)
+console.log("\n--- Iterating with generator ---");
+for (const row of db.iterate("SELECT name, stock FROM products")) {
+  console.log(`  ${row.name}: ${row.stock} units`);
+}
+
+// Column metadata
+const cols = db.columns("SELECT id, name, price FROM products");
+console.log("\nColumns:", cols.map((c) => c.name).join(", "));
+
+// Cleanup
+db.close();
+console.log("\nDatabase closed.");
+
+// Remove temp file
+try { unlinkSync(DB_PATH); } catch { /* ok */ }

--- a/clients/node/package-lock.json
+++ b/clients/node/package-lock.json
@@ -1,0 +1,64 @@
+{
+  "name": "csharpdb",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "csharpdb",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "koffi": "^2.9.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
+      "integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/clients/node/package.json
+++ b/clients/node/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "csharpdb",
+  "version": "1.0.0",
+  "description": "Node.js client for CSharpDB embedded database via NativeAOT FFI",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test tests/csharpdb.test.mjs",
+    "example": "node examples/basic.mjs"
+  },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "keywords": [
+    "database",
+    "embedded",
+    "sql",
+    "csharpdb",
+    "native",
+    "ffi"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "koffi": "^2.9.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/clients/node/src/index.ts
+++ b/clients/node/src/index.ts
@@ -1,0 +1,308 @@
+/**
+ * CSharpDB Node.js client — high-level TypeScript API over the NativeAOT shared library.
+ *
+ * @example
+ * ```ts
+ * import { Database } from 'csharpdb';
+ *
+ * const db = new Database('mydata.db');
+ * db.execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
+ * db.execute("INSERT INTO users VALUES (1, 'Alice')");
+ *
+ * for (const row of db.query('SELECT * FROM users')) {
+ *   console.log(row);  // { id: 1n, name: 'Alice' }
+ * }
+ *
+ * db.close();
+ * ```
+ */
+
+import koffi from "koffi";
+import { loadNativeLibrary, type NativeBindings, type DbHandle, type ResultHandle } from "./native.js";
+
+// ---------- Column type constants (matches CSharpDB.Core.DbType) ----------
+
+/** Column type codes returned by the native library. */
+export const ColumnType = {
+  NULL: 0,
+  INTEGER: 1,
+  REAL: 2,
+  TEXT: 3,
+  BLOB: 4,
+} as const;
+
+export type ColumnTypeValue = (typeof ColumnType)[keyof typeof ColumnType];
+
+// ---------- Public types ----------
+
+/** A single row returned by a query, mapping column names to JS values. */
+export type Row = Record<string, bigint | number | string | Buffer | null>;
+
+/** Column metadata from a query result. */
+export interface ColumnInfo {
+  name: string;
+  index: number;
+}
+
+/** Result of a non-query (INSERT/UPDATE/DELETE/DDL) execution. */
+export interface ExecResult {
+  rowsAffected: number;
+}
+
+/** Options for opening a database. */
+export interface DatabaseOptions {
+  /** Path to the CSharpDB NativeAOT shared library. Auto-detected if omitted. */
+  nativeLibraryPath?: string;
+}
+
+// ---------- CSharpDB Error ----------
+
+export class CSharpDBError extends Error {
+  constructor(
+    message: string,
+    public readonly code: number
+  ) {
+    super(message);
+    this.name = "CSharpDBError";
+  }
+}
+
+// ---------- Database class ----------
+
+export class Database {
+  private _native: NativeBindings;
+  private _handle: DbHandle | null;
+
+  /**
+   * Open or create a CSharpDB database.
+   * @param path File path for the database (created if it doesn't exist).
+   * @param options Optional configuration.
+   */
+  constructor(path: string, options?: DatabaseOptions) {
+    this._native = loadNativeLibrary(options?.nativeLibraryPath);
+    this._handle = this._native.csharpdb_open(path);
+    if (!this._handle) {
+      throw this._makeError();
+    }
+  }
+
+  /** Returns true if the database is open. */
+  get isOpen(): boolean {
+    return this._handle !== null;
+  }
+
+  /**
+   * Execute a SQL statement that does not return rows (INSERT, UPDATE, DELETE, DDL).
+   * @returns Number of rows affected.
+   */
+  execute(sql: string): ExecResult {
+    const result = this._exec(sql);
+    try {
+      const rowsAffected = this._native.csharpdb_result_rows_affected(result);
+      return { rowsAffected };
+    } finally {
+      this._native.csharpdb_result_free(result);
+    }
+  }
+
+  /**
+   * Execute a SELECT query and return all matching rows as an array.
+   * Each row is an object mapping column name -> value.
+   *
+   * Values are returned as:
+   * - INTEGER -> bigint
+   * - REAL -> number
+   * - TEXT -> string
+   * - BLOB -> Buffer
+   * - NULL -> null
+   */
+  query(sql: string): Row[] {
+    const result = this._exec(sql);
+    try {
+      return this._readRows(result);
+    } finally {
+      this._native.csharpdb_result_free(result);
+    }
+  }
+
+  /**
+   * Execute a SELECT query and return the first row, or null if empty.
+   */
+  queryOne(sql: string): Row | null {
+    const result = this._exec(sql);
+    try {
+      const columns = this._getColumns(result);
+      const status = this._native.csharpdb_result_next(result);
+      if (status === -1) throw this._makeError();
+      if (status === 0) return null;
+      return this._readCurrentRow(result, columns);
+    } finally {
+      this._native.csharpdb_result_free(result);
+    }
+  }
+
+  /**
+   * Iterate over query results row-by-row using a generator.
+   * More memory-efficient for large result sets.
+   *
+   * **Important:** The generator holds a native result handle. Always consume it
+   * fully or use a `for...of` loop which handles cleanup via `.return()`.
+   */
+  *iterate(sql: string): Generator<Row, void, undefined> {
+    const result = this._exec(sql);
+    try {
+      const columns = this._getColumns(result);
+      while (true) {
+        const status = this._native.csharpdb_result_next(result);
+        if (status === -1) throw this._makeError();
+        if (status === 0) break;
+        yield this._readCurrentRow(result, columns);
+      }
+    } finally {
+      this._native.csharpdb_result_free(result);
+    }
+  }
+
+  /**
+   * Get column metadata for a query without consuming rows.
+   */
+  columns(sql: string): ColumnInfo[] {
+    const result = this._exec(sql);
+    try {
+      return this._getColumns(result);
+    } finally {
+      this._native.csharpdb_result_free(result);
+    }
+  }
+
+  /**
+   * Run a function inside an explicit transaction.
+   * Automatically commits on success or rolls back on error.
+   */
+  transaction<T>(fn: () => T): T {
+    this._ensureOpen();
+    if (this._native.csharpdb_begin(this._handle!) === -1) {
+      throw this._makeError();
+    }
+    try {
+      const result = fn();
+      if (this._native.csharpdb_commit(this._handle!) === -1) {
+        throw this._makeError();
+      }
+      return result;
+    } catch (err) {
+      this._native.csharpdb_rollback(this._handle!);
+      throw err;
+    }
+  }
+
+  /**
+   * Close the database and release all native resources.
+   * Safe to call multiple times.
+   */
+  close(): void {
+    if (this._handle) {
+      this._native.csharpdb_close(this._handle);
+      this._handle = null;
+    }
+  }
+
+  /** Alias for close() — enables use with explicit cleanup patterns. */
+  [Symbol.dispose](): void {
+    this.close();
+  }
+
+  // ---------- Private helpers ----------
+
+  private _ensureOpen(): void {
+    if (!this._handle) {
+      throw new CSharpDBError("Database is closed", 0);
+    }
+  }
+
+  private _exec(sql: string): ResultHandle {
+    this._ensureOpen();
+    const result = this._native.csharpdb_execute(this._handle!, sql);
+    if (!result) {
+      throw this._makeError();
+    }
+    return result;
+  }
+
+  private _makeError(): CSharpDBError {
+    const msg = this._native.csharpdb_last_error() ?? "Unknown CSharpDB error";
+    const code = this._native.csharpdb_last_error_code();
+    return new CSharpDBError(msg, code);
+  }
+
+  private _getColumns(result: ResultHandle): ColumnInfo[] {
+    const count = this._native.csharpdb_result_column_count(result);
+    const columns: ColumnInfo[] = [];
+    for (let i = 0; i < count; i++) {
+      columns.push({
+        name: this._native.csharpdb_result_column_name(result, i) ?? `col${i}`,
+        index: i,
+      });
+    }
+    return columns;
+  }
+
+  private _readCurrentRow(result: ResultHandle, columns: ColumnInfo[]): Row {
+    const row: Row = {};
+    for (const col of columns) {
+      if (this._native.csharpdb_result_is_null(result, col.index) === 1) {
+        row[col.name] = null;
+        continue;
+      }
+      const type = this._native.csharpdb_result_column_type(result, col.index);
+      switch (type) {
+        case ColumnType.INTEGER:
+          row[col.name] = this._native.csharpdb_result_get_int64(result, col.index);
+          break;
+        case ColumnType.REAL:
+          row[col.name] = this._native.csharpdb_result_get_double(result, col.index);
+          break;
+        case ColumnType.TEXT:
+          row[col.name] = this._native.csharpdb_result_get_text(result, col.index) ?? "";
+          break;
+        case ColumnType.BLOB: {
+          const sizeBuffer = Buffer.alloc(4);
+          const ptr = this._native.csharpdb_result_get_blob(result, col.index, sizeBuffer);
+          const size = sizeBuffer.readInt32LE();
+          // koffi returns the blob data — we copy it into a Node Buffer
+          if (ptr && size > 0) {
+            row[col.name] = Buffer.from(koffi_decode(ptr, size));
+          } else {
+            row[col.name] = Buffer.alloc(0);
+          }
+          break;
+        }
+        default:
+          row[col.name] = null;
+      }
+    }
+    return row;
+  }
+
+  private _readRows(result: ResultHandle): Row[] {
+    const columns = this._getColumns(result);
+    const rows: Row[] = [];
+    while (true) {
+      const status = this._native.csharpdb_result_next(result);
+      if (status === -1) throw this._makeError();
+      if (status === 0) break;
+      rows.push(this._readCurrentRow(result, columns));
+    }
+    return rows;
+  }
+}
+
+// koffi helper for decoding raw pointer to Buffer (blob support)
+function koffi_decode(ptr: unknown, size: number): Uint8Array {
+  return koffi.decode(ptr, "uint8_t", size) as Uint8Array;
+}
+
+// ---------- Exports ----------
+
+export { loadNativeLibrary } from "./native.js";
+export type { NativeBindings, DbHandle, ResultHandle } from "./native.js";

--- a/clients/node/src/native.ts
+++ b/clients/node/src/native.ts
@@ -1,0 +1,130 @@
+/**
+ * Low-level FFI bindings to the CSharpDB NativeAOT shared library.
+ * Uses koffi to load and call the C API functions.
+ */
+
+import koffi from "koffi";
+import { platform } from "node:os";
+import { resolve, dirname } from "node:path";
+import { existsSync } from "node:fs";
+
+// ---------- Type aliases matching csharpdb.h ----------
+
+/** Opaque database handle (void*) */
+export type DbHandle = unknown;
+/** Opaque result handle (void*) */
+export type ResultHandle = unknown;
+
+// ---------- Library loader ----------
+
+function getDefaultLibraryName(): string {
+  switch (platform()) {
+    case "win32":
+      return "CSharpDB.Native.dll";
+    case "darwin":
+      return "CSharpDB.Native.dylib";
+    default:
+      return "CSharpDB.Native.so";
+  }
+}
+
+function findLibrary(customPath?: string): string {
+  if (customPath) {
+    if (!existsSync(customPath)) {
+      throw new Error(`CSharpDB native library not found at: ${customPath}`);
+    }
+    return customPath;
+  }
+
+  const libName = getDefaultLibraryName();
+
+  // Search order:
+  // 1. CSHARPDB_NATIVE_PATH env var
+  // 2. ./native/<libName>  (next to consuming app)
+  // 3. Same directory as this module
+  const searchPaths = [
+    process.env["CSHARPDB_NATIVE_PATH"],
+    resolve(process.cwd(), "native", libName),
+    resolve(process.cwd(), libName),
+    resolve(dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1")), "..", "native", libName),
+  ].filter(Boolean) as string[];
+
+  for (const p of searchPaths) {
+    if (existsSync(p)) return p;
+  }
+
+  throw new Error(
+    `CSharpDB native library not found. Searched:\n${searchPaths.map((p) => `  - ${p}`).join("\n")}\n\n` +
+      `Set CSHARPDB_NATIVE_PATH or place ${libName} in ./native/`
+  );
+}
+
+// ---------- FFI declarations ----------
+
+export interface NativeBindings {
+  // Database lifecycle
+  csharpdb_open(path: string): DbHandle;
+  csharpdb_close(db: DbHandle): void;
+
+  // SQL execution
+  csharpdb_execute(db: DbHandle, sql: string): ResultHandle;
+
+  // Result metadata
+  csharpdb_result_is_query(result: ResultHandle): number;
+  csharpdb_result_rows_affected(result: ResultHandle): number;
+  csharpdb_result_column_count(result: ResultHandle): number;
+  csharpdb_result_column_name(result: ResultHandle, index: number): string | null;
+
+  // Row iteration
+  csharpdb_result_next(result: ResultHandle): number;
+  csharpdb_result_column_type(result: ResultHandle, index: number): number;
+  csharpdb_result_is_null(result: ResultHandle, index: number): number;
+
+  // Value access
+  csharpdb_result_get_int64(result: ResultHandle, index: number): bigint;
+  csharpdb_result_get_double(result: ResultHandle, index: number): number;
+  csharpdb_result_get_text(result: ResultHandle, index: number): string | null;
+  csharpdb_result_get_blob(result: ResultHandle, index: number, outSize: Buffer): unknown;
+
+  // Result cleanup
+  csharpdb_result_free(result: ResultHandle): void;
+
+  // Transactions
+  csharpdb_begin(db: DbHandle): number;
+  csharpdb_commit(db: DbHandle): number;
+  csharpdb_rollback(db: DbHandle): number;
+
+  // Error handling
+  csharpdb_last_error(): string | null;
+  csharpdb_last_error_code(): number;
+  csharpdb_clear_error(): void;
+}
+
+export function loadNativeLibrary(libraryPath?: string): NativeBindings {
+  const libPath = findLibrary(libraryPath);
+  const lib = koffi.load(libPath);
+
+  return {
+    csharpdb_open: lib.func("csharpdb_open", "void*", ["str"]),
+    csharpdb_close: lib.func("csharpdb_close", "void", ["void*"]),
+    csharpdb_execute: lib.func("csharpdb_execute", "void*", ["void*", "str"]),
+    csharpdb_result_is_query: lib.func("csharpdb_result_is_query", "int", ["void*"]),
+    csharpdb_result_rows_affected: lib.func("csharpdb_result_rows_affected", "int", ["void*"]),
+    csharpdb_result_column_count: lib.func("csharpdb_result_column_count", "int", ["void*"]),
+    csharpdb_result_column_name: lib.func("csharpdb_result_column_name", "str", ["void*", "int"]),
+    csharpdb_result_next: lib.func("csharpdb_result_next", "int", ["void*"]),
+    csharpdb_result_column_type: lib.func("csharpdb_result_column_type", "int", ["void*", "int"]),
+    csharpdb_result_is_null: lib.func("csharpdb_result_is_null", "int", ["void*", "int"]),
+    csharpdb_result_get_int64: lib.func("csharpdb_result_get_int64", "int64_t", ["void*", "int"]),
+    csharpdb_result_get_double: lib.func("csharpdb_result_get_double", "double", ["void*", "int"]),
+    csharpdb_result_get_text: lib.func("csharpdb_result_get_text", "str", ["void*", "int"]),
+    csharpdb_result_get_blob: lib.func("csharpdb_result_get_blob", "void*", ["void*", "int", "uint8_t*"]),
+    csharpdb_result_free: lib.func("csharpdb_result_free", "void", ["void*"]),
+    csharpdb_begin: lib.func("csharpdb_begin", "int", ["void*"]),
+    csharpdb_commit: lib.func("csharpdb_commit", "int", ["void*"]),
+    csharpdb_rollback: lib.func("csharpdb_rollback", "int", ["void*"]),
+    csharpdb_last_error: lib.func("csharpdb_last_error", "str", []),
+    csharpdb_last_error_code: lib.func("csharpdb_last_error_code", "int", []),
+    csharpdb_clear_error: lib.func("csharpdb_clear_error", "void", []),
+  };
+}

--- a/clients/node/tests/csharpdb.test.mjs
+++ b/clients/node/tests/csharpdb.test.mjs
@@ -1,0 +1,211 @@
+/**
+ * CSharpDB Node.js client tests.
+ *
+ * Requires the native library to be published and available.
+ * Run with: node --test tests/csharpdb.test.mjs
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { unlinkSync, existsSync } from "node:fs";
+import { Database, CSharpDBError, ColumnType } from "../dist/index.js";
+
+const TEST_DB = "test_csharpdb.db";
+
+function cleanup() {
+  try {
+    if (existsSync(TEST_DB)) unlinkSync(TEST_DB);
+  } catch {
+    /* ok */
+  }
+}
+
+describe("Database", () => {
+  /** @type {Database} */
+  let db;
+
+  before(() => {
+    cleanup();
+  });
+
+  after(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    cleanup();
+    db = new Database(TEST_DB);
+  });
+
+  after(() => {
+    if (db?.isOpen) db.close();
+  });
+
+  describe("open/close", () => {
+    it("should open a new database", () => {
+      assert.equal(db.isOpen, true);
+      db.close();
+      assert.equal(db.isOpen, false);
+    });
+
+    it("should allow closing multiple times", () => {
+      db.close();
+      db.close(); // should not throw
+    });
+
+    it("should throw on operations after close", () => {
+      db.close();
+      assert.throws(() => db.execute("SELECT 1"), CSharpDBError);
+    });
+  });
+
+  describe("execute", () => {
+    it("should create a table", () => {
+      const result = db.execute("CREATE TABLE t (id INTEGER, name TEXT)");
+      assert.equal(result.rowsAffected, 0);
+    });
+
+    it("should insert rows and return affected count", () => {
+      db.execute("CREATE TABLE t (id INTEGER, name TEXT)");
+      const r1 = db.execute("INSERT INTO t VALUES (1, 'hello')");
+      assert.equal(r1.rowsAffected, 1);
+    });
+
+    it("should throw on invalid SQL", () => {
+      assert.throws(() => db.execute("INVALID SQL"), CSharpDBError);
+    });
+  });
+
+  describe("query", () => {
+    it("should return rows as objects", () => {
+      db.execute("CREATE TABLE t (id INTEGER, name TEXT)");
+      db.execute("INSERT INTO t VALUES (1, 'Alice')");
+      db.execute("INSERT INTO t VALUES (2, 'Bob')");
+
+      const rows = db.query("SELECT id, name FROM t ORDER BY id");
+      assert.equal(rows.length, 2);
+      assert.equal(rows[0].id, 1n); // bigint
+      assert.equal(rows[0].name, "Alice");
+      assert.equal(rows[1].id, 2n);
+      assert.equal(rows[1].name, "Bob");
+    });
+
+    it("should return empty array for no matches", () => {
+      db.execute("CREATE TABLE t (id INTEGER)");
+      const rows = db.query("SELECT * FROM t");
+      assert.deepEqual(rows, []);
+    });
+
+    it("should handle NULL values", () => {
+      db.execute("CREATE TABLE t (id INTEGER, val TEXT)");
+      db.execute("INSERT INTO t VALUES (1, NULL)");
+
+      const rows = db.query("SELECT * FROM t");
+      assert.equal(rows[0].val, null);
+    });
+
+    it("should handle REAL values", () => {
+      db.execute("CREATE TABLE t (val REAL)");
+      db.execute("INSERT INTO t VALUES (3.14)");
+
+      const rows = db.query("SELECT val FROM t");
+      assert.ok(Math.abs(Number(rows[0].val) - 3.14) < 0.001);
+    });
+  });
+
+  describe("queryOne", () => {
+    it("should return single row", () => {
+      db.execute("CREATE TABLE t (id INTEGER, name TEXT)");
+      db.execute("INSERT INTO t VALUES (1, 'Alice')");
+
+      const row = db.queryOne("SELECT * FROM t WHERE id = 1");
+      assert.notEqual(row, null);
+      assert.equal(row?.name, "Alice");
+    });
+
+    it("should return null when no rows", () => {
+      db.execute("CREATE TABLE t (id INTEGER)");
+      const row = db.queryOne("SELECT * FROM t");
+      assert.equal(row, null);
+    });
+  });
+
+  describe("iterate", () => {
+    it("should yield rows via generator", () => {
+      db.execute("CREATE TABLE t (id INTEGER)");
+      db.execute("INSERT INTO t VALUES (1)");
+      db.execute("INSERT INTO t VALUES (2)");
+      db.execute("INSERT INTO t VALUES (3)");
+
+      const ids = [];
+      for (const row of db.iterate("SELECT id FROM t ORDER BY id")) {
+        ids.push(Number(row.id));
+      }
+      assert.deepEqual(ids, [1, 2, 3]);
+    });
+
+    it("should handle early break", () => {
+      db.execute("CREATE TABLE t (id INTEGER)");
+      for (let i = 0; i < 100; i++) {
+        db.execute(`INSERT INTO t VALUES (${i})`);
+      }
+
+      let count = 0;
+      for (const _row of db.iterate("SELECT id FROM t")) {
+        count++;
+        if (count === 5) break;
+      }
+      assert.equal(count, 5);
+    });
+  });
+
+  describe("columns", () => {
+    it("should return column metadata", () => {
+      db.execute("CREATE TABLE t (id INTEGER, name TEXT, score REAL)");
+      const cols = db.columns("SELECT id, name, score FROM t");
+      assert.equal(cols.length, 3);
+      assert.equal(cols[0].name, "id");
+      assert.equal(cols[1].name, "name");
+      assert.equal(cols[2].name, "score");
+    });
+  });
+
+  describe("transaction", () => {
+    it("should commit on success", () => {
+      db.execute("CREATE TABLE t (id INTEGER)");
+
+      db.transaction(() => {
+        db.execute("INSERT INTO t VALUES (1)");
+        db.execute("INSERT INTO t VALUES (2)");
+      });
+
+      const rows = db.query("SELECT * FROM t");
+      assert.equal(rows.length, 2);
+    });
+
+    it("should rollback on error", () => {
+      db.execute("CREATE TABLE t (id INTEGER)");
+      db.execute("INSERT INTO t VALUES (0)");
+
+      assert.throws(() => {
+        db.transaction(() => {
+          db.execute("INSERT INTO t VALUES (1)");
+          throw new Error("abort!");
+        });
+      });
+
+      const rows = db.query("SELECT * FROM t");
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].id, 0n);
+    });
+
+    it("should return the function result", () => {
+      db.execute("CREATE TABLE t (id INTEGER)");
+      const result = db.transaction(() => {
+        db.execute("INSERT INTO t VALUES (42)");
+        return "done";
+      });
+      assert.equal(result, "done");
+    });
+  });
+});

--- a/clients/node/tsconfig.json
+++ b/clients/node/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "examples", "tests"]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,37 +1,50 @@
 # CSharpDB Architecture
 
-CSharpDB is a layered embedded database engine inspired by SQLite's architecture. Each layer has a clear responsibility and communicates only with adjacent layers.
+CSharpDB is a layered embedded database engine inspired by SQLite's architecture.
+The core engine layers have clear responsibilities and mostly communicate with
+adjacent layers. Above the engine, CSharpDB now exposes multiple consumer-facing
+entry points, with `CSharpDB.Client` as the authoritative database API.
 
 ## Layer Overview
 
 ```
-┌──────────────────────────────────────────────────┐
-│              CSharpDB.Data                       │   ADO.NET Provider
-│  DbConnection, DbCommand, DbDataReader           │
-├──────────────────────────────────────────────────┤
-│                CSharpDB.Engine                   │   Database API
-│  Database.OpenAsync / ExecuteAsync / Transactions│
-│  ReaderSession (concurrent snapshot reads)       │
-├──────────────────────────────────────────────────┤
-│              CSharpDB.Execution                  │   Query Execution
-│  QueryPlanner, Operators, ExpressionEvaluator    │
-├──────────────────────┬───────────────────────────┤
-│    CSharpDB.Sql      │    CSharpDB.Storage       │   SQL Frontend + Storage
-│  Tokenizer, Parser   │  Pager, B+Tree, WAL       │
-│  AST                 │  SlottedPage, RecordCodec │
-├──────────────────────┴───────────────────────────┤
-│                CSharpDB.Core                     │   Shared Types
-│  DbValue, DbType, Schema, ErrorCodes             │
-└──────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│ Hosts / Applications                                               │
+│ CSharpDB.Api   CSharpDB.Admin   CSharpDB.Cli   CSharpDB.Mcp        │
+├────────────────────────────────────────────────────────────────────┤
+│ Consumer Access Layer                                              │
+│ CSharpDB.Client        CSharpDB.Data        CSharpDB.Service       │
+│ ICSharpDbClient        ADO.NET Provider     Compatibility Facade   │
+├────────────────────────────────────────────────────────────────────┤
+│ CSharpDB.Engine                                                    │
+│ Database.OpenAsync / ExecuteAsync / Transactions / ReaderSession   │
+├────────────────────────────────────────────────────────────────────┤
+│ CSharpDB.Execution                                                 │
+│ QueryPlanner, Operators, ExpressionEvaluator                       │
+├───────────────────────────────┬────────────────────────────────────┤
+│ CSharpDB.Sql                  │ CSharpDB.Storage                   │
+│ Tokenizer, Parser, AST        │ Pager, B+Tree, WAL, RecordCodec    │
+├───────────────────────────────┴────────────────────────────────────┤
+│ CSharpDB.Core                                                      │
+│ DbValue, DbType, Schema, ErrorCodes                                │
+└────────────────────────────────────────────────────────────────────┘
 ```
 
 **Dependency graph:**
 
 ```
-Api     → Service
-Admin   → Service
-Service → Data     → Engine
-Cli     → Engine
+Api     → Client
+Admin   → Client
+Cli     → Client
+Cli     → Engine              (local-only helpers)
+Cli     → Sql
+Cli     → Storage.Diagnostics
+Mcp     → Service → Client
+Service → Sql                 (compatibility change notifications)
+Data    → Engine
+Client  → Engine
+Client  → Sql
+Client  → Storage.Diagnostics
 Engine  → Execution → Sql
                     → Storage → Core
           Execution → Core
@@ -153,7 +166,7 @@ CSharpDB uses a Write-Ahead Log for crash recovery and concurrent reader support
 │  [checksumSeed:4] [reserved:4]                       │
 ├──────────────────────────────────────────────────────┤
 │ Frame 0 (4120 bytes)                                 │
-│  [pageId:4] [dbPageCount:4] [salt1:4] [salt2:4]     │
+│  [pageId:4] [dbPageCount:4] [salt1:4] [salt2:4]      │
 │  [headerChecksum:4] [dataChecksum:4]                 │
 │  [page data: 4096 bytes]                             │
 ├──────────────────────────────────────────────────────┤
@@ -397,7 +410,53 @@ The `Database` class ties all layers together:
 
 ---
 
-## Layer 6: ADO.NET Provider (`CSharpDB.Data`)
+## Layer 6: Unified Client (`CSharpDB.Client`)
+
+`CSharpDB.Client` is the authoritative database API for CSharpDB consumers.
+
+It owns the public client contract and transport selection boundary used by the
+CLI, Web API, Admin dashboard, and future external consumers. Transport details
+stay behind this layer.
+
+Key pieces:
+
+- `ICSharpDbClient` — transport-agnostic database contract
+- `CSharpDbClientOptions` — endpoint / data source / connection string options
+- `CSharpDbTransport` — public transport selector
+- `AddCSharpDbClient(...)` — DI registration helper
+
+Current direction:
+
+- **Direct transport is implemented today** and is backed by `CSharpDB.Engine`
+- **HTTP, gRPC, TCP, and Named Pipes are part of the public transport model**
+  but are not implemented yet
+- **The client does not depend on `CSharpDB.Data`**
+- **New database-facing functionality should be added here first**
+
+Current surface includes:
+
+- database info and metadata
+- table schemas, browse, CRUD, and table/column DDL
+- indexes, views, and triggers
+- saved queries
+- procedures and procedure execution
+- SQL execution
+- client-managed transactions
+- document collections
+- checkpoint and storage diagnostics
+
+Implementation dependencies:
+
+- `CSharpDB.Engine`
+- `CSharpDB.Sql`
+- `CSharpDB.Storage.Diagnostics`
+
+This means the current direct client is a high-level engine-backed API, not an
+ADO.NET wrapper.
+
+---
+
+## Layer 7: ADO.NET Provider (`CSharpDB.Data`)
 
 | File | Purpose |
 |------|---------|
@@ -429,44 +488,75 @@ while (await reader.ReadAsync())
 
 ---
 
-## Layer 7: Shared Service (`CSharpDB.Service`)
+## Layer 8: Compatibility Service (`CSharpDB.Service`)
 
-The service layer provides a thread-safe singleton wrapper around `CSharpDbConnection`, shared by both the Admin dashboard and the REST API. It centralizes database lifecycle management and exposes high-level methods for tables, rows, indexes, views, triggers, and SQL execution.
+`CSharpDB.Service` is no longer the authoritative database API.
+
+It now acts as a compatibility facade over `CSharpDB.Client` for hosts that
+still inject `CSharpDbService`.
 
 Key design:
-- **Singleton** — one instance per application, manages a single database connection
-- **`SemaphoreSlim` locking** — ensures safe concurrent access from multiple HTTP requests or UI events
-- **Configuration-driven** — reads `ConnectionStrings:CSharpDB` from `IConfiguration`
-- **48 public methods** covering all database operations (CRUD on tables/rows, schema introspection, index/view/trigger management, SQL execution)
 
-Both `CSharpDB.Admin` and `CSharpDB.Api` reference this project to avoid duplicating data access logic.
+- **Compatibility layer** — preserves the old `CSharpDbService` DI shape
+- **`SemaphoreSlim` locking** — serializes calls for existing in-process hosts
+- **Configuration-driven** — reads `ConnectionStrings:CSharpDB` from `IConfiguration`
+- **Event bridge** — preserves `TablesChanged`, `SchemaChanged`, and `ProceduresChanged`
+- **Delegates to client** — schema, CRUD, SQL, procedures, saved queries, and
+  diagnostics flow through `CSharpDB.Client`
+
+Current primary consumer:
+
+- `CSharpDB.Mcp`
+
+This layer remains useful during migration, but it is not the long-term center
+of the architecture anymore.
 
 ---
 
-## Layer 8: REST API (`CSharpDB.Api`)
+## Layer 9: REST API (`CSharpDB.Api`)
 
 The REST API exposes the full database feature set over HTTP using ASP.NET Core Minimal APIs. It enables cross-language interoperability — any language with an HTTP client can work with CSharpDB.
 
 Components:
-- **Endpoints** — 30 endpoints organized by resource (tables, rows, indexes, views, triggers, SQL, info)
+- **Endpoints** — organized by resource (tables, rows, indexes, views, triggers, procedures, SQL, info, inspection)
 - **DTOs** — Request/response records for type-safe serialization
-- **JSON helpers** — Coerce `System.Text.Json` `JsonElement` values to CLR primitives for the engine
+- **JSON helpers** — Coerce `System.Text.Json` `JsonElement` values to CLR primitives for the client
 - **Exception middleware** — Maps `CSharpDbException` error codes to HTTP status codes (404, 409, 422, etc.)
-- **OpenAPI + Scalar** — Auto-generated API spec with interactive documentation at `/scalar/v1`
+- **OpenAPI + Scalar** — Auto-generated API spec with interactive documentation at `/scalar`
+
+The API now injects `ICSharpDbClient` directly. It no longer depends on
+`CSharpDB.Service` or `CSharpDB.Data`.
 
 See the [REST API Reference](../docs/rest-api.md) for the complete endpoint documentation.
 
 ---
 
-## Layer 9: Admin Dashboard (`CSharpDB.Admin`)
+## Layer 10: Admin Dashboard (`CSharpDB.Admin`)
 
 A Blazor Server application that provides a web-based UI for database administration. Features:
 - Tab-based interface for browsing tables, views, indexes, and triggers
 - Paginated data grid with column headers
 - SQL execution panel
+- Procedure editing and execution
+- Storage inspection
 - Schema introspection (columns, types, constraints)
 
-The Admin dashboard uses the same `CSharpDB.Service` layer as the REST API.
+The Admin dashboard now injects `ICSharpDbClient` directly. It uses an
+admin-local change notification service to refresh UI state after mutations
+without depending on `CSharpDB.Service`.
+
+---
+
+## Layer 11: CLI And MCP Hosts
+
+Two additional host applications sit above the consumer access layer:
+
+- **`CSharpDB.Cli`** — the interactive shell and local tooling entrypoint. It
+  now routes normal database access through `CSharpDB.Client`, while still
+  keeping a few local-only direct helpers for engine- and diagnostics-specific
+  features.
+- **`CSharpDB.Mcp`** — the MCP server host. It currently still uses
+  `CSharpDB.Service`, which in turn delegates to `CSharpDB.Client`.
 
 ---
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -5,7 +5,7 @@ This guide is for developers who want to understand, extend, or contribute to CS
 ## Project Structure
 
 ```
-CSharpDB.sln
+CSharpDB.slnx
 ├── src/
 │   ├── CSharpDB.Core/               Shared types (no dependencies)
 │   │   ├── DbType.cs                  Data type enum
@@ -33,7 +33,9 @@ CSharpDB.sln
 │   │   ├── Token.cs                    Token struct
 │   │   ├── Tokenizer.cs               Hand-rolled lexical scanner
 │   │   ├── Ast.cs                      Statement and Expression AST nodes
-│   │   └── Parser.cs                   Recursive descent parser
+│   │   ├── Parser.cs                   Recursive descent parser
+│   │   ├── SqlScriptSplitter.cs        Multi-statement script splitting (tracks BEGIN/END depth for triggers)
+│   │   └── SqlStatementClassifier.cs   Classifies statements as read-only or mutating
 │   │
 │   ├── CSharpDB.Execution/          Query execution (depends on Core, Sql, Storage)
 │   │   ├── IOperator.cs                Iterator interface
@@ -43,6 +45,15 @@ CSharpDB.sln
 │   │
 │   ├── CSharpDB.Engine/             Public API (depends on all above)
 │   │   └── Database.cs                 Open, Execute, Transactions, Checkpoint, ReaderSession
+│   │
+│   ├── CSharpDB.Client/             Unified client SDK (depends on Engine, Sql, Storage.Diagnostics)
+│   │   ├── ICSharpDbClient.cs          Public client contract (all database operations)
+│   │   ├── CSharpDbClient.cs           Factory: Create() → transport-specific implementation
+│   │   ├── CSharpDbClientOptions.cs    Configuration (DataSource, Endpoint, Transport, ConnectionString)
+│   │   ├── CSharpDbTransport.cs        Transport enum (Direct, Http, Grpc, Tcp, NamedPipes)
+│   │   ├── ServiceCollectionExtensions.cs  DI registration (AddCSharpDbClient)
+│   │   ├── Internal/                   Direct-transport implementation (engine-backed client)
+│   │   └── Models/                     Schema, data, procedure, transaction, and collection models
 │   │
 │   ├── CSharpDB.Data/               ADO.NET provider (depends on Engine)
 │   │   ├── CSharpDbConnection.cs       DbConnection implementation
@@ -54,19 +65,29 @@ CSharpDB.sln
 │   │   ├── SqlParameterBinder.cs       @param placeholder binding
 │   │   └── TypeMapper.cs               CSharpDB ↔ CLR type mapping
 │   │
-│   ├── CSharpDB.Cli/                Interactive REPL (depends on Engine)
-│   │   ├── Program.cs                  Entry point
-│   │   ├── Repl.cs                     Read-eval-print loop
-│   │   ├── TableFormatter.cs           ASCII table output
-│   │   └── MetaCommands.cs             .tables, .schema, .quit, etc.
+│   ├── CSharpDB.Native/             NativeAOT C FFI library (depends on Engine, Execution, Core)
+│   │   ├── NativeExports.cs            20 exported C functions (open, close, execute, result iteration, transactions, errors)
+│   │   ├── HandleTable.cs              GCHandle-based opaque pointer management
+│   │   ├── StringCache.cs              Unmanaged UTF-8 string lifetime management
+│   │   ├── BlobCache.cs                Pinned byte[] lifetime management
+│   │   ├── ErrorState.cs               Thread-local errno-style error reporting
+│   │   └── csharpdb.h                  C header file for consumers
 │   │
-│   ├── CSharpDB.Service/            Shared service layer (depends on Data)
-│   │   ├── CSharpDbService.cs          Thread-safe singleton wrapping CSharpDbConnection
+│   ├── CSharpDB.Cli/                Interactive REPL (depends on Client)
+│   │   ├── Program.cs                  Entry point with CLI argument parsing
+│   │   ├── CliShellOptions.cs          Parses --endpoint, --server, --transport flags
+│   │   ├── Repl.cs                     Read-eval-print loop
+│   │   ├── TableFormatter.cs           ASCII table output with alignment
+│   │   ├── MetaCommands.cs             .tables, .schema, .quit, etc.
+│   │   └── MetaCommandContext.cs       Session state (client, transactions, snapshots)
+│   │
+│   ├── CSharpDB.Service/            Compatibility facade over CSharpDB.Client (depends on Client)
+│   │   ├── CSharpDbService.cs          Delegates to ICSharpDbClient
 │   │   └── Models/                     TableBrowseResult, ViewBrowseResult, SqlExecutionResult, ViewDefinition
 │   │
 │   ├── CSharpDB.Admin/              Blazor Server admin dashboard (depends on Service)
 │   │   ├── Program.cs                  Blazor Server entry point
-│   │   ├── Services/                   Theme, toast, modal, tab manager services
+│   │   ├── Services/                   Theme, toast, modal, tab manager, DatabaseChangeService
 │   │   └── Components/                 Razor components for UI
 │   │
 │   ├── CSharpDB.Api/                REST API (depends on Service)
@@ -78,8 +99,15 @@ CSharpDB.sln
 │   │
 │   └── CSharpDB.Mcp/                MCP server for AI assistants (depends on Service)
 │       ├── Program.cs                  Generic Host with stdio transport
-│       ├── Tools/                      SchemaTools, DataTools, MutationTools, SqlTools (14 tools)
+│       ├── Tools/                      SchemaTools, DataTools, MutationTools, SqlTools (15 tools)
 │       └── Helpers/                    JSON serialization and value coercion
+│
+├── clients/
+│   └── node/                         Node.js/TypeScript client (wraps CSharpDB.Native via koffi)
+│       ├── src/index.ts                Database class, query/execute/transaction API
+│       ├── src/native.ts               koffi FFI bindings to CSharpDB.Native
+│       ├── examples/                   Basic usage example
+│       └── tests/                      Integration tests
 │
 ├── tests/
 │   ├── CSharpDB.Tests/              Engine unit + integration tests
@@ -88,7 +116,9 @@ CSharpDB.sln
 │   │   ├── TokenizerTests.cs           SQL tokenization
 │   │   ├── ParserTests.cs              SQL parsing to AST
 │   │   ├── IntegrationTests.cs         Full SQL round-trips (end-to-end)
-│   │   └── WalTests.cs                 WAL mode: commit, rollback, crash recovery, snapshots
+│   │   ├── WalTests.cs                 WAL mode: commit, rollback, crash recovery, snapshots
+│   │   ├── ClientSqlExecutionTests.cs  Client SDK SQL execution tests
+│   │   └── SqlScriptSplitterTests.cs   Script splitting edge cases
 │   │
 │   ├── CSharpDB.Data.Tests/         ADO.NET provider tests
 │   │   ├── ConnectionTests.cs          Connection open/close/state
@@ -96,9 +126,13 @@ CSharpDB.sln
 │   │   ├── DataReaderTests.cs          Typed getters, schema table, null handling
 │   │   └── TransactionTests.cs         ADO.NET transaction commit/rollback
 │   │
-│   ├── CSharpDB.Cli.Tests/          CLI smoke tests
+│   ├── CSharpDB.Cli.Tests/          CLI smoke + integration tests
 │   │
 │   └── CSharpDB.Benchmarks/         Performance benchmarks
+│
+├── docs/
+│   ├── tutorials/native-ffi/         FFI tutorials (JavaScript via koffi, Python via ctypes)
+│   └── service-daemon/               Service daemon design document
 │
 └── samples/                          Sample SQL datasets
     ├── ecommerce-store.sql             Northwind Electronics
@@ -311,8 +345,13 @@ See [docs/roadmap.md](roadmap.md) for the full roadmap with near-term, mid-term,
 
 - [Architecture Guide](architecture.md) — Layer-by-layer design deep dive
 - [Getting Started Tutorial](getting-started.md) — Step-by-step walkthrough with code examples
-- [REST API Reference](rest-api.md) — All 30 API endpoints with examples
+- [Client SDK](../src/CSharpDB.Client/README.md) — Unified client API and transport model
+- [Native Library Reference](../src/CSharpDB.Native/README.md) — C FFI API, build instructions, cross-language examples
+- [Node.js Client](../clients/node/README.md) — TypeScript/JavaScript package
+- [REST API Reference](rest-api.md) — All 33 API endpoints with examples
 - [MCP Server Reference](mcp-server.md) — AI assistant integration via Model Context Protocol
 - [CLI Reference](cli.md) — Interactive REPL commands and meta-commands
+- [Service Daemon Design](service-daemon/README.md) — Background service architecture and roadmap
+- [FFI Tutorials](tutorials/native-ffi/) — JavaScript and Python interop guides
 - [Roadmap](roadmap.md) — Planned features and project direction
 - [Benchmark Suite](../tests/CSharpDB.Benchmarks/README.md) — Performance data and comparison

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -9,23 +9,29 @@ The server exposes 14 tools for schema inspection, data browsing, row mutations,
 ## Running the Server
 
 ```bash
-# Default database (csharpdb.db in the current directory)
+# Default direct client target (ConnectionStrings:CSharpDB or csharpdb.db)
 dotnet run --project src/CSharpDB.Mcp
 
-# Specific database file
+# Direct client target via database path
 dotnet run --project src/CSharpDB.Mcp -- --database mydata.db
+
+# Explicit endpoint selection
+dotnet run --project src/CSharpDB.Mcp -- --endpoint http://localhost:61818 --transport http
 ```
 
-### Database Path Configuration
+### Client Target Configuration
 
-The database file is resolved in this order:
+The MCP server resolves `CSharpDbClientOptions` in this order:
 
-| Priority | Source | Example |
-|----------|--------|---------|
-| 1 | CLI argument | `--database mydata.db` or `-d mydata.db` |
-| 2 | Environment variable | `CSHARPDB_DATABASE=mydata.db` |
-| 3 | `appsettings.json` | `ConnectionStrings:CSharpDB` |
-| 4 | Default | `csharpdb.db` |
+| Setting | Priority | Example |
+|---------|----------|---------|
+| `Endpoint` | `--endpoint` / `-e`, then `CSHARPDB_ENDPOINT` | `--endpoint http://localhost:61818` |
+| `Transport` | `--transport` / `-t`, then `CSHARPDB_TRANSPORT` | `--transport http` |
+| Direct database path | `--database` / `-d`, then `CSHARPDB_DATABASE` | `--database mydata.db` |
+| Connection string | `ConnectionStrings:CSharpDB` from `appsettings.json` | `Data Source=csharpdb.db` |
+| Default | `csharpdb.db` when no other target is supplied | `Data Source=csharpdb.db` |
+
+`Direct` remains the default transport. If you pass an HTTP endpoint without `--transport`, the client infers `Http`. `Grpc`, `Tcp`, and named pipes can be selected in options but are not implemented yet.
 
 ---
 
@@ -209,16 +215,16 @@ AI Client (Claude, Cursor, etc.)
     │
 CSharpDB.Mcp (Generic Host)
     │
-CSharpDbService (thread-safe singleton)
+ICSharpDbClient
     │
-CSharpDbConnection (ADO.NET)
+CSharpDB.Client (transport-selecting SDK)
     │
 CSharpDB Engine (B+tree, WAL, Pager)
     │
 mydata.db
 ```
 
-All 14 tools are thin wrappers around `CSharpDbService`, which handles connection management, locking, and SQL execution. The MCP SDK (`ModelContextProtocol` NuGet package) handles protocol framing, tool discovery, and transport.
+All 14 tools are thin wrappers around `ICSharpDbClient`. In the current repo, MCP uses the direct engine-backed client by default, but the host can also be pointed at an HTTP endpoint through the same client options. The MCP SDK (`ModelContextProtocol` NuGet package) handles protocol framing, tool discovery, and stdio transport.
 
 ---
 

--- a/docs/releases/v1.6.0-pr-notes.md
+++ b/docs/releases/v1.6.0-pr-notes.md
@@ -1,0 +1,41 @@
+# Summary
+
+Release-prep for the `v1.6.0` client unification pass focused on making `CSharpDB.Client` the single authoritative API for database consumers, moving host applications onto that surface, and adding the first native/Node integration scaffolding.
+
+## Type of Change
+
+- [x] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [x] Documentation update
+- [x] Refactor / maintenance
+- [x] Tests only
+
+## Related Issues
+
+- Client unification and host migration effort for CLI, API, Admin, and MCP.
+- SQL parsing ownership cleanup so REPL and direct client execution share the same statement handling rules.
+
+## Testing
+
+- [x] `dotnet build CSharpDB.slnx /p:UseSharedCompilation=false`
+- [x] `dotnet test tests/CSharpDB.Cli.Tests/CSharpDB.Cli.Tests.csproj /p:UseSharedCompilation=false`
+- [x] `dotnet test tests/CSharpDB.Api.Tests/CSharpDB.Api.Tests.csproj /p:UseSharedCompilation=false`
+- [x] `dotnet test tests/CSharpDB.Tests/CSharpDB.Tests.csproj /p:UseSharedCompilation=false`
+- [x] Manual CLI verification for `.info` and direct database startup
+
+## Checklist
+
+- [x] I followed the project style and conventions.
+- [x] I added or updated tests for behavior changes.
+- [x] I covered both success and failure paths for changed behavior.
+- [x] I updated docs for user-facing changes.
+- [x] I verified no sensitive data was added.
+
+## Notes for Reviewers
+
+- `CSharpDB.Client` is now the authoritative public API; `CSharpDB.Service` remains only as a compatibility facade.
+- The CLI, Web API, Admin app, and MCP host now resolve database access through the client, with `Direct` as the default transport.
+- `Grpc`, `Tcp`, and named-pipe transport selection are part of the client options model, but only direct execution is implemented end-to-end in this pass.
+- SQL script splitting and read/write classification moved into `CSharpDB.Sql`, which removes the CLI-local parser copy and keeps REPL/client behavior aligned.
+- The branch also adds `CSharpDB.Native`, a Node client package, and native FFI tutorial/docs scaffolding; reviewers should treat those as additive SDK work alongside the client migration.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,7 +16,9 @@ Focused improvements to SQL completeness and query performance.
 | **Prepared statement cache** | Cache parsed ASTs and query plans to avoid re-parsing identical SQL | Done |
 | **Cached max rowid** | Avoid repeated O(n) scans when generating row IDs on insert (in-memory + persisted high-water mark) | Done |
 | **B+tree delete rebalancing** | Merge underflowed pages on delete to reclaim space | Done |
-| **Architecture enforcement** | Single authoritative API access layer — CLI, Admin, MCP communicate via HTTP client SDK | Planned |
+| **Architecture enforcement** | Single authoritative API access layer — CLI, Admin, MCP communicate via HTTP client SDK | Done |
+| **Database administration** | Reindex (full + incremental), VACUUM/compact, fragmentation analysis, database size report | Planned |
+| **Table/index statistics** | ANALYZE command with persisted row counts, column NDV, min/max; cost-based index selection in query planner | Planned |
 
 ---
 
@@ -32,6 +34,7 @@ SQL feature parity and ecosystem expansion.
 | **`DEFAULT` column values** | Allow default expressions in column definitions | Planned |
 | **`CHECK` constraints** | Arbitrary expression-based constraints per column or per table | Planned |
 | **Foreign key constraints** | `REFERENCES` with optional `ON DELETE CASCADE` | Planned |
+| **Service daemon** | Persistent background service keeping the database loaded with concurrent readers, cross-platform (systemd, Windows Service, launchd) | Planned |
 | **Cross-platform deployment** | dotnet tool, self-contained binaries, Docker, Homebrew, winget, install scripts | Planned |
 | **NuGet package** | Publish `CSharpDB.Engine`, `CSharpDB.Data`, and `CSharpDB.Service` as NuGet packages | Planned |
 | **Connection pooling** | Pool `CSharpDbConnection` instances to amortize open/close cost | Planned |
@@ -51,7 +54,7 @@ Advanced features and fundamental architecture enhancements.
 | **JSON path querying** | Query into JSON document fields in the Collection API (e.g., `$.address.city`) | Planned |
 | **Collection optimization & indexing** | Separate storage path, direct binary hydration, expression-based field indexes | Planned |
 | **Page-level compression** | Compress cell content within pages to reduce I/O and storage | Planned |
-| **Cost-based query optimizer** | Statistics-driven join ordering and index selection | Planned |
+| **Cost-based query optimizer** | Statistics-driven join ordering and index selection (initial support via ANALYZE in Near-Term; advanced histograms and adaptive re-optimization here) | Planned |
 | **Async I/O batching** | Group multiple page writes into fewer system calls during batch operations | Planned |
 | **Write-ahead buffering** | Buffer WAL writes before flushing to improve auto-commit throughput | Planned |
 | **Multi-writer support** | Allow concurrent write transactions (conflict detection + retry) | Research |
@@ -73,6 +76,9 @@ These are known simplifications in the current implementation:
 | **Concurrency** | Single writer only (no multi-writer) |
 | **Storage** | No page-level compression |
 | **Storage** | No mmap read path |
+| **Storage** | No VACUUM/compaction — database file grows monotonically, freed pages go to freelist but file never shrinks |
+| **Storage** | No REINDEX — indexes cannot be rebuilt without DROP + CREATE |
+| **Query** | No ANALYZE — query planner uses rule-based heuristics instead of statistics-driven cost estimation |
 
 ---
 
@@ -114,4 +120,6 @@ Major features already implemented:
 - [Storage Engine Guide](storage/README.md) — CSharpDB.Storage API reference: device, pager, B+tree, WAL, indexing, serialization, and catalog
 - [Collection Optimization Plan](collection-optimization/README.md) — Separate storage path, direct hydration, and document field indexing for Collection<T>
 - [Architecture Enforcement Plan](architecture-enforcement/README.md) — Single API gateway with HTTP client SDK for all consumers
+- [Service Daemon Plan](service-daemon/README.md) — Persistent background service with concurrent readers, cross-platform deployment, and multi-protocol access
+- [Native FFI Tutorials](tutorials/native-ffi/README.md) — Python and Node.js examples using the NativeAOT shared library
 - [Benchmark Suite](../tests/CSharpDB.Benchmarks/README.md) — Performance data informing optimization priorities

--- a/docs/service-daemon/README.md
+++ b/docs/service-daemon/README.md
@@ -1,0 +1,672 @@
+# CSharpDB Service Daemon — Roadmap & Design
+
+A persistent background service that keeps CSharpDB loaded in memory, serves multiple clients concurrently, and persists changes to disk automatically. Runs on Windows, Linux, and macOS.
+
+---
+
+## Problem
+
+Today, every client connection opens the database file from scratch — parsing the file header, loading the schema catalog, and building the page cache from cold. The existing `CSharpDbService` serializes all requests behind a single `SemaphoreSlim` lock, meaning only one query runs at a time. There is no way to keep the database warm between client sessions or serve concurrent reads.
+
+## Goal
+
+A long-running service process that:
+
+1. **Opens the database once** at startup and keeps it loaded
+2. **Serves concurrent reads** via snapshot-isolated reader sessions (already built in the engine)
+3. **Persists writes immediately** through the WAL, with periodic checkpoint to the main `.db` file
+4. **Manages memory intelligently** — only the working set (hot pages) lives in RAM, cold pages are read from disk on demand and evicted under memory pressure
+5. **Runs cross-platform** — systemd on Linux, Windows Service on Windows, launchd on macOS
+6. **Exposes multiple protocols** — HTTP/REST for broad compatibility, plus fast local transports (Unix sockets, named pipes)
+
+---
+
+## Design Decisions
+
+- **Single project, multi-platform** — One `CSharpDB.Daemon` project using .NET Generic Host. Platform-specific service integration via NuGet packages (`Microsoft.Extensions.Hosting.WindowsServices`, `Microsoft.Extensions.Hosting.Systemd`).
+- **Database-per-service instance** — Each daemon process manages one database file. Run multiple instances for multiple databases (different ports).
+- **Reuse existing engine** — The WAL, page cache, checkpoint policies, reader sessions, and statement cache are production-ready. The daemon is an orchestration layer, not a rewrite.
+- **Concurrent readers, single writer** — Matches the existing engine model. Reads scale horizontally via reader sessions; writes are serialized by the engine's writer lock.
+- **Graceful degradation** — If the service crashes, WAL recovery replays uncommitted frames on next start. No data loss for committed transactions.
+
+---
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────────────────────┐
+                    │              CSharpDB.Daemon                    │
+                    │                                                 │
+  HTTP Client ────► │  ┌──────────────┐    ┌──────────────────────┐   │
+  (any language)    │  │  Kestrel     │    │  DatabaseHost        │   │
+                    │  │  REST API    │───►│                      │   │
+  gRPC Client ────► │  │  + gRPC      │    │  ┌────────────────┐  │   │
+  (high perf)       │  │  + WebSocket │    │  │ Database       │  │   │
+                    │  └──────────────┘    │  │ (single inst.) │  │   │
+  Unix Socket ────► │                      │  └───────┬────────┘  │   │
+  (local fast)      │  ┌─────────────┐     │          │           │   │
+                    │  │  Health     │     │  ┌───────▼────────┐  │   │
+  Named Pipe ─────► │  │  Monitor    │     │  │ Reader Session │  │   │
+  (Windows local)   │  └─────────────┘     │  │ Pool           │  │   │
+                    │                      │  │ (concurrent    │  │   │
+                    │  ┌──────────────┐    │  │  snapshots)    │  │   │
+                    │  │  Checkpoint  │    │  └───────┬────────┘  │   │
+                    │  │  Scheduler   │    │          │           │   │
+                    │  └──────────────┘    │  ┌───────▼────────┐  │   │
+                    │                      │  │ LRU Page Cache │  │   │
+                    │  ┌──────────────┐    │  │ (hot pages     │  │   │
+                    │  │  Metrics     │    │  │  in memory)    │  │   │
+                    │  │  Collector   │    │  └───────┬────────┘  │   │
+                    │  └──────────────┘    │          │           │   │
+                    │                      │  ┌───────▼────────┐  │   │
+                    │                      │  │ WAL + .db file │  │   │
+                    │                      │  │ (durable)      │  │   │
+                    │                      │  └────────────────┘  │   │
+                    │                      └──────────────────────┘   │
+                    └─────────────────────────────────────────────────┘
+```
+
+### Memory Model
+
+```
+┌───────────────────────────────────────────────────────┐
+│                    Database File (e.g. 500 MB)        │
+│  ┌───────────────────────────────────────────────┐    │
+│  │  Page 1  │  Page 2  │  ...  │  Page 125,000   │    │
+│  └───────────────────────────────────────────────┘    │
+│       ▲           ▲                                   │
+│       │ cached    │ cached                            │
+│  ┌────┴───────────┴───────────────┐                   │
+│  │    LRU Page Cache (e.g. 50 MB) │  ◄── hot pages    │
+│  │    ~12,500 pages in memory     │      only         │
+│  │    evicts cold pages on demand │                   │
+│  └────────────────────────────────┘                   │
+│                                                       │
+│  Pages NOT in cache are read from disk when needed    │
+│  and cached for subsequent access.                    │
+└───────────────────────────────────────────────────────┘
+```
+
+### Write Path
+
+```
+Client: INSERT INTO users VALUES (...)
+   │
+   ▼
+1. Engine acquires writer lock (single writer)
+2. Statement cache hit? Use cached plan : parse SQL
+3. Execute plan → modify B+tree pages in memory
+4. Write dirty pages to WAL (.wal file) + fsync
+5. Release writer lock → client gets response
+   │
+   ▼  (async, periodic)
+6. Checkpoint scheduler triggers
+7. If no active readers: copy WAL frames → main .db file
+8. Truncate WAL
+```
+
+### Read Path (Concurrent)
+
+```
+Client A: SELECT * FROM users WHERE id = 42
+Client B: SELECT COUNT(*) FROM orders
+Client C: SELECT * FROM products WHERE price > 10
+   │            │            │
+   ▼            ▼            ▼
+   Reader       Reader       Reader
+   Session 1    Session 2    Session 3
+   (snapshot)   (snapshot)   (snapshot)
+   │            │            │
+   ▼            ▼            ▼
+   LRU Page Cache (shared, read-only snapshots)
+   │
+   ▼
+   Disk (for pages not in cache)
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Daemon — DatabaseHost + Kestrel REST
+
+**Goal:** A single-binary service that keeps the database open and serves the existing REST API endpoints concurrently.
+
+**New project:** `src/CSharpDB.Daemon/`
+
+#### 1A. DatabaseHost (IHostedService)
+
+Manages the `Database` lifecycle as a .NET hosted service.
+
+**File:** `src/CSharpDB.Daemon/DatabaseHost.cs`
+
+Responsibilities:
+- `StartAsync()`: Open database with configured `PagerOptions`, warm the page cache by loading the schema catalog
+- `StopAsync()`: Checkpoint, flush WAL, dispose database gracefully
+- Expose the `Database` instance to the DI container as a singleton
+- Configure `LruPageCache` with `MaxCachedPages` from settings
+- Configure checkpoint policy (combine time interval + frame count via `AnyCheckpointPolicy`)
+
+```csharp
+// Pseudo-code — lifecycle management
+public class DatabaseHost : IHostedService, IAsyncDisposable
+{
+    private Database? _database;
+
+    public async Task StartAsync(CancellationToken ct)
+    {
+        _database = await Database.OpenAsync(_options.DatabasePath, new PagerOptions
+        {
+            MaxCachedPages = _options.MaxCachedPages,      // e.g. 12500 (~50 MB)
+            CheckpointPolicy = new AnyCheckpointPolicy(
+                new FrameCountCheckpointPolicy(1000),
+                new TimeIntervalCheckpointPolicy(TimeSpan.FromSeconds(30))
+            ),
+            WriterLockTimeout = TimeSpan.FromSeconds(30),
+        });
+    }
+
+    public async Task StopAsync(CancellationToken ct)
+    {
+        if (_database != null)
+            await _database.DisposeAsync();   // checkpoints + closes
+    }
+}
+```
+
+Configuration model:
+
+```json
+{
+  "CSharpDB": {
+    "DatabasePath": "./data/myapp.db",
+    "MaxCachedPages": 12500,
+    "CheckpointIntervalSeconds": 30,
+    "CheckpointFrameThreshold": 1000,
+    "WriterLockTimeoutSeconds": 30,
+    "ListenUrl": "http://0.0.0.0:5820"
+  }
+}
+```
+
+#### 1B. Concurrent Request Handler
+
+Replace the single-lock `CSharpDbService` with a handler that uses reader sessions for SELECTs and the writer path for mutations.
+
+**File:** `src/CSharpDB.Daemon/ConcurrentDbService.cs`
+
+Routing logic:
+- `SELECT` statements → `Database.CreateReaderSession()` → execute → dispose session
+- `INSERT/UPDATE/DELETE/DDL` → `Database.ExecuteAsync()` (writer lock handled by engine)
+- Each HTTP request gets its own reader session — no global lock for reads
+
+```csharp
+// Pseudo-code — concurrent read handling
+public async Task<QueryResult> ExecuteAsync(string sql)
+{
+    if (IsReadOnly(sql))
+    {
+        using var reader = _database.CreateReaderSession();
+        return await reader.ExecuteReadAsync(sql);
+    }
+    else
+    {
+        return await _database.ExecuteAsync(sql);
+    }
+}
+```
+
+#### 1C. Wire Up Existing REST Endpoints
+
+Reuse the existing endpoint extension methods (`MapTableEndpoints`, `MapRowEndpoints`, etc.) from `CSharpDB.Api`, pointing them at `ConcurrentDbService` instead of the old `CSharpDbService`.
+
+#### 1D. Cross-Platform Service Registration
+
+Add NuGet references for platform-specific hosting:
+
+```xml
+<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+<PackageReference Include="Microsoft.Extensions.Hosting.Systemd" />
+```
+
+Host builder:
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddWindowsService();        // Windows Service support
+builder.Services.AddSystemd();               // systemd support (Linux)
+// macOS: launchd launches a normal process — no special package needed
+```
+
+**Deliverables:**
+- [ ] `CSharpDB.Daemon` project with `DatabaseHost`
+- [ ] `ConcurrentDbService` replacing single-lock pattern
+- [ ] REST API endpoints wired to concurrent service
+- [ ] `appsettings.json` with all configuration options
+- [ ] Build as self-contained binary for win-x64, linux-x64, osx-arm64
+
+---
+
+### Phase 2: Platform Service Installation
+
+**Goal:** Install and manage the daemon as a native OS service.
+
+#### 2A. systemd (Linux / Ubuntu)
+
+**File:** `deploy/linux/csharpdb.service`
+
+```ini
+[Unit]
+Description=CSharpDB Database Service
+After=network.target
+
+[Service]
+Type=notify
+ExecStart=/opt/csharpdb/csharpdb-daemon --database /var/lib/csharpdb/data.db
+Restart=on-failure
+RestartSec=5
+WorkingDirectory=/opt/csharpdb
+User=csharpdb
+Group=csharpdb
+LimitNOFILE=65536
+
+# Graceful shutdown — gives time for checkpoint
+TimeoutStopSec=30
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Usage:
+```bash
+sudo systemctl enable csharpdb
+sudo systemctl start csharpdb
+sudo systemctl status csharpdb
+journalctl -u csharpdb -f          # live logs
+```
+
+#### 2B. Windows Service
+
+No additional files needed — `AddWindowsService()` handles registration. Install via `sc.exe`:
+
+```powershell
+sc.exe create CSharpDB binPath="C:\Program Files\CSharpDB\csharpdb-daemon.exe"
+sc.exe start CSharpDB
+sc.exe query CSharpDB
+```
+
+Or via PowerShell:
+```powershell
+New-Service -Name "CSharpDB" -BinaryPathName "C:\Program Files\CSharpDB\csharpdb-daemon.exe" -StartupType Automatic
+Start-Service CSharpDB
+```
+
+#### 2C. launchd (macOS)
+
+**File:** `deploy/macos/com.csharpdb.daemon.plist`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.csharpdb.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/csharpdb-daemon</string>
+        <string>--database</string>
+        <string>/usr/local/var/csharpdb/data.db</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/csharpdb/stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/csharpdb/stderr.log</string>
+</dict>
+</plist>
+```
+
+Usage:
+```bash
+sudo cp deploy/macos/com.csharpdb.daemon.plist /Library/LaunchDaemons/
+sudo launchctl load /Library/LaunchDaemons/com.csharpdb.daemon.plist
+sudo launchctl list | grep csharpdb
+```
+
+**Deliverables:**
+- [ ] `deploy/linux/csharpdb.service` — systemd unit file
+- [ ] `deploy/macos/com.csharpdb.daemon.plist` — launchd plist
+- [ ] `deploy/windows/install.ps1` — PowerShell install script
+- [ ] Installation guide in docs
+
+---
+
+### Phase 3: Local Transport — Unix Sockets & Named Pipes
+
+**Goal:** Add fast local-only transports for same-machine clients (Python, Node.js, etc.).
+
+#### 3A. Unix Domain Socket (Linux / macOS)
+
+Kestrel natively supports Unix sockets:
+
+```csharp
+builder.WebHost.ConfigureKestrel(options =>
+{
+    // TCP for remote clients
+    options.ListenAnyIP(5820);
+
+    // Unix socket for local clients (Linux / macOS)
+    if (!OperatingSystem.IsWindows())
+    {
+        options.ListenUnixSocket("/var/run/csharpdb/csharpdb.sock");
+    }
+});
+```
+
+Python client connects via:
+```python
+import urllib3
+http = urllib3.HTTPConnectionPool("localhost", scheme="http+unix", host="/var/run/csharpdb/csharpdb.sock")
+response = http.request("POST", "/api/sql", body='{"sql": "SELECT 1"}')
+```
+
+Node.js client connects via:
+```javascript
+const response = await fetch("http://unix:/var/run/csharpdb/csharpdb.sock:/api/sql", {
+  method: "POST",
+  body: JSON.stringify({ sql: "SELECT 1" }),
+});
+```
+
+#### 3B. Named Pipes (Windows)
+
+Kestrel also supports named pipes:
+
+```csharp
+if (OperatingSystem.IsWindows())
+{
+    options.ListenNamedPipe("csharpdb");
+}
+```
+
+.NET client connects via:
+```csharp
+var handler = new SocketsHttpHandler { ConnectCallback = NamedPipeConnectAsync };
+var client = new HttpClient(handler) { BaseAddress = new Uri("http://csharpdb.pipe") };
+```
+
+#### 3C. Auto-Discovery
+
+Clients should auto-detect the fastest available transport:
+
+```
+1. Check for Unix socket / named pipe → use if available (fastest)
+2. Check for localhost TCP → use if available
+3. Fall back to remote TCP
+```
+
+**Deliverables:**
+- [ ] Unix socket listener in Kestrel configuration
+- [ ] Named pipe listener for Windows
+- [ ] Python client helper for socket connection
+- [ ] Node.js client helper for socket connection
+- [ ] Auto-discovery logic in client libraries
+
+---
+
+### Phase 4: Operational Features
+
+**Goal:** Health monitoring, metrics, and admin controls for production use.
+
+#### 4A. Health Check Endpoint
+
+```
+GET /health
+
+{
+  "status": "healthy",
+  "uptime": "2d 14h 32m",
+  "database": {
+    "path": "/var/lib/csharpdb/data.db",
+    "sizeBytes": 524288000,
+    "walSizeBytes": 1048576,
+    "cachedPages": 8432,
+    "maxCachedPages": 12500,
+    "activeReaders": 3,
+    "totalQueries": 1458923,
+    "totalWrites": 23456
+  }
+}
+```
+
+#### 4B. Metrics Endpoint (Prometheus-Compatible)
+
+```
+GET /metrics
+
+# HELP csharpdb_queries_total Total queries executed
+# TYPE csharpdb_queries_total counter
+csharpdb_queries_total{type="read"} 1458923
+csharpdb_queries_total{type="write"} 23456
+
+# HELP csharpdb_cache_hit_ratio Page cache hit ratio
+# TYPE csharpdb_cache_hit_ratio gauge
+csharpdb_cache_hit_ratio 0.94
+
+# HELP csharpdb_active_readers Current active reader sessions
+# TYPE csharpdb_active_readers gauge
+csharpdb_active_readers 3
+
+# HELP csharpdb_wal_frames_pending WAL frames awaiting checkpoint
+# TYPE csharpdb_wal_frames_pending gauge
+csharpdb_wal_frames_pending 42
+
+# HELP csharpdb_checkpoint_duration_seconds Time spent on last checkpoint
+# TYPE csharpdb_checkpoint_duration_seconds gauge
+csharpdb_checkpoint_duration_seconds 0.12
+```
+
+#### 4C. Admin Control Endpoints
+
+```
+POST /admin/checkpoint          # Force immediate checkpoint
+POST /admin/compact             # Checkpoint + VACUUM
+POST /admin/cache/clear         # Evict all cached pages
+GET  /admin/cache/stats         # Cache hit/miss/eviction counters
+GET  /admin/wal/status          # WAL frame count, size, last checkpoint time
+POST /admin/shutdown            # Graceful shutdown (checkpoint + close)
+```
+
+#### 4D. Structured Logging
+
+Use `ILogger` with structured output for observability:
+
+```
+[2026-03-08 14:23:01.123 INF] Database opened path=/var/lib/csharpdb/data.db pages=125000 cache_capacity=12500
+[2026-03-08 14:23:05.456 INF] Checkpoint completed frames=847 duration_ms=120 wal_truncated=true
+[2026-03-08 14:25:12.789 WRN] Writer lock contention waited_ms=1200 sql="INSERT INTO..."
+[2026-03-08 14:30:00.000 INF] Health check uptime=6m58s cached_pages=4231 active_readers=2
+```
+
+**Deliverables:**
+- [ ] `/health` endpoint with database stats
+- [ ] `/metrics` Prometheus-compatible endpoint
+- [ ] `/admin/*` control endpoints (authenticated)
+- [ ] Structured logging throughout daemon lifecycle
+
+---
+
+### Phase 5: Client SDK Updates
+
+**Goal:** Update the Python, Node.js, and TypeScript clients to connect to the daemon via HTTP (or local socket) instead of loading the native library directly.
+
+#### 5A. Python Client (HTTP Mode)
+
+```python
+from csharpdb import CSharpDB
+
+# Option 1: Direct FFI (current — loads native library)
+db = CSharpDB(lib_path="./CSharpDB.Native.dll")
+db.open("mydata.db")
+
+# Option 2: HTTP client (new — connects to daemon)
+db = CSharpDB.connect("http://localhost:5820")
+# or auto-discover local socket:
+db = CSharpDB.connect()  # finds /var/run/csharpdb/csharpdb.sock or localhost:5820
+```
+
+Same `db.query()`, `db.execute()`, `db.transaction()` API — the transport is transparent.
+
+#### 5B. Node.js Client (HTTP Mode)
+
+```javascript
+import { Database } from 'csharpdb';
+
+// Option 1: Direct FFI (current)
+const db = new Database('mydata.db');
+
+// Option 2: HTTP client (new)
+const db = Database.connect('http://localhost:5820');
+// or auto-discover:
+const db = Database.connect();
+```
+
+#### 5C. .NET Client SDK
+
+A thin HTTP client package for .NET apps that want to connect to a remote daemon:
+
+```csharp
+// Instead of opening the file directly:
+await using var db = await CSharpDbClient.ConnectAsync("http://localhost:5820");
+var result = await db.ExecuteAsync("SELECT * FROM users");
+```
+
+**Deliverables:**
+- [ ] Python `CSharpDB.connect()` HTTP/socket client mode
+- [ ] Node.js `Database.connect()` HTTP/socket client mode
+- [ ] `CSharpDB.Client` NuGet package for .NET HTTP client
+- [ ] Connection string parsing (`csharpdb://localhost:5820/mydb`)
+
+---
+
+### Phase 6: Advanced Features (Future)
+
+#### 6A. WebSocket Streaming
+
+Long-lived connections with server-push for:
+- Live query subscriptions (`SUBSCRIBE SELECT * FROM orders WHERE status = 'new'`)
+- Change notifications (table X was modified)
+- Streaming large result sets without buffering
+
+#### 6B. Connection Authentication
+
+- API key authentication for remote connections
+- mTLS for encrypted transport
+- Role-based access control (read-only vs read-write)
+
+#### 6C. Multi-Database Support
+
+Single daemon instance managing multiple database files:
+
+```
+GET  /databases                           # List managed databases
+POST /databases  { "name": "orders" }     # Create/open new database
+POST /databases/orders/sql                # Execute against specific DB
+```
+
+#### 6D. Hot Backup
+
+Non-blocking backup while the service is running:
+
+```
+POST /admin/backup?dest=/backups/mydb-2026-03-08.db
+```
+
+Uses WAL snapshot to create a consistent copy without stopping writes.
+
+#### 6E. Replication (Read Replicas)
+
+Stream committed WAL frames to read-only replicas:
+
+```
+Primary ──WAL stream──► Replica 1 (read-only)
+                    ──► Replica 2 (read-only)
+```
+
+---
+
+## Configuration Reference
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `DatabasePath` | string | `./csharpdb.db` | Path to the database file |
+| `ListenUrl` | string | `http://0.0.0.0:5820` | HTTP listen address |
+| `UnixSocketPath` | string | `/var/run/csharpdb/csharpdb.sock` | Unix socket path (Linux/macOS) |
+| `NamedPipeName` | string | `csharpdb` | Named pipe name (Windows) |
+| `MaxCachedPages` | int | `12500` | Max pages in LRU cache (~50 MB at 4 KB/page) |
+| `CheckpointIntervalSeconds` | int | `30` | Time-based checkpoint interval |
+| `CheckpointFrameThreshold` | int | `1000` | Frame-count checkpoint trigger |
+| `WriterLockTimeoutSeconds` | int | `30` | Max wait for write lock |
+| `MaxConcurrentReaders` | int | `64` | Reader session pool size |
+| `EnableMetrics` | bool | `true` | Expose /metrics endpoint |
+| `LogLevel` | string | `Information` | Minimum log level |
+
+---
+
+## File Layout
+
+```
+src/CSharpDB.Daemon/
+  CSharpDB.Daemon.csproj
+  Program.cs                    # Host builder, Kestrel config, DI setup
+  DatabaseHost.cs               # IHostedService — database lifecycle
+  ConcurrentDbService.cs        # Reader session routing (read vs write)
+  Configuration/
+    DaemonOptions.cs            # Strongly-typed settings
+  Health/
+    HealthCheckEndpoints.cs     # /health, /metrics
+  Admin/
+    AdminEndpoints.cs           # /admin/* control endpoints
+  appsettings.json              # Default configuration
+
+deploy/
+  linux/
+    csharpdb.service            # systemd unit file
+    install.sh                  # Linux install script
+  macos/
+    com.csharpdb.daemon.plist   # launchd plist
+    install.sh                  # macOS install script
+  windows/
+    install.ps1                 # Windows Service install script
+  docker/
+    Dockerfile                  # Container image
+    docker-compose.yml          # Compose example
+```
+
+---
+
+## Priority Order
+
+| Phase | Effort | Impact | Priority |
+|-------|--------|--------|----------|
+| **Phase 1**: Core Daemon | Medium | High — unlocks persistent service model | **P0** |
+| **Phase 2**: Platform Installation | Small | High — makes it usable in production | **P0** |
+| **Phase 3**: Local Transports | Small | Medium — improves local client perf | **P1** |
+| **Phase 4**: Operational Features | Medium | Medium — production monitoring | **P1** |
+| **Phase 5**: Client SDK Updates | Medium | Medium — seamless client experience | **P2** |
+| **Phase 6**: Advanced Features | Large | Variable — future capabilities | **P3** |
+
+---
+
+## See Also
+
+- [Architecture Guide](../architecture.md) — How the engine is structured
+- [Deployment & Installation Plan](../deployment/README.md) — Cross-platform distribution
+- [Storage Engine Guide](../storage/README.md) — WAL, page cache, checkpoint internals
+- [Native FFI Tutorials](../tutorials/native-ffi/README.md) — Python and Node.js client examples
+- [NativeAOT Library](../../src/CSharpDB.Native/README.md) — C-compatible shared library for FFI clients

--- a/docs/tutorials/native-ffi/README.md
+++ b/docs/tutorials/native-ffi/README.md
@@ -1,0 +1,52 @@
+# Native FFI Tutorials
+
+These tutorials show how to use CSharpDB from non-.NET languages via the NativeAOT shared library (`CSharpDB.Native`). The native library exposes a C-compatible API that any language with FFI support can call.
+
+## Prerequisites
+
+1. **Build the native library** (requires .NET 10 SDK + C++ toolchain):
+
+   ```bash
+   # Windows
+   dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r win-x64
+
+   # Linux
+   dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r linux-x64
+
+   # macOS
+   dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r osx-arm64
+   ```
+
+2. The published library will be at:
+   ```
+   src/CSharpDB.Native/bin/Release/net10.0/<rid>/publish/CSharpDB.Native.{dll,so,dylib}
+   ```
+
+## Tutorials
+
+| Language | Directory | Dependencies |
+|----------|-----------|-------------|
+| [Python](python/) | `python/` | None (uses built-in `ctypes`) |
+| [JavaScript / Node.js](javascript/) | `javascript/` | `koffi` (npm package) |
+
+## Architecture
+
+```
+Your App (Python / Node.js / Go / Rust / ...)
+    |
+    | FFI call (ctypes / koffi / cgo / extern "C")
+    v
+CSharpDB.Native.dll (.so / .dylib)   <-- NativeAOT compiled, no .NET runtime
+    |
+    | Direct function calls
+    v
+CSharpDB Engine (embedded in the native binary)
+    |
+    v
+Database file on disk (*.db)
+```
+
+Each tutorial includes:
+- A **reusable wrapper module** that loads the native library and provides an idiomatic API
+- **Runnable examples** covering CRUD operations, transactions, and queries
+- A **README** with setup and usage instructions

--- a/docs/tutorials/native-ffi/javascript/.gitignore
+++ b/docs/tutorials/native-ffi/javascript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.db

--- a/docs/tutorials/native-ffi/javascript/README.md
+++ b/docs/tutorials/native-ffi/javascript/README.md
@@ -1,0 +1,95 @@
+# JavaScript / Node.js FFI Tutorial
+
+Use CSharpDB from Node.js via [koffi](https://koffi.dev/), a zero-dependency FFI library.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `csharpdb.mjs` | Reusable ESM wrapper module with typed queries and transactions |
+| `example_crud.mjs` | Create, read, update, delete operations |
+| `example_transactions.mjs` | Explicit and automatic transactions, rollback on error |
+| `package.json` | npm project with koffi dependency |
+
+## Prerequisites
+
+1. Node.js 18+
+2. The CSharpDB native library (see [build instructions](../README.md))
+
+## Quick Start
+
+1. **Install dependencies**:
+
+   ```bash
+   cd docs/tutorials/native-ffi/javascript
+   npm install
+   ```
+
+2. **Set the library path** (or edit the `LIB_PATH` in the example files):
+
+   ```bash
+   # Windows
+   set CSHARPDB_NATIVE_PATH=C:\path\to\CSharpDB.Native.dll
+
+   # Linux / macOS
+   export CSHARPDB_NATIVE_PATH=/path/to/CSharpDB.Native.so
+   ```
+
+3. **Run the examples**:
+
+   ```bash
+   node example_crud.mjs
+   node example_transactions.mjs
+   ```
+
+   Or use npm scripts:
+
+   ```bash
+   npm run crud
+   npm run transactions
+   ```
+
+## Using the Wrapper in Your Project
+
+Copy `csharpdb.mjs` into your project and use it:
+
+```javascript
+import { CSharpDB } from './csharpdb.mjs';
+
+const db = new CSharpDB('/path/to/CSharpDB.Native.dll');
+db.open('myapp.db');
+
+db.execute('CREATE TABLE items (id INTEGER, name TEXT, price REAL)');
+db.execute("INSERT INTO items VALUES (1, 'Widget', 9.99)");
+
+const rows = db.query('SELECT * FROM items');
+console.log(rows);  // [{ id: 1, name: 'Widget', price: 9.99 }]
+
+db.close();
+```
+
+For a production-ready TypeScript package with full type safety, see [`clients/node/`](../../../../clients/node/).
+
+## API Summary
+
+| Method | Description |
+|--------|-------------|
+| `new CSharpDB(libPath)` | Load the native library |
+| `db.open(path)` | Open or create a database |
+| `db.close()` | Close the database |
+| `db.execute(sql)` | Run INSERT/UPDATE/DELETE/DDL, returns rows affected |
+| `db.query(sql)` | Run SELECT, returns array of objects |
+| `db.queryOne(sql)` | Run SELECT, returns first row or `null` |
+| `db.begin()` | Start a transaction |
+| `db.commit()` | Commit the transaction |
+| `db.rollback()` | Rollback the transaction |
+| `db.transaction(fn)` | Run `fn` in a transaction with auto commit/rollback |
+
+## Value Types
+
+| CSharpDB Type | JavaScript Type |
+|---------------|-----------------|
+| INTEGER | `Number` (auto-converted from BigInt if safe) |
+| REAL | `Number` |
+| TEXT | `String` |
+| NULL | `null` |

--- a/docs/tutorials/native-ffi/javascript/csharpdb.mjs
+++ b/docs/tutorials/native-ffi/javascript/csharpdb.mjs
@@ -1,0 +1,180 @@
+/**
+ * csharpdb.mjs — Node.js wrapper for the CSharpDB NativeAOT shared library.
+ *
+ * Usage:
+ *   import { CSharpDB } from './csharpdb.mjs';
+ *
+ *   const db = new CSharpDB('path/to/CSharpDB.Native.dll');
+ *   db.open('mydata.db');
+ *   db.execute("CREATE TABLE t (id INTEGER, name TEXT)");
+ *   const rows = db.query("SELECT * FROM t");
+ *   db.close();
+ */
+
+import koffi from "koffi";
+
+// Type codes matching CSharpDB.Core.DbType
+export const DbType = { NULL: 0, INTEGER: 1, REAL: 2, TEXT: 3, BLOB: 4 };
+
+export class CSharpDB {
+  /**
+   * Load the native library.
+   * @param {string} libPath - Path to CSharpDB.Native.dll / .so / .dylib
+   */
+  constructor(libPath) {
+    if (!libPath) {
+      if (process.platform === "win32") libPath = "./CSharpDB.Native.dll";
+      else if (process.platform === "darwin") libPath = "./CSharpDB.Native.dylib";
+      else libPath = "./CSharpDB.Native.so";
+    }
+
+    const lib = koffi.load(libPath);
+
+    // Bind all exported functions
+    this._open = lib.func("csharpdb_open", "void*", ["str"]);
+    this._close = lib.func("csharpdb_close", "void", ["void*"]);
+    this._execute = lib.func("csharpdb_execute", "void*", ["void*", "str"]);
+
+    this._resultIsQuery = lib.func("csharpdb_result_is_query", "int", ["void*"]);
+    this._resultNext = lib.func("csharpdb_result_next", "int", ["void*"]);
+    this._resultRowsAffected = lib.func("csharpdb_result_rows_affected", "int", ["void*"]);
+    this._resultColumnCount = lib.func("csharpdb_result_column_count", "int", ["void*"]);
+    this._resultColumnName = lib.func("csharpdb_result_column_name", "str", ["void*", "int"]);
+    this._resultColumnType = lib.func("csharpdb_result_column_type", "int", ["void*", "int"]);
+    this._resultIsNull = lib.func("csharpdb_result_is_null", "int", ["void*", "int"]);
+    this._resultGetInt64 = lib.func("csharpdb_result_get_int64", "int64_t", ["void*", "int"]);
+    this._resultGetDouble = lib.func("csharpdb_result_get_double", "double", ["void*", "int"]);
+    this._resultGetText = lib.func("csharpdb_result_get_text", "str", ["void*", "int"]);
+    this._resultFree = lib.func("csharpdb_result_free", "void", ["void*"]);
+
+    this._begin = lib.func("csharpdb_begin", "int", ["void*"]);
+    this._commit = lib.func("csharpdb_commit", "int", ["void*"]);
+    this._rollback = lib.func("csharpdb_rollback", "int", ["void*"]);
+
+    this._lastError = lib.func("csharpdb_last_error", "str", []);
+    this._lastErrorCode = lib.func("csharpdb_last_error_code", "int", []);
+    this._clearError = lib.func("csharpdb_clear_error", "void", []);
+
+    this._db = null;
+  }
+
+  /** Open or create a database file. */
+  open(dbPath) {
+    this._db = this._open(dbPath);
+    if (!this._db) {
+      throw new Error(`Failed to open database: ${this._lastError()}`);
+    }
+  }
+
+  /** Close the database. Safe to call multiple times. */
+  close() {
+    if (this._db) {
+      this._close(this._db);
+      this._db = null;
+    }
+  }
+
+  /**
+   * Execute a non-query statement (INSERT, UPDATE, DELETE, DDL).
+   * @returns {number} Number of rows affected.
+   */
+  execute(sql) {
+    const r = this._execute(this._db, sql);
+    if (!r) throw new Error(`SQL error: ${this._lastError()}`);
+    const affected = this._resultRowsAffected(r);
+    this._resultFree(r);
+    return affected;
+  }
+
+  /**
+   * Execute a SELECT and return an array of objects.
+   * Values: INTEGER -> BigInt (auto-converted to Number if safe), REAL -> Number, TEXT -> String.
+   */
+  query(sql) {
+    const r = this._execute(this._db, sql);
+    if (!r) throw new Error(`Query error: ${this._lastError()}`);
+
+    const colCount = this._resultColumnCount(r);
+    const columns = [];
+    for (let i = 0; i < colCount; i++) {
+      columns.push(this._resultColumnName(r, i) || `col_${i}`);
+    }
+
+    const rows = [];
+    while (this._resultNext(r) === 1) {
+      const row = {};
+      for (let i = 0; i < colCount; i++) {
+        if (this._resultIsNull(r, i) === 1) {
+          row[columns[i]] = null;
+          continue;
+        }
+        const type = this._resultColumnType(r, i);
+        switch (type) {
+          case DbType.INTEGER: {
+            const val = this._resultGetInt64(r, i);
+            // Convert BigInt to Number if it fits safely
+            row[columns[i]] =
+              typeof val === "bigint" &&
+              val >= -Number.MAX_SAFE_INTEGER &&
+              val <= Number.MAX_SAFE_INTEGER
+                ? Number(val)
+                : val;
+            break;
+          }
+          case DbType.REAL:
+            row[columns[i]] = this._resultGetDouble(r, i);
+            break;
+          case DbType.TEXT:
+            row[columns[i]] = this._resultGetText(r, i) || "";
+            break;
+          default:
+            row[columns[i]] = null;
+        }
+      }
+      rows.push(row);
+    }
+
+    this._resultFree(r);
+    return rows;
+  }
+
+  /** Execute a SELECT and return the first row, or null. */
+  queryOne(sql) {
+    const rows = this.query(sql);
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  /** Begin an explicit transaction. */
+  begin() {
+    if (this._begin(this._db) !== 0)
+      throw new Error(`Transaction error: ${this._lastError()}`);
+  }
+
+  /** Commit the current transaction. */
+  commit() {
+    if (this._commit(this._db) !== 0)
+      throw new Error(`Commit error: ${this._lastError()}`);
+  }
+
+  /** Rollback the current transaction. */
+  rollback() {
+    if (this._rollback(this._db) !== 0)
+      throw new Error(`Rollback error: ${this._lastError()}`);
+  }
+
+  /**
+   * Run a function inside a transaction.
+   * Auto-commits on success, rolls back on error.
+   */
+  transaction(fn) {
+    this.begin();
+    try {
+      const result = fn(this);
+      this.commit();
+      return result;
+    } catch (err) {
+      this.rollback();
+      throw err;
+    }
+  }
+}

--- a/docs/tutorials/native-ffi/javascript/example_crud.mjs
+++ b/docs/tutorials/native-ffi/javascript/example_crud.mjs
@@ -1,0 +1,95 @@
+/**
+ * Example: Basic CRUD operations with CSharpDB from Node.js.
+ *
+ * Run:
+ *   npm install
+ *   node example_crud.mjs
+ */
+
+import { CSharpDB } from "./csharpdb.mjs";
+import { unlinkSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Adjust this path to your published CSharpDB.Native library
+const LIB_PATH =
+  process.env.CSHARPDB_NATIVE_PATH ||
+  resolve(
+    __dirname,
+    "..", "..", "..", "..",
+    "src", "CSharpDB.Native", "bin", "Release",
+    "net10.0", "win-x64", "publish", "CSharpDB.Native.dll"
+  );
+
+const DB_FILE = "tutorial_crud.db";
+
+// Clean up from previous runs
+if (existsSync(DB_FILE)) unlinkSync(DB_FILE);
+
+console.log("=== CSharpDB Node.js Tutorial: CRUD Operations ===\n");
+
+const db = new CSharpDB(LIB_PATH);
+db.open(DB_FILE);
+console.log(`Opened database: ${DB_FILE}`);
+
+// --- CREATE ---
+console.log("\n--- CREATE TABLE ---");
+db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT, age INTEGER)");
+console.log("Created 'users' table");
+
+// --- INSERT ---
+console.log("\n--- INSERT ---");
+db.execute("INSERT INTO users VALUES (1, 'Alice', 'alice@example.com', 30)");
+db.execute("INSERT INTO users VALUES (2, 'Bob', 'bob@example.com', 25)");
+db.execute("INSERT INTO users VALUES (3, 'Charlie', 'charlie@example.com', 35)");
+console.log("Inserted 3 users");
+
+// --- READ (SELECT all) ---
+console.log("\n--- SELECT * FROM users ---");
+const allUsers = db.query("SELECT * FROM users ORDER BY id");
+for (const row of allUsers) {
+  console.log(`  id=${row.id}, name=${row.name}, email=${row.email}, age=${row.age}`);
+}
+
+// --- READ (SELECT with filter) ---
+console.log("\n--- SELECT users older than 28 ---");
+const olderUsers = db.query("SELECT name, age FROM users WHERE age > 28 ORDER BY age");
+for (const row of olderUsers) {
+  console.log(`  ${row.name} (age ${row.age})`);
+}
+
+// --- READ (single row) ---
+console.log("\n--- SELECT single user ---");
+const user = db.queryOne("SELECT name, email FROM users WHERE id = 2");
+if (user) {
+  console.log(`  User 2: ${user.name} <${user.email}>`);
+}
+
+// --- UPDATE ---
+console.log("\n--- UPDATE ---");
+const updated = db.execute("UPDATE users SET age = 31 WHERE name = 'Alice'");
+console.log(`  Updated ${updated} row(s)`);
+
+const alice = db.queryOne("SELECT name, age FROM users WHERE name = 'Alice'");
+console.log(`  Alice's age is now: ${alice.age}`);
+
+// --- DELETE ---
+console.log("\n--- DELETE ---");
+const deleted = db.execute("DELETE FROM users WHERE name = 'Charlie'");
+console.log(`  Deleted ${deleted} row(s)`);
+
+const remaining = db.query("SELECT name FROM users ORDER BY name");
+console.log(`  Remaining users: ${remaining.map((r) => r.name).join(", ")}`);
+
+// --- Aggregates ---
+console.log("\n--- AGGREGATES ---");
+const stats = db.queryOne("SELECT COUNT(*) as total, AVG(age) as avg_age FROM users");
+console.log(`  ${stats.total} users, average age: ${stats.avg_age.toFixed(1)}`);
+
+// Cleanup
+db.close();
+console.log(`\nDatabase closed. Cleaning up ${DB_FILE}...`);
+unlinkSync(DB_FILE);
+console.log("Done!");

--- a/docs/tutorials/native-ffi/javascript/example_transactions.mjs
+++ b/docs/tutorials/native-ffi/javascript/example_transactions.mjs
@@ -1,0 +1,110 @@
+/**
+ * Example: Transactions with CSharpDB from Node.js.
+ *
+ * Demonstrates:
+ *   - Explicit begin/commit/rollback
+ *   - transaction() helper for automatic commit/rollback
+ *   - Rollback on error
+ *
+ * Run:
+ *   npm install
+ *   node example_transactions.mjs
+ */
+
+import { CSharpDB } from "./csharpdb.mjs";
+import { unlinkSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const LIB_PATH =
+  process.env.CSHARPDB_NATIVE_PATH ||
+  resolve(
+    __dirname,
+    "..", "..", "..", "..",
+    "src", "CSharpDB.Native", "bin", "Release",
+    "net10.0", "win-x64", "publish", "CSharpDB.Native.dll"
+  );
+
+const DB_FILE = "tutorial_transactions.db";
+
+if (existsSync(DB_FILE)) unlinkSync(DB_FILE);
+
+console.log("=== CSharpDB Node.js Tutorial: Transactions ===\n");
+
+const db = new CSharpDB(LIB_PATH);
+db.open(DB_FILE);
+
+// Setup
+db.execute("CREATE TABLE accounts (id INTEGER PRIMARY KEY, name TEXT, balance REAL)");
+db.execute("INSERT INTO accounts VALUES (1, 'Alice', 1000.00)");
+db.execute("INSERT INTO accounts VALUES (2, 'Bob', 500.00)");
+
+function showBalances() {
+  const rows = db.query("SELECT name, balance FROM accounts ORDER BY id");
+  for (const r of rows) {
+    console.log(`    ${r.name}: $${r.balance.toFixed(2)}`);
+  }
+}
+
+console.log("Initial balances:");
+showBalances();
+
+// --- Example 1: Successful transaction (explicit) ---
+console.log("\n--- Example 1: Successful transfer (explicit begin/commit) ---");
+db.begin();
+db.execute("UPDATE accounts SET balance = balance - 200 WHERE name = 'Alice'");
+db.execute("UPDATE accounts SET balance = balance + 200 WHERE name = 'Bob'");
+db.commit();
+console.log("  Transferred $200 from Alice to Bob");
+showBalances();
+
+// --- Example 2: Rolled-back transaction ---
+console.log("\n--- Example 2: Rolled-back transfer ---");
+db.begin();
+db.execute("UPDATE accounts SET balance = balance - 9999 WHERE name = 'Alice'");
+console.log("  (Oops, transferring $9999 - let's rollback)");
+db.rollback();
+console.log("  Rolled back!");
+showBalances();
+
+// --- Example 3: transaction() helper with auto-commit ---
+console.log("\n--- Example 3: transaction() helper ---");
+db.transaction(() => {
+  db.execute("UPDATE accounts SET balance = balance - 100 WHERE name = 'Bob'");
+  db.execute("UPDATE accounts SET balance = balance + 100 WHERE name = 'Alice'");
+});
+console.log("  Auto-committed $100 transfer from Bob to Alice");
+showBalances();
+
+// --- Example 4: transaction() helper with auto-rollback on error ---
+console.log("\n--- Example 4: transaction() with error (auto-rollback) ---");
+try {
+  db.transaction(() => {
+    db.execute("UPDATE accounts SET balance = balance - 50 WHERE name = 'Alice'");
+    throw new Error("Something went wrong mid-transfer!");
+  });
+} catch (err) {
+  console.log(`  Caught error: ${err.message}`);
+  console.log("  Transaction was automatically rolled back");
+}
+showBalances();
+
+// --- Example 5: Batch insert in transaction ---
+console.log("\n--- Example 5: Batch insert in a transaction ---");
+db.execute("CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)");
+
+db.transaction(() => {
+  for (let i = 1; i <= 5; i++) {
+    db.execute(`INSERT INTO logs VALUES (${i}, 'Log entry ${i}')`);
+  }
+});
+const count = db.queryOne("SELECT COUNT(*) as cnt FROM logs");
+console.log(`  Inserted ${count.cnt} log entries in a single transaction`);
+
+// Cleanup
+db.close();
+console.log(`\nCleaning up ${DB_FILE}...`);
+unlinkSync(DB_FILE);
+console.log("Done!");

--- a/docs/tutorials/native-ffi/javascript/package-lock.json
+++ b/docs/tutorials/native-ffi/javascript/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "csharpdb-tutorial",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "csharpdb-tutorial",
+      "version": "1.0.0",
+      "dependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
+      "integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    }
+  }
+}

--- a/docs/tutorials/native-ffi/javascript/package.json
+++ b/docs/tutorials/native-ffi/javascript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "csharpdb-tutorial",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "CSharpDB JavaScript/Node.js FFI tutorial examples",
+  "scripts": {
+    "crud": "node example_crud.mjs",
+    "transactions": "node example_transactions.mjs"
+  },
+  "dependencies": {
+    "koffi": "^2.9.0"
+  }
+}

--- a/docs/tutorials/native-ffi/python/README.md
+++ b/docs/tutorials/native-ffi/python/README.md
@@ -1,0 +1,71 @@
+# Python FFI Tutorial
+
+Use CSharpDB from Python via the built-in `ctypes` module. No external packages required.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `csharpdb.py` | Reusable wrapper module with typed query results, transactions, and context manager |
+| `example_crud.py` | Create, read, update, delete operations |
+| `example_transactions.py` | Explicit and automatic transactions, rollback on error |
+
+## Prerequisites
+
+1. Python 3.10+
+2. The CSharpDB native library (see [build instructions](../README.md))
+
+## Quick Start
+
+1. **Set the library path** (or edit the `LIB_PATH` in the example files):
+
+   ```bash
+   # Windows
+   set CSHARPDB_NATIVE_PATH=C:\path\to\CSharpDB.Native.dll
+
+   # Linux / macOS
+   export CSHARPDB_NATIVE_PATH=/path/to/CSharpDB.Native.so
+   ```
+
+2. **Run the examples**:
+
+   ```bash
+   cd docs/tutorials/native-ffi/python
+
+   python example_crud.py
+   python example_transactions.py
+   ```
+
+## Using the Wrapper in Your Project
+
+Copy `csharpdb.py` into your project and use it:
+
+```python
+from csharpdb import CSharpDB
+
+with CSharpDB("/path/to/CSharpDB.Native.dll") as db:
+    db.open("myapp.db")
+
+    db.execute("CREATE TABLE items (id INTEGER, name TEXT, price REAL)")
+    db.execute("INSERT INTO items VALUES (1, 'Widget', 9.99)")
+
+    for row in db.query("SELECT * FROM items"):
+        print(row)  # {'id': 1, 'name': 'Widget', 'price': 9.99}
+```
+
+## API Summary
+
+| Method | Description |
+|--------|-------------|
+| `CSharpDB(lib_path)` | Load the native library |
+| `db.open(path)` | Open or create a database |
+| `db.close()` | Close the database |
+| `db.execute(sql)` | Run INSERT/UPDATE/DELETE/DDL, returns rows affected |
+| `db.query(sql)` | Run SELECT, returns `list[dict]` |
+| `db.query_one(sql)` | Run SELECT, returns first row or `None` |
+| `db.begin()` | Start a transaction |
+| `db.commit()` | Commit the transaction |
+| `db.rollback()` | Rollback the transaction |
+| `db.transaction(fn)` | Run `fn` in a transaction with auto commit/rollback |
+
+The class also supports `with` statements for automatic cleanup.

--- a/docs/tutorials/native-ffi/python/csharpdb.py
+++ b/docs/tutorials/native-ffi/python/csharpdb.py
@@ -1,0 +1,226 @@
+"""csharpdb.py — Python wrapper for the CSharpDB NativeAOT shared library.
+
+Usage:
+    from csharpdb import CSharpDB
+
+    with CSharpDB("path/to/CSharpDB.Native.dll") as db:
+        db.open("mydata.db")
+        db.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+        db.execute("INSERT INTO t VALUES (1, 'Alice')")
+        rows = db.query("SELECT * FROM t")
+        print(rows)  # [{'id': 1, 'name': 'Alice'}]
+"""
+
+import ctypes
+import sys
+
+
+class CSharpDBError(Exception):
+    """Raised when a CSharpDB native call fails."""
+
+    def __init__(self, message: str, code: int = -1):
+        super().__init__(message)
+        self.code = code
+
+
+class CSharpDB:
+    """Thin Python wrapper around the CSharpDB NativeAOT shared library."""
+
+    # Type codes matching CSharpDB.Core.DbType
+    NULL, INTEGER, REAL, TEXT, BLOB = 0, 1, 2, 3, 4
+
+    def __init__(self, lib_path: str | None = None):
+        """Load the native library.
+
+        Args:
+            lib_path: Path to CSharpDB.Native.dll/.so/.dylib.
+                      Auto-detects by platform if not provided.
+        """
+        if lib_path is None:
+            if sys.platform == "win32":
+                lib_path = "./CSharpDB.Native.dll"
+            elif sys.platform == "darwin":
+                lib_path = "./CSharpDB.Native.dylib"
+            else:
+                lib_path = "./CSharpDB.Native.so"
+
+        self._lib = ctypes.CDLL(lib_path)
+        self._setup_signatures()
+        self._db = None
+
+    def _setup_signatures(self):
+        L = self._lib
+        vp = ctypes.c_void_p
+
+        # Database lifecycle
+        L.csharpdb_open.restype = vp
+        L.csharpdb_open.argtypes = [ctypes.c_char_p]
+        L.csharpdb_close.restype = None
+        L.csharpdb_close.argtypes = [vp]
+
+        # SQL execution
+        L.csharpdb_execute.restype = vp
+        L.csharpdb_execute.argtypes = [vp, ctypes.c_char_p]
+
+        # Result metadata
+        L.csharpdb_result_is_query.restype = ctypes.c_int
+        L.csharpdb_result_is_query.argtypes = [vp]
+        L.csharpdb_result_next.restype = ctypes.c_int
+        L.csharpdb_result_next.argtypes = [vp]
+        L.csharpdb_result_rows_affected.restype = ctypes.c_int
+        L.csharpdb_result_rows_affected.argtypes = [vp]
+        L.csharpdb_result_column_count.restype = ctypes.c_int
+        L.csharpdb_result_column_count.argtypes = [vp]
+        L.csharpdb_result_column_name.restype = ctypes.c_char_p
+        L.csharpdb_result_column_name.argtypes = [vp, ctypes.c_int]
+
+        # Value access
+        L.csharpdb_result_column_type.restype = ctypes.c_int
+        L.csharpdb_result_column_type.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_is_null.restype = ctypes.c_int
+        L.csharpdb_result_is_null.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_get_int64.restype = ctypes.c_int64
+        L.csharpdb_result_get_int64.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_get_double.restype = ctypes.c_double
+        L.csharpdb_result_get_double.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_get_text.restype = ctypes.c_char_p
+        L.csharpdb_result_get_text.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_get_blob.restype = vp
+        L.csharpdb_result_get_blob.argtypes = [vp, ctypes.c_int, ctypes.POINTER(ctypes.c_int)]
+        L.csharpdb_result_free.restype = None
+        L.csharpdb_result_free.argtypes = [vp]
+
+        # Transactions
+        L.csharpdb_begin.restype = ctypes.c_int
+        L.csharpdb_begin.argtypes = [vp]
+        L.csharpdb_commit.restype = ctypes.c_int
+        L.csharpdb_commit.argtypes = [vp]
+        L.csharpdb_rollback.restype = ctypes.c_int
+        L.csharpdb_rollback.argtypes = [vp]
+
+        # Error handling
+        L.csharpdb_last_error.restype = ctypes.c_char_p
+        L.csharpdb_last_error_code.restype = ctypes.c_int
+        L.csharpdb_clear_error.restype = None
+
+    def _check_error(self, context: str = ""):
+        err = self._lib.csharpdb_last_error()
+        if err:
+            code = self._lib.csharpdb_last_error_code()
+            raise CSharpDBError(
+                f"CSharpDB error{' (' + context + ')' if context else ''}: {err.decode()}",
+                code,
+            )
+
+    def open(self, path: str):
+        """Open or create a database file."""
+        self._db = self._lib.csharpdb_open(path.encode("utf-8"))
+        if not self._db:
+            self._check_error("open")
+
+    def close(self):
+        """Close the database. Safe to call multiple times."""
+        if self._db:
+            self._lib.csharpdb_close(self._db)
+            self._db = None
+
+    def execute(self, sql: str) -> int:
+        """Execute a non-query statement (INSERT, UPDATE, DELETE, DDL).
+
+        Returns:
+            Number of rows affected.
+        """
+        r = self._lib.csharpdb_execute(self._db, sql.encode("utf-8"))
+        if not r:
+            self._check_error("execute")
+        affected = self._lib.csharpdb_result_rows_affected(r)
+        self._lib.csharpdb_result_free(r)
+        return affected
+
+    def query(self, sql: str) -> list[dict]:
+        """Execute a SELECT and return rows as a list of dicts.
+
+        Value types:
+            INTEGER -> int
+            REAL    -> float
+            TEXT    -> str
+            BLOB    -> bytes
+            NULL    -> None
+        """
+        r = self._lib.csharpdb_execute(self._db, sql.encode("utf-8"))
+        if not r:
+            self._check_error("query")
+
+        col_count = self._lib.csharpdb_result_column_count(r)
+        columns = []
+        for i in range(col_count):
+            name = self._lib.csharpdb_result_column_name(r, i)
+            columns.append(name.decode() if name else f"col_{i}")
+
+        rows = []
+        while self._lib.csharpdb_result_next(r) == 1:
+            row = {}
+            for i, col in enumerate(columns):
+                if self._lib.csharpdb_result_is_null(r, i) == 1:
+                    row[col] = None
+                else:
+                    col_type = self._lib.csharpdb_result_column_type(r, i)
+                    if col_type == self.INTEGER:
+                        row[col] = self._lib.csharpdb_result_get_int64(r, i)
+                    elif col_type == self.REAL:
+                        row[col] = self._lib.csharpdb_result_get_double(r, i)
+                    elif col_type == self.TEXT:
+                        val = self._lib.csharpdb_result_get_text(r, i)
+                        row[col] = val.decode() if val else ""
+                    elif col_type == self.BLOB:
+                        size = ctypes.c_int(0)
+                        ptr = self._lib.csharpdb_result_get_blob(
+                            r, i, ctypes.byref(size)
+                        )
+                        if ptr and size.value > 0:
+                            row[col] = ctypes.string_at(ptr, size.value)
+                        else:
+                            row[col] = b""
+                    else:
+                        row[col] = None
+            rows.append(row)
+
+        self._lib.csharpdb_result_free(r)
+        return rows
+
+    def query_one(self, sql: str) -> dict | None:
+        """Execute a SELECT and return the first row, or None."""
+        rows = self.query(sql)
+        return rows[0] if rows else None
+
+    def begin(self):
+        """Begin an explicit transaction."""
+        if self._lib.csharpdb_begin(self._db) != 0:
+            self._check_error("begin")
+
+    def commit(self):
+        """Commit the current transaction."""
+        if self._lib.csharpdb_commit(self._db) != 0:
+            self._check_error("commit")
+
+    def rollback(self):
+        """Rollback the current transaction."""
+        if self._lib.csharpdb_rollback(self._db) != 0:
+            self._check_error("rollback")
+
+    def transaction(self, fn):
+        """Run a function inside a transaction. Auto-commits on success, rolls back on error."""
+        self.begin()
+        try:
+            result = fn()
+            self.commit()
+            return result
+        except Exception:
+            self.rollback()
+            raise
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/docs/tutorials/native-ffi/python/example_crud.py
+++ b/docs/tutorials/native-ffi/python/example_crud.py
@@ -1,0 +1,90 @@
+"""Example: Basic CRUD operations with CSharpDB from Python.
+
+Run:
+    python example_crud.py
+
+Requires the native library path — set LIB_PATH below or pass via command line.
+"""
+
+import os
+import sys
+
+# Adjust this path to your published CSharpDB.Native library
+LIB_PATH = os.environ.get(
+    "CSHARPDB_NATIVE_PATH",
+    os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "..", "..",
+        "src", "CSharpDB.Native", "bin", "Release",
+        "net10.0", "win-x64", "publish", "CSharpDB.Native.dll",
+    ),
+)
+
+from csharpdb import CSharpDB
+
+DB_FILE = "tutorial_crud.db"
+
+# Clean up from previous runs
+if os.path.exists(DB_FILE):
+    os.remove(DB_FILE)
+
+print("=== CSharpDB Python Tutorial: CRUD Operations ===\n")
+
+with CSharpDB(LIB_PATH) as db:
+    db.open(DB_FILE)
+    print(f"Opened database: {DB_FILE}")
+
+    # --- CREATE ---
+    print("\n--- CREATE TABLE ---")
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT, age INTEGER)")
+    print("Created 'users' table")
+
+    # --- INSERT ---
+    print("\n--- INSERT ---")
+    db.execute("INSERT INTO users VALUES (1, 'Alice', 'alice@example.com', 30)")
+    db.execute("INSERT INTO users VALUES (2, 'Bob', 'bob@example.com', 25)")
+    db.execute("INSERT INTO users VALUES (3, 'Charlie', 'charlie@example.com', 35)")
+    print("Inserted 3 users")
+
+    # --- READ (SELECT all) ---
+    print("\n--- SELECT * FROM users ---")
+    rows = db.query("SELECT * FROM users ORDER BY id")
+    for row in rows:
+        print(f"  id={row['id']}, name={row['name']}, email={row['email']}, age={row['age']}")
+
+    # --- READ (SELECT with filter) ---
+    print("\n--- SELECT users older than 28 ---")
+    rows = db.query("SELECT name, age FROM users WHERE age > 28 ORDER BY age")
+    for row in rows:
+        print(f"  {row['name']} (age {row['age']})")
+
+    # --- READ (single row) ---
+    print("\n--- SELECT single user ---")
+    user = db.query_one("SELECT name, email FROM users WHERE id = 2")
+    if user:
+        print(f"  User 2: {user['name']} <{user['email']}>")
+
+    # --- UPDATE ---
+    print("\n--- UPDATE ---")
+    affected = db.execute("UPDATE users SET age = 31 WHERE name = 'Alice'")
+    print(f"  Updated {affected} row(s)")
+
+    updated = db.query_one("SELECT name, age FROM users WHERE name = 'Alice'")
+    print(f"  Alice's age is now: {updated['age']}")
+
+    # --- DELETE ---
+    print("\n--- DELETE ---")
+    affected = db.execute("DELETE FROM users WHERE name = 'Charlie'")
+    print(f"  Deleted {affected} row(s)")
+
+    remaining = db.query("SELECT name FROM users ORDER BY name")
+    print(f"  Remaining users: {', '.join(r['name'] for r in remaining)}")
+
+    # --- Aggregates ---
+    print("\n--- AGGREGATES ---")
+    stats = db.query_one("SELECT COUNT(*) as total, AVG(age) as avg_age FROM users")
+    print(f"  {stats['total']} users, average age: {stats['avg_age']:.1f}")
+
+print(f"\nDatabase closed. Cleaning up {DB_FILE}...")
+os.remove(DB_FILE)
+print("Done!")

--- a/docs/tutorials/native-ffi/python/example_transactions.py
+++ b/docs/tutorials/native-ffi/python/example_transactions.py
@@ -1,0 +1,106 @@
+"""Example: Transactions with CSharpDB from Python.
+
+Demonstrates:
+  - Explicit begin/commit/rollback
+  - transaction() helper for automatic commit/rollback
+  - Rollback on error
+
+Run:
+    python example_transactions.py
+"""
+
+import os
+import sys
+
+LIB_PATH = os.environ.get(
+    "CSHARPDB_NATIVE_PATH",
+    os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "..", "..",
+        "src", "CSharpDB.Native", "bin", "Release",
+        "net10.0", "win-x64", "publish", "CSharpDB.Native.dll",
+    ),
+)
+
+from csharpdb import CSharpDB, CSharpDBError
+
+DB_FILE = "tutorial_transactions.db"
+
+if os.path.exists(DB_FILE):
+    os.remove(DB_FILE)
+
+print("=== CSharpDB Python Tutorial: Transactions ===\n")
+
+with CSharpDB(LIB_PATH) as db:
+    db.open(DB_FILE)
+
+    # Setup
+    db.execute("CREATE TABLE accounts (id INTEGER PRIMARY KEY, name TEXT, balance REAL)")
+    db.execute("INSERT INTO accounts VALUES (1, 'Alice', 1000.00)")
+    db.execute("INSERT INTO accounts VALUES (2, 'Bob', 500.00)")
+
+    def show_balances():
+        rows = db.query("SELECT name, balance FROM accounts ORDER BY id")
+        for r in rows:
+            print(f"    {r['name']}: ${r['balance']:.2f}")
+
+    print("Initial balances:")
+    show_balances()
+
+    # --- Example 1: Successful transaction (explicit) ---
+    print("\n--- Example 1: Successful transfer (explicit begin/commit) ---")
+    db.begin()
+    db.execute("UPDATE accounts SET balance = balance - 200 WHERE name = 'Alice'")
+    db.execute("UPDATE accounts SET balance = balance + 200 WHERE name = 'Bob'")
+    db.commit()
+    print("  Transferred $200 from Alice to Bob")
+    show_balances()
+
+    # --- Example 2: Rolled-back transaction ---
+    print("\n--- Example 2: Rolled-back transfer ---")
+    db.begin()
+    db.execute("UPDATE accounts SET balance = balance - 9999 WHERE name = 'Alice'")
+    print("  (Oops, transferring $9999 — let's rollback)")
+    db.rollback()
+    print("  Rolled back!")
+    show_balances()
+
+    # --- Example 3: transaction() helper with auto-commit ---
+    print("\n--- Example 3: transaction() helper ---")
+
+    def transfer():
+        db.execute("UPDATE accounts SET balance = balance - 100 WHERE name = 'Bob'")
+        db.execute("UPDATE accounts SET balance = balance + 100 WHERE name = 'Alice'")
+
+    db.transaction(transfer)
+    print("  Auto-committed $100 transfer from Bob to Alice")
+    show_balances()
+
+    # --- Example 4: transaction() helper with auto-rollback on error ---
+    print("\n--- Example 4: transaction() with error (auto-rollback) ---")
+    try:
+        def bad_transfer():
+            db.execute("UPDATE accounts SET balance = balance - 50 WHERE name = 'Alice'")
+            raise ValueError("Something went wrong mid-transfer!")
+
+        db.transaction(bad_transfer)
+    except ValueError as e:
+        print(f"  Caught error: {e}")
+        print("  Transaction was automatically rolled back")
+    show_balances()
+
+    # --- Example 5: Batch insert in transaction ---
+    print("\n--- Example 5: Batch insert in a transaction ---")
+    db.execute("CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)")
+
+    def batch_insert():
+        for i in range(1, 6):
+            db.execute(f"INSERT INTO logs VALUES ({i}, 'Log entry {i}')")
+
+    db.transaction(batch_insert)
+    count = db.query_one("SELECT COUNT(*) as cnt FROM logs")
+    print(f"  Inserted {count['cnt']} log entries in a single transaction")
+
+print(f"\nCleaning up {DB_FILE}...")
+os.remove(DB_FILE)
+print("Done!")

--- a/src/CSharpDB.Admin/CSharpDB.Admin.csproj
+++ b/src/CSharpDB.Admin/CSharpDB.Admin.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CSharpDB.Service\CSharpDB.Service.csproj" />
+    <ProjectReference Include="..\CSharpDB.Client\CSharpDB.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CSharpDB.Admin/Components/Layout/NavMenu.razor
+++ b/src/CSharpDB.Admin/Components/Layout/NavMenu.razor
@@ -1,4 +1,5 @@
-@inject CSharpDbService DbService
+@inject ICSharpDbClient DbClient
+@inject DatabaseChangeService Changes
 @inject TabManagerService TabManager
 @inject IJSRuntime JS
 @implements IDisposable
@@ -190,22 +191,20 @@
 
     private IReadOnlyCollection<string>? _tableNames;
     private IReadOnlyCollection<string>? _viewNames;
-    private IReadOnlyList<CSharpDB.Core.IndexSchema>? _indexes;
-    private IReadOnlyList<CSharpDB.Core.TriggerSchema>? _triggers;
-    private IReadOnlyList<CSharpDB.Service.Models.ProcedureDefinition>? _procedures;
+    private IReadOnlyList<IndexSchema>? _indexes;
+    private IReadOnlyList<TriggerSchema>? _triggers;
+    private IReadOnlyList<ProcedureDefinition>? _procedures;
     private string _searchQuery = string.Empty;
     private readonly HashSet<string> _expandedGroups = new() { "tables", "system", "views", "procedures" };
 
     protected override async Task OnInitializedAsync()
     {
-        DbService.TablesChanged += OnSchemaChanged;
-        DbService.SchemaChanged += OnSchemaChanged;
-        DbService.ProceduresChanged += OnSchemaChanged;
+        Changes.Changed += OnChanged;
         TabManager.StateChanged += OnTabChanged;
         await LoadObjects();
     }
 
-    private async void OnSchemaChanged()
+    private async void OnChanged()
     {
         await LoadObjects();
         await InvokeAsync(StateHasChanged);
@@ -217,11 +216,11 @@
     {
         try
         {
-            _tableNames = (await DbService.GetTableNamesAsync()).OrderBy(n => n).ToList();
-            _viewNames = (await DbService.GetViewNamesAsync()).OrderBy(n => n).ToList();
-            _indexes = (await DbService.GetIndexesAsync()).OrderBy(i => i.IndexName).ToList();
-            _triggers = (await DbService.GetTriggersAsync()).OrderBy(t => t.TriggerName).ToList();
-            _procedures = (await DbService.GetProceduresAsync()).OrderBy(p => p.Name).ToList();
+            _tableNames = (await DbClient.GetTableNamesAsync()).OrderBy(n => n).ToList();
+            _viewNames = (await DbClient.GetViewNamesAsync()).OrderBy(n => n).ToList();
+            _indexes = (await DbClient.GetIndexesAsync()).OrderBy(i => i.IndexName).ToList();
+            _triggers = (await DbClient.GetTriggersAsync()).OrderBy(t => t.TriggerName).ToList();
+            _procedures = (await DbClient.GetProceduresAsync()).OrderBy(p => p.Name).ToList();
         }
         catch
         {
@@ -248,25 +247,25 @@
         return items.Where(n => n.Contains(_searchQuery, StringComparison.OrdinalIgnoreCase));
     }
 
-    private IEnumerable<CSharpDB.Core.IndexSchema> FilterIndexes()
+    private IEnumerable<IndexSchema> FilterIndexes()
     {
-        if (_indexes is null) return Enumerable.Empty<CSharpDB.Core.IndexSchema>();
+        if (_indexes is null) return Enumerable.Empty<IndexSchema>();
         if (string.IsNullOrWhiteSpace(_searchQuery)) return _indexes;
         return _indexes.Where(i => i.IndexName.Contains(_searchQuery, StringComparison.OrdinalIgnoreCase)
                                  || i.TableName.Contains(_searchQuery, StringComparison.OrdinalIgnoreCase));
     }
 
-    private IEnumerable<CSharpDB.Core.TriggerSchema> FilterTriggers()
+    private IEnumerable<TriggerSchema> FilterTriggers()
     {
-        if (_triggers is null) return Enumerable.Empty<CSharpDB.Core.TriggerSchema>();
+        if (_triggers is null) return Enumerable.Empty<TriggerSchema>();
         if (string.IsNullOrWhiteSpace(_searchQuery)) return _triggers;
         return _triggers.Where(t => t.TriggerName.Contains(_searchQuery, StringComparison.OrdinalIgnoreCase)
                                   || t.TableName.Contains(_searchQuery, StringComparison.OrdinalIgnoreCase));
     }
 
-    private IEnumerable<CSharpDB.Service.Models.ProcedureDefinition> FilterProcedures()
+    private IEnumerable<ProcedureDefinition> FilterProcedures()
     {
-        if (_procedures is null) return Enumerable.Empty<CSharpDB.Service.Models.ProcedureDefinition>();
+        if (_procedures is null) return Enumerable.Empty<ProcedureDefinition>();
         if (string.IsNullOrWhiteSpace(_searchQuery)) return _procedures;
         return _procedures.Where(p => p.Name.Contains(_searchQuery, StringComparison.OrdinalIgnoreCase)
                                    || (p.Description?.Contains(_searchQuery, StringComparison.OrdinalIgnoreCase) ?? false));
@@ -311,9 +310,7 @@
 
     public void Dispose()
     {
-        DbService.TablesChanged -= OnSchemaChanged;
-        DbService.SchemaChanged -= OnSchemaChanged;
-        DbService.ProceduresChanged -= OnSchemaChanged;
+        Changes.Changed -= OnChanged;
         TabManager.StateChanged -= OnTabChanged;
     }
 }

--- a/src/CSharpDB.Admin/Components/Layout/StatusBar.razor
+++ b/src/CSharpDB.Admin/Components/Layout/StatusBar.razor
@@ -1,4 +1,5 @@
-@inject CSharpDbService DbService
+@inject ICSharpDbClient DbClient
+@inject DatabaseChangeService Changes
 @inject TabManagerService TabManager
 @implements IDisposable
 
@@ -8,7 +9,7 @@
         Connected
     </div>
     <div class="status-item">
-        <i class="bi bi-database"></i> @DbService.DataSource
+        <i class="bi bi-database"></i> @DbClient.DataSource
     </div>
     <div class="status-item">
         @_tableCount tables, @_viewCount views, @_procedureCount procedures
@@ -29,13 +30,11 @@
 
     protected override async Task OnInitializedAsync()
     {
-        DbService.SchemaChanged += OnSchemaChanged;
-        DbService.TablesChanged += OnSchemaChanged;
-        DbService.ProceduresChanged += OnSchemaChanged;
+        Changes.Changed += OnChanged;
         await LoadCounts();
     }
 
-    private async void OnSchemaChanged()
+    private async void OnChanged()
     {
         await LoadCounts();
         await InvokeAsync(StateHasChanged);
@@ -45,20 +44,16 @@
     {
         try
         {
-            var tables = await DbService.GetTableNamesAsync();
-            var views = await DbService.GetViewNamesAsync();
-            var procedures = await DbService.GetProceduresAsync();
-            _tableCount = tables.Count;
-            _viewCount = views.Count;
-            _procedureCount = procedures.Count;
+            var info = await DbClient.GetInfoAsync();
+            _tableCount = info.TableCount;
+            _viewCount = info.ViewCount;
+            _procedureCount = info.ProcedureCount;
         }
         catch { /* ignore */ }
     }
 
     public void Dispose()
     {
-        DbService.SchemaChanged -= OnSchemaChanged;
-        DbService.TablesChanged -= OnSchemaChanged;
-        DbService.ProceduresChanged -= OnSchemaChanged;
+        Changes.Changed -= OnChanged;
     }
 }

--- a/src/CSharpDB.Admin/Components/Layout/TitleBar.razor
+++ b/src/CSharpDB.Admin/Components/Layout/TitleBar.razor
@@ -1,13 +1,13 @@
 @inject ThemeService Theme
 @inject TabManagerService TabManager
-@inject CSharpDbService DbService
+@inject ICSharpDbClient DbClient
 @implements IDisposable
 
 <div class="titlebar">
     <div class="titlebar-logo">
         <i class="bi bi-database-fill"></i>
         <span class="titlebar-brand">CSharpDB Studio</span>
-        <span class="titlebar-dbname">@("\u2014") @DbService.DataSource</span>
+        <span class="titlebar-dbname">@("\u2014") @DbClient.DataSource</span>
     </div>
     <div class="titlebar-center">
         <span class="status-dot connected"></span>

--- a/src/CSharpDB.Admin/Components/Shared/DataGrid.razor
+++ b/src/CSharpDB.Admin/Components/Shared/DataGrid.razor
@@ -1,4 +1,5 @@
-@inject CSharpDbService DbService
+@inject ICSharpDbClient DbClient
+@inject DatabaseChangeService Changes
 @inject ToastService Toast
 @inject ModalService Modal
 
@@ -213,7 +214,7 @@
         {
             if (TableName is not null)
             {
-                var result = await DbService.BrowseTableAsync(TableName, _page, _pageSize);
+                var result = await DbClient.BrowseTableAsync(TableName, _page, _pageSize);
                 _totalRows = result.TotalRows;
                 _allRows = result.Rows.Select(r => new DataGridRow(r)).ToList();
 
@@ -227,7 +228,7 @@
             }
             else if (ViewName is not null)
             {
-                var result = await DbService.BrowseViewAsync(ViewName, _page, _pageSize);
+                var result = await DbClient.BrowseViewAsync(ViewName, _page, _pageSize);
                 _totalRows = result.TotalRows;
                 Columns = result.ColumnNames;
                 _allRows = result.Rows.Select(r => new DataGridRow(r)).ToList();
@@ -393,9 +394,9 @@
                             if (row.CurrentValues[c] is not null)
                                 insertVals[Columns[c]] = row.CurrentValues[c];
                         }
-                        if (insertVals.Count > 0)
-                        {
-                            await DbService.InsertRowAsync(TableName, insertVals);
+                            if (insertVals.Count > 0)
+                            {
+                            await DbClient.InsertRowAsync(TableName, insertVals);
                             saved++;
                         }
                         break;
@@ -404,12 +405,12 @@
                         var updateVals = new Dictionary<string, object?>();
                         for (int c = 0; c < Columns!.Length; c++)
                             updateVals[Columns[c]] = row.CurrentValues[c];
-                        await DbService.UpdateRowAsync(TableName, PrimaryKeyColumn, row.OriginalValues[pkColIdx]!, updateVals);
+                        await DbClient.UpdateRowAsync(TableName, PrimaryKeyColumn, row.OriginalValues[pkColIdx]!, updateVals);
                         saved++;
                         break;
 
                     case RowState.Deleted:
-                        await DbService.DeleteRowAsync(TableName, PrimaryKeyColumn, row.OriginalValues[pkColIdx]!);
+                        await DbClient.DeleteRowAsync(TableName, PrimaryKeyColumn, row.OriginalValues[pkColIdx]!);
                         saved++;
                         break;
                 }
@@ -423,6 +424,7 @@
 
         if (saved > 0) Toast.Success($"{saved} change(s) saved");
         if (errors > 0) Toast.Warning($"{errors} error(s) occurred");
+        if (saved > 0) Changes.NotifyChanged();
 
         await LoadDataAsync();
     }

--- a/src/CSharpDB.Admin/Components/Tabs/DataTab.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/DataTab.razor
@@ -1,4 +1,5 @@
-@inject CSharpDbService DbService
+@inject ICSharpDbClient DbClient
+@inject DatabaseChangeService Changes
 @inject TabManagerService TabManager
 @inject ToastService Toast
 @inject ModalService Modal
@@ -119,11 +120,11 @@
                                         </div>
                                         <div class="schema-field">
                                             <label>Type</label>
-                                            <select class="schema-input" value="@_addColType" @onchange="e => { if (Enum.TryParse<CSharpDB.Core.DbType>(e.Value?.ToString(), out var t)) _addColType = t; }">
-                                                <option value="@CSharpDB.Core.DbType.Integer">INTEGER</option>
-                                                <option value="@CSharpDB.Core.DbType.Real">REAL</option>
-                                                <option value="@CSharpDB.Core.DbType.Text">TEXT</option>
-                                                <option value="@CSharpDB.Core.DbType.Blob">BLOB</option>
+                                            <select class="schema-input" value="@_addColType" @onchange="e => { if (Enum.TryParse<DbType>(e.Value?.ToString(), out var t)) _addColType = t; }">
+                                                <option value="@DbType.Integer">INTEGER</option>
+                                                <option value="@DbType.Real">REAL</option>
+                                                <option value="@DbType.Text">TEXT</option>
+                                                <option value="@DbType.Blob">BLOB</option>
                                             </select>
                                         </div>
                                         <div class="schema-field">
@@ -303,17 +304,17 @@
                             </div>
                             <div class="schema-field">
                                 <label>Timing</label>
-                                <select class="schema-input" value="@_trigTiming" @onchange="e => { if (Enum.TryParse<CSharpDB.Core.TriggerTiming>(e.Value?.ToString(), out var t)) _trigTiming = t; }">
-                                    <option value="@CSharpDB.Core.TriggerTiming.Before">BEFORE</option>
-                                    <option value="@CSharpDB.Core.TriggerTiming.After">AFTER</option>
+                                <select class="schema-input" value="@_trigTiming" @onchange="e => { if (Enum.TryParse<TriggerTiming>(e.Value?.ToString(), out var t)) _trigTiming = t; }">
+                                    <option value="@TriggerTiming.Before">BEFORE</option>
+                                    <option value="@TriggerTiming.After">AFTER</option>
                                 </select>
                             </div>
                             <div class="schema-field">
                                 <label>Event</label>
-                                <select class="schema-input" value="@_trigEvent" @onchange="e => { if (Enum.TryParse<CSharpDB.Core.TriggerEvent>(e.Value?.ToString(), out var t)) _trigEvent = t; }">
-                                    <option value="@CSharpDB.Core.TriggerEvent.Insert">INSERT</option>
-                                    <option value="@CSharpDB.Core.TriggerEvent.Update">UPDATE</option>
-                                    <option value="@CSharpDB.Core.TriggerEvent.Delete">DELETE</option>
+                                <select class="schema-input" value="@_trigEvent" @onchange="e => { if (Enum.TryParse<TriggerEvent>(e.Value?.ToString(), out var t)) _trigEvent = t; }">
+                                    <option value="@TriggerEvent.Insert">INSERT</option>
+                                    <option value="@TriggerEvent.Update">UPDATE</option>
+                                    <option value="@TriggerEvent.Delete">DELETE</option>
                                 </select>
                             </div>
                         </div>
@@ -377,17 +378,17 @@
     private bool HasSelection => _selectedRowCount > 0;
 
     // ─── Schema data ────────────────────
-    private CSharpDB.Core.TableSchema? _schema;
+    private TableSchema? _schema;
     private string? _viewSql;
-    private IReadOnlyCollection<CSharpDB.Core.IndexSchema>? _indexes;
-    private IReadOnlyCollection<CSharpDB.Core.TriggerSchema>? _triggers;
+    private IReadOnlyCollection<IndexSchema>? _indexes;
+    private IReadOnlyCollection<TriggerSchema>? _triggers;
 
     // ─── Alter table state ──────────────
     private bool _showAlterTable;
     private bool _submitting;
     private TableOp _tableOperation = TableOp.AddColumn;
     private string _addColName = string.Empty;
-    private CSharpDB.Core.DbType _addColType = CSharpDB.Core.DbType.Text;
+    private DbType _addColType = DbType.Text;
     private bool _addColNotNull;
     private string _dropColName = string.Empty;
     private string _renameOldCol = string.Empty;
@@ -403,8 +404,8 @@
     // ─── Trigger editing state ──────────
     private string? _editingTrigName;
     private string _trigName = string.Empty;
-    private CSharpDB.Core.TriggerTiming _trigTiming = CSharpDB.Core.TriggerTiming.After;
-    private CSharpDB.Core.TriggerEvent _trigEvent = CSharpDB.Core.TriggerEvent.Insert;
+    private TriggerTiming _trigTiming = TriggerTiming.After;
+    private TriggerEvent _trigEvent = TriggerEvent.Insert;
     private string _trigBody = string.Empty;
 
     // ─── View editing state ─────────────
@@ -435,10 +436,10 @@
         {
             if (!IsView)
             {
-                _schema = await DbService.GetTableSchemaAsync(ObjectName);
-                var allIndexes = await DbService.GetIndexesAsync();
+                _schema = await DbClient.GetTableSchemaAsync(ObjectName);
+                var allIndexes = await DbClient.GetIndexesAsync();
                 _indexes = allIndexes.Where(i => i.TableName.Equals(ObjectName, StringComparison.OrdinalIgnoreCase)).ToList();
-                var allTriggers = await DbService.GetTriggersAsync();
+                var allTriggers = await DbClient.GetTriggersAsync();
                 _triggers = allTriggers.Where(t => t.TableName.Equals(ObjectName, StringComparison.OrdinalIgnoreCase)).ToList();
 
                 // Sync dropdown defaults
@@ -454,7 +455,7 @@
             }
             else
             {
-                _viewSql = await DbService.GetViewSqlAsync(ObjectName);
+                _viewSql = await DbClient.GetViewSqlAsync(ObjectName);
             }
         }
         catch (Exception ex)
@@ -527,25 +528,26 @@
             switch (_tableOperation)
             {
                 case TableOp.AddColumn:
-                    await DbService.AddColumnAsync(ObjectName, _addColName, _addColType, _addColNotNull);
+                    await DbClient.AddColumnAsync(ObjectName, _addColName, _addColType, _addColNotNull);
                     Toast.Success($"Added column '{_addColName}'.");
                     _addColName = string.Empty;
                     break;
                 case TableOp.DropColumn:
-                    await DbService.DropColumnAsync(ObjectName, _dropColName);
+                    await DbClient.DropColumnAsync(ObjectName, _dropColName);
                     Toast.Success($"Dropped column '{_dropColName}'.");
                     break;
                 case TableOp.RenameColumn:
-                    await DbService.RenameColumnAsync(ObjectName, _renameOldCol, _renameNewCol);
+                    await DbClient.RenameColumnAsync(ObjectName, _renameOldCol, _renameNewCol);
                     Toast.Success($"Renamed '{_renameOldCol}' → '{_renameNewCol}'.");
                     _renameNewCol = string.Empty;
                     break;
                 case TableOp.RenameTable:
-                    await DbService.RenameTableAsync(ObjectName, _newTableName);
+                    await DbClient.RenameTableAsync(ObjectName, _newTableName);
                     Toast.Success($"Renamed table → '{_newTableName}'.");
                     _newTableName = string.Empty;
                     break;
             }
+            Changes.NotifyChanged();
             await LoadSchemaAsync();
         }
         catch (Exception ex) { Toast.Error(ex.Message); }
@@ -556,7 +558,7 @@
     // INDEXES
     // ═══════════════════════════════════════
 
-    private void StartIndexEdit(CSharpDB.Core.IndexSchema idx)
+    private void StartIndexEdit(IndexSchema idx)
     {
         _editingIdxName = idx.IndexName;
         _idxName = idx.IndexName;
@@ -578,15 +580,16 @@
         {
             if (_editingIdxName is null)
             {
-                await DbService.CreateIndexAsync(_idxName, ObjectName, _idxColumn, _idxUnique);
+                await DbClient.CreateIndexAsync(_idxName, ObjectName, _idxColumn, _idxUnique);
                 Toast.Success($"Created index '{_idxName}'.");
             }
             else
             {
-                await DbService.UpdateIndexAsync(_editingIdxName, _idxName, ObjectName, _idxColumn, _idxUnique);
+                await DbClient.UpdateIndexAsync(_editingIdxName, _idxName, ObjectName, _idxColumn, _idxUnique);
                 Toast.Success($"Updated index '{_editingIdxName}'.");
             }
             CancelIndexEdit();
+            Changes.NotifyChanged();
             await LoadSchemaAsync();
         }
         catch (Exception ex) { Toast.Error(ex.Message); }
@@ -598,8 +601,9 @@
         _confirmDrop = null;
         try
         {
-            await DbService.DropIndexAsync(indexName);
+            await DbClient.DropIndexAsync(indexName);
             Toast.Success($"Dropped index '{indexName}'.");
+            Changes.NotifyChanged();
             await LoadSchemaAsync();
         }
         catch (Exception ex) { Toast.Error(ex.Message); }
@@ -609,7 +613,7 @@
     // TRIGGERS
     // ═══════════════════════════════════════
 
-    private void StartTriggerEdit(CSharpDB.Core.TriggerSchema trig)
+    private void StartTriggerEdit(TriggerSchema trig)
     {
         _editingTrigName = trig.TriggerName;
         _trigName = trig.TriggerName;
@@ -622,8 +626,8 @@
     {
         _editingTrigName = null;
         _trigName = string.Empty;
-        _trigTiming = CSharpDB.Core.TriggerTiming.After;
-        _trigEvent = CSharpDB.Core.TriggerEvent.Insert;
+        _trigTiming = TriggerTiming.After;
+        _trigEvent = TriggerEvent.Insert;
         _trigBody = string.Empty;
     }
 
@@ -634,15 +638,16 @@
         {
             if (_editingTrigName is null)
             {
-                await DbService.CreateTriggerAsync(_trigName, ObjectName, _trigTiming, _trigEvent, _trigBody);
+                await DbClient.CreateTriggerAsync(_trigName, ObjectName, _trigTiming, _trigEvent, _trigBody);
                 Toast.Success($"Created trigger '{_trigName}'.");
             }
             else
             {
-                await DbService.UpdateTriggerAsync(_editingTrigName, _trigName, ObjectName, _trigTiming, _trigEvent, _trigBody);
+                await DbClient.UpdateTriggerAsync(_editingTrigName, _trigName, ObjectName, _trigTiming, _trigEvent, _trigBody);
                 Toast.Success($"Updated trigger '{_editingTrigName}'.");
             }
             CancelTriggerEdit();
+            Changes.NotifyChanged();
             await LoadSchemaAsync();
         }
         catch (Exception ex) { Toast.Error(ex.Message); }
@@ -654,8 +659,9 @@
         _confirmDrop = null;
         try
         {
-            await DbService.DropTriggerAsync(triggerName);
+            await DbClient.DropTriggerAsync(triggerName);
             Toast.Success($"Dropped trigger '{triggerName}'.");
+            Changes.NotifyChanged();
             await LoadSchemaAsync();
         }
         catch (Exception ex) { Toast.Error(ex.Message); }
@@ -679,9 +685,10 @@
         _submitting = true;
         try
         {
-            await DbService.UpdateViewAsync(ObjectName, _editViewName, _editViewSql);
+            await DbClient.UpdateViewAsync(ObjectName, _editViewName, _editViewSql);
             Toast.Success($"Updated view '{ObjectName}'.");
             _editingView = false;
+            Changes.NotifyChanged();
             await LoadSchemaAsync();
         }
         catch (Exception ex) { Toast.Error(ex.Message); }
@@ -695,8 +702,9 @@
         {
             try
             {
-                await DbService.DropViewAsync(ObjectName);
+                await DbClient.DropViewAsync(ObjectName);
                 Toast.Success($"Dropped view '{ObjectName}'.");
+                Changes.NotifyChanged();
             }
             catch (Exception ex) { Toast.Error(ex.Message); }
         }
@@ -714,8 +722,9 @@
 
         try
         {
-            await DbService.DropTableAsync(ObjectName);
+            await DbClient.DropTableAsync(ObjectName);
             Toast.Success($"Dropped table '{ObjectName}'.");
+            Changes.NotifyChanged();
             TabManager.CloseTabsForObject(ObjectName);
         }
         catch (Exception ex)

--- a/src/CSharpDB.Admin/Components/Tabs/ProcedureTab.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/ProcedureTab.razor
@@ -1,7 +1,7 @@
 @using System.Text.Json
-@using CSharpDB.Core
-@using CSharpDB.Service.Models
-@inject CSharpDbService DbService
+@using CSharpDB.Client.Models
+@inject ICSharpDbClient DbClient
+@inject DatabaseChangeService Changes
 @inject ToastService Toast
 @inject ModalService Modal
 @inject TabManagerService TabManager
@@ -223,7 +223,7 @@
     {
         try
         {
-            var procedure = await DbService.GetProcedureAsync(name);
+            var procedure = await DbClient.GetProcedureAsync(name);
             if (procedure is null)
             {
                 _error = $"Procedure '{name}' not found.";
@@ -270,15 +270,17 @@
 
             if (_isNew)
             {
-                await DbService.CreateProcedureAsync(definition);
+                await DbClient.CreateProcedureAsync(definition);
                 Toast.Success($"Procedure '{definition.Name}' created.");
+                Changes.NotifyChanged();
                 OpenNamedTab(definition.Name);
             }
             else
             {
                 string existingName = Tab?.ObjectName ?? _name;
-                await DbService.UpdateProcedureAsync(existingName, definition);
+                await DbClient.UpdateProcedureAsync(existingName, definition);
                 Toast.Success($"Procedure '{existingName}' updated.");
+                Changes.NotifyChanged();
                 OpenNamedTab(definition.Name);
             }
         }
@@ -309,8 +311,9 @@
         _error = null;
         try
         {
-            await DbService.DeleteProcedureAsync(_name);
+            await DbClient.DeleteProcedureAsync(_name);
             Toast.Success($"Procedure '{_name}' deleted.");
+            Changes.NotifyChanged();
             if (Tab is not null)
                 TabManager.CloseTab(Tab.Id);
         }
@@ -339,10 +342,13 @@
             }
 
             var args = ParseArgsJson(_argsJson);
-            _executionResult = await DbService.ExecuteProcedureAsync(_name, args);
+            _executionResult = await DbClient.ExecuteProcedureAsync(_name, args);
 
             if (_executionResult.Succeeded)
+            {
                 Toast.Success($"Procedure '{_name}' executed.");
+                Changes.NotifyChanged();
+            }
             else
                 _error = _executionResult.Error ?? "Execution failed.";
         }

--- a/src/CSharpDB.Admin/Components/Tabs/QueryTab.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/QueryTab.razor
@@ -2,8 +2,9 @@
 @using System.Globalization
 @using System.Text
 @using System.Text.RegularExpressions
-@using CSharpDB.Service.Models
-@inject CSharpDbService DbService
+@using CSharpDB.Client.Models
+@inject ICSharpDbClient DbClient
+@inject DatabaseChangeService Changes
 @inject ToastService Toast
 
 <div class="query-tab">
@@ -197,7 +198,7 @@
             }
             else
             {
-                var result = await DbService.ExecuteSqlAsync(trimmedSql);
+                var result = await DbClient.ExecuteSqlAsync(trimmedSql);
                 _elapsed = result.Elapsed;
 
                 if (result.Error is not null)
@@ -214,6 +215,8 @@
                     _nonQueryMessage = $"{result.RowsAffected} row(s) affected";
                     Toast.Success(_nonQueryMessage);
                 }
+
+                Changes.NotifyFromSql(trimmedSql);
             }
         }
         catch (Exception ex)
@@ -261,7 +264,7 @@
 
         try
         {
-            var saved = await DbService.UpsertSavedQueryAsync(name, _sqlText);
+            var saved = await DbClient.UpsertSavedQueryAsync(name, _sqlText);
             _savedQueryName = saved.Name;
             _selectedSavedQueryName = saved.Name;
             if (Tab is not null)
@@ -286,7 +289,7 @@
 
         try
         {
-            var saved = await DbService.GetSavedQueryAsync(_selectedSavedQueryName);
+            var saved = await DbClient.GetSavedQueryAsync(_selectedSavedQueryName);
             if (saved is null)
             {
                 Toast.Warning($"Saved query '{_selectedSavedQueryName}' was not found.");
@@ -320,7 +323,7 @@
 
         try
         {
-            _savedQueries = await DbService.GetSavedQueriesAsync();
+            _savedQueries = await DbClient.GetSavedQueriesAsync();
             if (!string.IsNullOrWhiteSpace(keepSelection)
                 && _savedQueries.Any(q => string.Equals(q.Name, keepSelection, StringComparison.OrdinalIgnoreCase)))
             {
@@ -348,7 +351,7 @@
 
     private async Task RunExecuteCommandAsync(string procedureName, IReadOnlyDictionary<string, object?> args)
     {
-        var result = await DbService.ExecuteProcedureAsync(procedureName, args);
+        var result = await DbClient.ExecuteProcedureAsync(procedureName, args);
         _elapsed = result.Elapsed;
 
         if (!result.Succeeded)
@@ -377,6 +380,7 @@
         int affected = result.Statements.Where(s => !s.IsQuery).Sum(s => s.RowsAffected);
         _nonQueryMessage = $"Procedure '{procedureName}' executed. {affected} row(s) affected.";
         Toast.Success(_nonQueryMessage);
+        Changes.NotifyChanged();
     }
 
     private static bool TryParseExecuteCommand(

--- a/src/CSharpDB.Admin/Components/Tabs/StorageTab.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/StorageTab.razor
@@ -1,5 +1,5 @@
 @using CSharpDB.Storage.Diagnostics
-@inject CSharpDbService DbService
+@inject ICSharpDbClient DbClient
 @inject ToastService Toast
 
 <div class="storage-tab">
@@ -17,7 +17,7 @@
             <i class="bi bi-search"></i> Inspect Page
         </button>
         <div class="toolbar-spacer"></div>
-        <div class="toolbar-info">@(_dbReport?.DatabasePath ?? DbService.DataSource)</div>
+        <div class="toolbar-info">@(_dbReport?.DatabasePath ?? DbClient.DataSource)</div>
     </div>
 
     @if (_loading)
@@ -248,9 +248,9 @@
         _loading = true;
         try
         {
-            _dbReport = await DbService.InspectStorageAsync(includePages: false);
-            _walReport = await DbService.CheckWalAsync();
-            _indexReport = await DbService.CheckIndexesAsync();
+            _dbReport = await DbClient.InspectStorageAsync(includePages: false);
+            _walReport = await DbClient.CheckWalAsync();
+            _indexReport = await DbClient.CheckIndexesAsync();
             RebuildIssueList();
         }
         catch (Exception ex)
@@ -274,7 +274,7 @@
         _loadingPage = true;
         try
         {
-            _pageReport = await DbService.InspectPageAsync(pageId, _includeHex);
+            _pageReport = await DbClient.InspectPageAsync(pageId, _includeHex);
         }
         catch (Exception ex)
         {

--- a/src/CSharpDB.Admin/Components/Tabs/WelcomeTab.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/WelcomeTab.razor
@@ -1,5 +1,7 @@
-@inject CSharpDbService DbService
+@inject ICSharpDbClient DbClient
+@inject DatabaseChangeService Changes
 @inject TabManagerService TabManager
+@implements IDisposable
 
 <div class="welcome-tab">
     <div class="empty-state">
@@ -50,18 +52,33 @@
 
     protected override async Task OnInitializedAsync()
     {
+        Changes.Changed += OnChanged;
+        await LoadTablesAsync();
+    }
+
+    private async void OnChanged()
+    {
+        await LoadTablesAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task LoadTablesAsync()
+    {
         try
         {
-            _tableNames = (await DbService.GetTableNamesAsync()).OrderBy(n => n).ToList();
+            _tableNames = (await DbClient.GetTableNamesAsync()).OrderBy(n => n).ToList();
+            _rowCounts.Clear();
             foreach (var name in _tableNames)
             {
                 try
                 {
-                    _rowCounts[name] = await DbService.GetRowCountAsync(name);
+                    _rowCounts[name] = await DbClient.GetRowCountAsync(name);
                 }
                 catch { /* ignore */ }
             }
         }
         catch { /* ignore */ }
     }
+
+    public void Dispose() => Changes.Changed -= OnChanged;
 }

--- a/src/CSharpDB.Admin/Program.cs
+++ b/src/CSharpDB.Admin/Program.cs
@@ -1,23 +1,31 @@
 using CSharpDB.Admin.Components;
 using CSharpDB.Admin.Services;
-using CSharpDB.Service;
+using CSharpDB.Client;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
-builder.Services.AddSingleton<CSharpDbService>();
+builder.Services.AddCSharpDbClient(sp => new CSharpDbClientOptions
+{
+    ConnectionString = sp.GetRequiredService<IConfiguration>().GetConnectionString("CSharpDB")
+        ?? "Data Source=csharpdb.db",
+});
 builder.Services.AddScoped<TabManagerService>();
 builder.Services.AddScoped<ThemeService>();
 builder.Services.AddScoped<ToastService>();
 builder.Services.AddScoped<ModalService>();
+builder.Services.AddScoped<DatabaseChangeService>();
 
 var app = builder.Build();
 
 // Open the database connection at startup (before any requests arrive)
-var dbService = app.Services.GetRequiredService<CSharpDbService>();
-await dbService.InitializeAsync();
+await using (var scope = app.Services.CreateAsyncScope())
+{
+    var dbClient = scope.ServiceProvider.GetRequiredService<ICSharpDbClient>();
+    _ = await dbClient.GetInfoAsync();
+}
 
 if (!app.Environment.IsDevelopment())
 {

--- a/src/CSharpDB.Admin/Services/DatabaseChangeService.cs
+++ b/src/CSharpDB.Admin/Services/DatabaseChangeService.cs
@@ -1,0 +1,56 @@
+using CSharpDB.Sql;
+
+namespace CSharpDB.Admin.Services;
+
+/// <summary>
+/// Admin-local change notifier used to refresh UI components after client writes.
+/// </summary>
+public sealed class DatabaseChangeService
+{
+    private const string ProcedureTableName = "__procedures";
+
+    public event Action? Changed;
+
+    public void NotifyChanged() => Changed?.Invoke();
+
+    public void NotifyFromSql(string sql)
+    {
+        AnalyzeSqlEffects(sql, out bool schemaMutated, out bool proceduresMutated);
+        if (schemaMutated || proceduresMutated)
+            NotifyChanged();
+    }
+
+    private static void AnalyzeSqlEffects(string sql, out bool schemaMutated, out bool proceduresMutated)
+    {
+        schemaMutated = false;
+        proceduresMutated = false;
+
+        foreach (string statement in SqlScriptSplitter.SplitExecutableStatements(sql))
+        {
+            if (LooksLikeSchemaMutation(statement))
+                schemaMutated = true;
+
+            proceduresMutated |= LooksLikeProcedureMutation(statement);
+        }
+    }
+
+    private static bool LooksLikeSchemaMutation(string sql)
+    {
+        string upper = sql.TrimStart().ToUpperInvariant();
+        return upper.StartsWith("CREATE ", StringComparison.Ordinal)
+            || upper.StartsWith("DROP ", StringComparison.Ordinal)
+            || upper.StartsWith("ALTER ", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeProcedureMutation(string sql)
+    {
+        string upper = sql.TrimStart().ToUpperInvariant();
+        return upper.StartsWith($"INSERT INTO {ProcedureTableName.ToUpperInvariant()}", StringComparison.Ordinal)
+            || upper.StartsWith($"UPDATE {ProcedureTableName.ToUpperInvariant()}", StringComparison.Ordinal)
+            || upper.StartsWith($"DELETE FROM {ProcedureTableName.ToUpperInvariant()}", StringComparison.Ordinal)
+            || upper.StartsWith($"CREATE TABLE {ProcedureTableName.ToUpperInvariant()}", StringComparison.Ordinal)
+            || upper.StartsWith($"CREATE TABLE IF NOT EXISTS {ProcedureTableName.ToUpperInvariant()}", StringComparison.Ordinal)
+            || upper.StartsWith($"DROP TABLE {ProcedureTableName.ToUpperInvariant()}", StringComparison.Ordinal)
+            || upper.StartsWith($"ALTER TABLE {ProcedureTableName.ToUpperInvariant()}", StringComparison.Ordinal);
+    }
+}

--- a/src/CSharpDB.Admin/_Imports.razor
+++ b/src/CSharpDB.Admin/_Imports.razor
@@ -13,5 +13,5 @@
 @using CSharpDB.Admin.Helpers
 @using CSharpDB.Admin.Models
 @using CSharpDB.Admin.Services
-@using CSharpDB.Service
-@using CSharpDB.Service.Models
+@using CSharpDB.Client
+@using CSharpDB.Client.Models

--- a/src/CSharpDB.Api/CSharpDB.Api.csproj
+++ b/src/CSharpDB.Api/CSharpDB.Api.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CSharpDB.Service\CSharpDB.Service.csproj" />
+    <ProjectReference Include="..\CSharpDB.Client\CSharpDB.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CSharpDB.Api/Endpoints/IndexEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/IndexEndpoints.cs
@@ -1,5 +1,5 @@
 using CSharpDB.Api.Dtos;
-using CSharpDB.Service;
+using CSharpDB.Client;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -15,7 +15,7 @@ public static class IndexEndpoints
         return group;
     }
 
-    private static async Task<IResult> GetAllIndexes(CSharpDbService db)
+    private static async Task<IResult> GetAllIndexes(ICSharpDbClient db)
     {
         var indexes = await db.GetIndexesAsync();
         var response = indexes.Select(i => new IndexResponse(
@@ -23,21 +23,21 @@ public static class IndexEndpoints
         return Results.Ok(response);
     }
 
-    private static async Task<IResult> CreateIndex(CreateIndexRequest req, CSharpDbService db)
+    private static async Task<IResult> CreateIndex(CreateIndexRequest req, ICSharpDbClient db)
     {
         await db.CreateIndexAsync(req.IndexName, req.TableName, req.ColumnName, req.IsUnique);
         return Results.Created($"/api/indexes/{req.IndexName}", new IndexResponse(
             req.IndexName, req.TableName, [req.ColumnName], req.IsUnique));
     }
 
-    private static async Task<IResult> UpdateIndex(string name, UpdateIndexRequest req, CSharpDbService db)
+    private static async Task<IResult> UpdateIndex(string name, UpdateIndexRequest req, ICSharpDbClient db)
     {
         await db.UpdateIndexAsync(name, req.NewIndexName, req.TableName, req.ColumnName, req.IsUnique);
         return Results.Ok(new IndexResponse(
             req.NewIndexName, req.TableName, [req.ColumnName], req.IsUnique));
     }
 
-    private static async Task<IResult> DropIndex(string name, CSharpDbService db)
+    private static async Task<IResult> DropIndex(string name, ICSharpDbClient db)
     {
         await db.DropIndexAsync(name);
         return Results.NoContent();

--- a/src/CSharpDB.Api/Endpoints/InspectEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/InspectEndpoints.cs
@@ -1,4 +1,4 @@
-using CSharpDB.Service;
+using CSharpDB.Client;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -14,7 +14,7 @@ public static class InspectEndpoints
     }
 
     private static async Task<IResult> InspectStorage(
-        CSharpDbService db,
+        ICSharpDbClient db,
         bool includePages = false,
         string? path = null)
     {
@@ -23,7 +23,7 @@ public static class InspectEndpoints
     }
 
     private static async Task<IResult> InspectWal(
-        CSharpDbService db,
+        ICSharpDbClient db,
         string? path = null)
     {
         var report = await db.CheckWalAsync(path);
@@ -32,7 +32,7 @@ public static class InspectEndpoints
 
     private static async Task<IResult> InspectPage(
         uint id,
-        CSharpDbService db,
+        ICSharpDbClient db,
         bool hex = false,
         string? path = null)
     {
@@ -41,7 +41,7 @@ public static class InspectEndpoints
     }
 
     private static async Task<IResult> CheckIndexes(
-        CSharpDbService db,
+        ICSharpDbClient db,
         string? index = null,
         int? sample = null,
         string? path = null)

--- a/src/CSharpDB.Api/Endpoints/ProcedureEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/ProcedureEndpoints.cs
@@ -1,8 +1,7 @@
 using CSharpDB.Api.Dtos;
 using CSharpDB.Api.Helpers;
-using CSharpDB.Core;
-using CSharpDB.Service;
-using CSharpDB.Service.Models;
+using CSharpDB.Client;
+using CSharpDB.Client.Models;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -20,14 +19,14 @@ public static class ProcedureEndpoints
         return group;
     }
 
-    private static async Task<IResult> GetProcedures(CSharpDbService db, bool includeDisabled = true)
+    private static async Task<IResult> GetProcedures(ICSharpDbClient db, bool includeDisabled = true)
     {
         var procedures = await db.GetProceduresAsync(includeDisabled);
         var response = procedures.Select(MapSummary).ToList();
         return Results.Ok(response);
     }
 
-    private static async Task<IResult> GetProcedure(string name, CSharpDbService db)
+    private static async Task<IResult> GetProcedure(string name, ICSharpDbClient db)
     {
         var procedure = await db.GetProcedureAsync(name);
         if (procedure is null)
@@ -36,7 +35,7 @@ public static class ProcedureEndpoints
         return Results.Ok(MapDetail(procedure));
     }
 
-    private static async Task<IResult> CreateProcedure(CreateProcedureRequest req, CSharpDbService db)
+    private static async Task<IResult> CreateProcedure(CreateProcedureRequest req, ICSharpDbClient db)
     {
         var definition = MapDefinition(req.Name, req.BodySql, req.Parameters, req.Description, req.IsEnabled);
         await db.CreateProcedureAsync(definition);
@@ -45,7 +44,7 @@ public static class ProcedureEndpoints
         return Results.Created($"/api/procedures/{req.Name}", created is null ? MapDetail(definition) : MapDetail(created));
     }
 
-    private static async Task<IResult> UpdateProcedure(string name, UpdateProcedureRequest req, CSharpDbService db)
+    private static async Task<IResult> UpdateProcedure(string name, UpdateProcedureRequest req, ICSharpDbClient db)
     {
         var definition = MapDefinition(req.NewName, req.BodySql, req.Parameters, req.Description, req.IsEnabled);
         await db.UpdateProcedureAsync(name, definition);
@@ -54,13 +53,13 @@ public static class ProcedureEndpoints
         return Results.Ok(updated is null ? MapDetail(definition) : MapDetail(updated));
     }
 
-    private static async Task<IResult> DeleteProcedure(string name, CSharpDbService db)
+    private static async Task<IResult> DeleteProcedure(string name, ICSharpDbClient db)
     {
         await db.DeleteProcedureAsync(name);
         return Results.NoContent();
     }
 
-    private static async Task<IResult> ExecuteProcedure(string name, ExecuteProcedureRequest req, CSharpDbService db)
+    private static async Task<IResult> ExecuteProcedure(string name, ExecuteProcedureRequest req, ICSharpDbClient db)
     {
         var procedure = await db.GetProcedureAsync(name);
         if (procedure is null)

--- a/src/CSharpDB.Api/Endpoints/RowEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/RowEndpoints.cs
@@ -1,6 +1,6 @@
 using CSharpDB.Api.Dtos;
 using CSharpDB.Api.Helpers;
-using CSharpDB.Service;
+using CSharpDB.Client;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -18,7 +18,7 @@ public static class RowEndpoints
     }
 
     private static async Task<IResult> BrowseRows(
-        string name, CSharpDbService db, int page = 1, int pageSize = 50)
+        string name, ICSharpDbClient db, int page = 1, int pageSize = 50)
     {
         if (page < 1) page = 1;
         if (pageSize < 1) pageSize = 50;
@@ -34,7 +34,7 @@ public static class RowEndpoints
     }
 
     private static async Task<IResult> GetRowByPk(
-        string name, string pkValue, CSharpDbService db, string pkColumn = "id")
+        string name, string pkValue, ICSharpDbClient db, string pkColumn = "id")
     {
         object coerced = CoercePkValue(pkValue);
         var row = await db.GetRowByPkAsync(name, pkColumn, coerced);
@@ -43,7 +43,7 @@ public static class RowEndpoints
             : Results.Ok(row);
     }
 
-    private static async Task<IResult> InsertRow(string name, InsertRowRequest req, CSharpDbService db)
+    private static async Task<IResult> InsertRow(string name, InsertRowRequest req, ICSharpDbClient db)
     {
         var values = JsonHelper.CoerceDictionary(req.Values);
         var affected = await db.InsertRowAsync(name, values);
@@ -51,7 +51,7 @@ public static class RowEndpoints
     }
 
     private static async Task<IResult> UpdateRow(
-        string name, string pkValue, UpdateRowRequest req, CSharpDbService db, string pkColumn = "id")
+        string name, string pkValue, UpdateRowRequest req, ICSharpDbClient db, string pkColumn = "id")
     {
         object coerced = CoercePkValue(pkValue);
         var values = JsonHelper.CoerceDictionary(req.Values);
@@ -60,7 +60,7 @@ public static class RowEndpoints
     }
 
     private static async Task<IResult> DeleteRow(
-        string name, string pkValue, CSharpDbService db, string pkColumn = "id")
+        string name, string pkValue, ICSharpDbClient db, string pkColumn = "id")
     {
         object coerced = CoercePkValue(pkValue);
         var affected = await db.DeleteRowAsync(name, pkColumn, coerced);

--- a/src/CSharpDB.Api/Endpoints/SchemaEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/SchemaEndpoints.cs
@@ -1,5 +1,5 @@
 using CSharpDB.Api.Dtos;
-using CSharpDB.Service;
+using CSharpDB.Client;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -11,20 +11,16 @@ public static class SchemaEndpoints
         return group;
     }
 
-    private static async Task<IResult> GetDatabaseInfo(CSharpDbService db)
+    private static async Task<IResult> GetDatabaseInfo(ICSharpDbClient db)
     {
-        var tables = await db.GetTableNamesAsync();
-        var indexes = await db.GetIndexesAsync();
-        var views = await db.GetViewsAsync();
-        var triggers = await db.GetTriggersAsync();
-        var procedures = await db.GetProceduresAsync();
+        var info = await db.GetInfoAsync();
 
         return Results.Ok(new DatabaseInfoResponse(
-            db.DataSource,
-            tables.Count,
-            indexes.Count,
-            views.Count,
-            triggers.Count,
-            procedures.Count));
+            info.DataSource,
+            info.TableCount,
+            info.IndexCount,
+            info.ViewCount,
+            info.TriggerCount,
+            info.ProcedureCount));
     }
 }

--- a/src/CSharpDB.Api/Endpoints/SqlEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/SqlEndpoints.cs
@@ -1,6 +1,6 @@
 using CSharpDB.Api.Dtos;
 using CSharpDB.Api.Helpers;
-using CSharpDB.Service;
+using CSharpDB.Client;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -12,7 +12,7 @@ public static class SqlEndpoints
         return group;
     }
 
-    private static async Task<IResult> ExecuteSql(ExecuteSqlRequest req, CSharpDbService db)
+    private static async Task<IResult> ExecuteSql(ExecuteSqlRequest req, ICSharpDbClient db)
     {
         var result = await db.ExecuteSqlAsync(req.Sql);
 

--- a/src/CSharpDB.Api/Endpoints/TableEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/TableEndpoints.cs
@@ -1,6 +1,6 @@
 using CSharpDB.Api.Dtos;
-using CSharpDB.Core;
-using CSharpDB.Service;
+using CSharpDB.Client;
+using CSharpDB.Client.Models;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -20,13 +20,13 @@ public static class TableEndpoints
         return group;
     }
 
-    private static async Task<IResult> GetTableNames(CSharpDbService db)
+    private static async Task<IResult> GetTableNames(ICSharpDbClient db)
     {
         var names = await db.GetTableNamesAsync();
         return Results.Ok(names);
     }
 
-    private static async Task<IResult> GetTableSchema(string name, CSharpDbService db)
+    private static async Task<IResult> GetTableSchema(string name, ICSharpDbClient db)
     {
         var schema = await db.GetTableSchemaAsync(name);
         if (schema is null)
@@ -40,25 +40,25 @@ public static class TableEndpoints
         return Results.Ok(response);
     }
 
-    private static async Task<IResult> GetRowCount(string name, CSharpDbService db)
+    private static async Task<IResult> GetRowCount(string name, ICSharpDbClient db)
     {
         var count = await db.GetRowCountAsync(name);
         return Results.Ok(new RowCountResponse(name, count));
     }
 
-    private static async Task<IResult> DropTable(string name, CSharpDbService db)
+    private static async Task<IResult> DropTable(string name, ICSharpDbClient db)
     {
         await db.DropTableAsync(name);
         return Results.NoContent();
     }
 
-    private static async Task<IResult> RenameTable(string name, RenameTableRequest req, CSharpDbService db)
+    private static async Task<IResult> RenameTable(string name, RenameTableRequest req, ICSharpDbClient db)
     {
         await db.RenameTableAsync(name, req.NewName);
         return Results.NoContent();
     }
 
-    private static async Task<IResult> AddColumn(string name, AddColumnRequest req, CSharpDbService db)
+    private static async Task<IResult> AddColumn(string name, AddColumnRequest req, ICSharpDbClient db)
     {
         if (!Enum.TryParse<DbType>(req.Type, ignoreCase: true, out var dbType))
             return Results.BadRequest(new { error = $"Invalid column type '{req.Type}'. Valid types: Integer, Real, Text, Blob." });
@@ -67,13 +67,13 @@ public static class TableEndpoints
         return Results.NoContent();
     }
 
-    private static async Task<IResult> DropColumn(string name, string col, CSharpDbService db)
+    private static async Task<IResult> DropColumn(string name, string col, ICSharpDbClient db)
     {
         await db.DropColumnAsync(name, col);
         return Results.NoContent();
     }
 
-    private static async Task<IResult> RenameColumn(string name, string col, RenameColumnRequest req, CSharpDbService db)
+    private static async Task<IResult> RenameColumn(string name, string col, RenameColumnRequest req, ICSharpDbClient db)
     {
         await db.RenameColumnAsync(name, col, req.NewName);
         return Results.NoContent();

--- a/src/CSharpDB.Api/Endpoints/TriggerEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/TriggerEndpoints.cs
@@ -1,6 +1,6 @@
 using CSharpDB.Api.Dtos;
-using CSharpDB.Core;
-using CSharpDB.Service;
+using CSharpDB.Client;
+using CSharpDB.Client.Models;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -16,7 +16,7 @@ public static class TriggerEndpoints
         return group;
     }
 
-    private static async Task<IResult> GetAllTriggers(CSharpDbService db)
+    private static async Task<IResult> GetAllTriggers(ICSharpDbClient db)
     {
         var triggers = await db.GetTriggersAsync();
         var response = triggers.Select(t => new TriggerResponse(
@@ -26,7 +26,7 @@ public static class TriggerEndpoints
         return Results.Ok(response);
     }
 
-    private static async Task<IResult> CreateTrigger(CreateTriggerRequest req, CSharpDbService db)
+    private static async Task<IResult> CreateTrigger(CreateTriggerRequest req, ICSharpDbClient db)
     {
         if (!Enum.TryParse<TriggerTiming>(req.Timing, ignoreCase: true, out var timing))
             return Results.BadRequest(new { error = $"Invalid timing '{req.Timing}'. Valid values: Before, After." });
@@ -38,7 +38,7 @@ public static class TriggerEndpoints
             req.TriggerName, req.TableName, timing.ToString(), triggerEvent.ToString(), req.BodySql));
     }
 
-    private static async Task<IResult> UpdateTrigger(string name, UpdateTriggerRequest req, CSharpDbService db)
+    private static async Task<IResult> UpdateTrigger(string name, UpdateTriggerRequest req, ICSharpDbClient db)
     {
         if (!Enum.TryParse<TriggerTiming>(req.Timing, ignoreCase: true, out var timing))
             return Results.BadRequest(new { error = $"Invalid timing '{req.Timing}'. Valid values: Before, After." });
@@ -50,7 +50,7 @@ public static class TriggerEndpoints
             req.NewTriggerName, req.TableName, timing.ToString(), triggerEvent.ToString(), req.BodySql));
     }
 
-    private static async Task<IResult> DropTrigger(string name, CSharpDbService db)
+    private static async Task<IResult> DropTrigger(string name, ICSharpDbClient db)
     {
         await db.DropTriggerAsync(name);
         return Results.NoContent();

--- a/src/CSharpDB.Api/Endpoints/ViewEndpoints.cs
+++ b/src/CSharpDB.Api/Endpoints/ViewEndpoints.cs
@@ -1,6 +1,6 @@
 using CSharpDB.Api.Dtos;
 using CSharpDB.Api.Helpers;
-using CSharpDB.Service;
+using CSharpDB.Client;
 
 namespace CSharpDB.Api.Endpoints;
 
@@ -18,14 +18,14 @@ public static class ViewEndpoints
         return group;
     }
 
-    private static async Task<IResult> GetAllViews(CSharpDbService db)
+    private static async Task<IResult> GetAllViews(ICSharpDbClient db)
     {
         var views = await db.GetViewsAsync();
         var response = views.Select(v => new ViewResponse(v.Name, v.Sql)).ToList();
         return Results.Ok(response);
     }
 
-    private static async Task<IResult> GetView(string name, CSharpDbService db)
+    private static async Task<IResult> GetView(string name, ICSharpDbClient db)
     {
         var sql = await db.GetViewSqlAsync(name);
         return sql is null
@@ -34,7 +34,7 @@ public static class ViewEndpoints
     }
 
     private static async Task<IResult> BrowseViewRows(
-        string name, CSharpDbService db, int page = 1, int pageSize = 50)
+        string name, ICSharpDbClient db, int page = 1, int pageSize = 50)
     {
         if (page < 1) page = 1;
         if (pageSize < 1) pageSize = 50;
@@ -47,19 +47,19 @@ public static class ViewEndpoints
             result.ColumnNames, rows, result.TotalRows, result.Page, result.PageSize, result.TotalPages));
     }
 
-    private static async Task<IResult> CreateView(CreateViewRequest req, CSharpDbService db)
+    private static async Task<IResult> CreateView(CreateViewRequest req, ICSharpDbClient db)
     {
         await db.CreateViewAsync(req.ViewName, req.SelectSql);
         return Results.Created($"/api/views/{req.ViewName}", new ViewResponse(req.ViewName, req.SelectSql));
     }
 
-    private static async Task<IResult> UpdateView(string name, UpdateViewRequest req, CSharpDbService db)
+    private static async Task<IResult> UpdateView(string name, UpdateViewRequest req, ICSharpDbClient db)
     {
         await db.UpdateViewAsync(name, req.NewViewName, req.SelectSql);
         return Results.Ok(new ViewResponse(req.NewViewName, req.SelectSql));
     }
 
-    private static async Task<IResult> DropView(string name, CSharpDbService db)
+    private static async Task<IResult> DropView(string name, ICSharpDbClient db)
     {
         await db.DropViewAsync(name);
         return Results.NoContent();

--- a/src/CSharpDB.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/CSharpDB.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,6 +1,6 @@
 using System.Net;
+using CSharpDB.Client;
 using CSharpDB.Core;
-using CSharpDB.Data;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CSharpDB.Api.Middleware;
@@ -22,15 +22,25 @@ public sealed class ExceptionHandlingMiddleware
         {
             await _next(context);
         }
-        catch (CSharpDbDataException ex)
-        {
-            _logger.LogWarning(ex, "Database error: {ErrorCode}", ex.ErrorCode);
-            await WriteErrorResponse(context, MapErrorCode(ex.ErrorCode), ex.Message);
-        }
         catch (ArgumentException ex)
         {
             _logger.LogWarning(ex, "Validation error");
             await WriteErrorResponse(context, HttpStatusCode.BadRequest, ex.Message);
+        }
+        catch (CSharpDbClientConfigurationException ex)
+        {
+            _logger.LogWarning(ex, "Client configuration error");
+            await WriteErrorResponse(context, HttpStatusCode.BadRequest, ex.Message);
+        }
+        catch (CSharpDbException ex)
+        {
+            _logger.LogWarning(ex, "Database error: {ErrorCode}", ex.Code);
+            await WriteErrorResponse(context, MapErrorCode(ex.Code), ex.Message);
+        }
+        catch (CSharpDbClientException ex)
+        {
+            _logger.LogError(ex, "Client error");
+            await WriteErrorResponse(context, HttpStatusCode.InternalServerError, ex.Message);
         }
         catch (Exception ex)
         {

--- a/src/CSharpDB.Api/Program.cs
+++ b/src/CSharpDB.Api/Program.cs
@@ -1,15 +1,19 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using CSharpDB.Client;
 using CSharpDB.Api.Endpoints;
 using CSharpDB.Api.Middleware;
-using CSharpDB.Service;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // ─── Services ───────────────────────────────────────────────
 
-builder.Services.AddSingleton<CSharpDbService>();
+builder.Services.AddCSharpDbClient(sp => new CSharpDbClientOptions
+{
+    ConnectionString = sp.GetRequiredService<IConfiguration>().GetConnectionString("CSharpDB")
+        ?? "Data Source=csharpdb.db",
+});
 
 builder.Services.AddOpenApi();
 
@@ -34,8 +38,11 @@ var app = builder.Build();
 
 // ─── Initialize database ────────────────────────────────────
 
-var dbService = app.Services.GetRequiredService<CSharpDbService>();
-await dbService.InitializeAsync();
+await using (var scope = app.Services.CreateAsyncScope())
+{
+    var dbClient = scope.ServiceProvider.GetRequiredService<ICSharpDbClient>();
+    _ = await dbClient.GetInfoAsync();
+}
 
 // ─── Middleware pipeline ────────────────────────────────────
 

--- a/src/CSharpDB.Api/README.md
+++ b/src/CSharpDB.Api/README.md
@@ -1,0 +1,406 @@
+# CSharpDB.Api
+
+`CSharpDB.Api` is the HTTP host for CSharpDB.
+
+It is a thin ASP.NET Core layer over `CSharpDB.Client`. The API does not talk to
+`CSharpDB.Service` or `CSharpDB.Data`. Requests are handled through
+`ICSharpDbClient`, which currently uses the direct engine-backed client under the
+hood.
+
+## What This Project Is For
+
+Use this project when you want to:
+
+- expose a local CSharpDB database over HTTP
+- test the database through a browser-based API UI
+- integrate with tools that prefer REST over direct embedded access
+- inspect database, WAL, and index state remotely
+
+Use `CSharpDB.Client` directly when you are writing an in-process consumer and do
+not need HTTP.
+
+## Architecture
+
+The API host is intentionally thin:
+
+- ASP.NET Core provides routing, hosting, JSON serialization, and middleware
+- `CSharpDB.Client` is the authoritative database API
+- `ICSharpDbClient` is registered at startup from configuration
+- the client is warmed up during startup with `GetInfoAsync()` so configuration
+  and database initialization failures happen early
+
+Current request flow:
+
+1. HTTP request hits an endpoint under `/api`
+2. the endpoint resolves `ICSharpDbClient` from DI
+3. the client executes against the configured database
+4. the endpoint maps client models to HTTP response DTOs
+5. exceptions are translated to `application/problem+json`
+
+## Configuration
+
+The API reads the database connection string from `ConnectionStrings:CSharpDB`.
+
+Default `appsettings.json`:
+
+```json
+{
+  "ConnectionStrings": {
+    "CSharpDB": "Data Source=csharpdb.db"
+  }
+}
+```
+
+If no connection string is configured, the API falls back to:
+
+```text
+Data Source=csharpdb.db
+```
+
+That means a local `csharpdb.db` file is used by default.
+
+## Running Locally
+
+Start the API:
+
+```powershell
+dotnet run --project src/CSharpDB.Api/CSharpDB.Api.csproj
+```
+
+With the default launch profile, the local URLs are:
+
+- `https://localhost:61819`
+- `http://localhost:61818`
+
+The launch profile also sets:
+
+- `ASPNETCORE_ENVIRONMENT=Development`
+
+## Testing Through The Browser UI
+
+In Development, the project exposes:
+
+- Scalar UI at `/scalar`
+- OpenAPI JSON at `/openapi/v1.json`
+
+Open one of these after starting the API:
+
+- `http://localhost:61818/scalar`
+- `https://localhost:61819/scalar`
+
+Raw OpenAPI document:
+
+- `http://localhost:61818/openapi/v1.json`
+- `https://localhost:61819/openapi/v1.json`
+
+Notes:
+
+- `launchBrowser` is disabled, so the browser does not open automatically
+- Scalar is only mapped in Development
+- if you run the built executable directly, make sure `ASPNETCORE_ENVIRONMENT`
+  is set to `Development` if you want the UI
+
+## JSON Conventions
+
+The API uses:
+
+- camelCase JSON property names
+- camelCase enum serialization
+- null values omitted when writing responses
+
+Examples:
+
+- `before`, `after` for trigger timing
+- `insert`, `update`, `delete` for trigger event values in JSON
+
+## CORS
+
+The API currently allows all origins, methods, and headers.
+
+This is useful for local testing but is not a hardened production policy.
+
+## Authentication
+
+There is currently no authentication or authorization in this project.
+
+Anyone who can reach the API can execute database operations.
+
+## Endpoint Overview
+
+All routes are under `/api`.
+
+### Database Info
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/info` | Returns top-level database counts and data source information. |
+
+### Tables And Columns
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/tables` | List table names. |
+| `GET` | `/api/tables/{name}/schema` | Get a table schema. |
+| `GET` | `/api/tables/{name}/count` | Get row count for a table. |
+| `DELETE` | `/api/tables/{name}` | Drop a table. |
+| `PATCH` | `/api/tables/{name}/rename` | Rename a table. |
+| `POST` | `/api/tables/{name}/columns` | Add a column. |
+| `DELETE` | `/api/tables/{name}/columns/{col}` | Drop a column. |
+| `PATCH` | `/api/tables/{name}/columns/{col}/rename` | Rename a column. |
+
+### Rows
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/tables/{name}/rows?page=1&pageSize=50` | Browse rows in a table. |
+| `GET` | `/api/tables/{name}/rows/{pkValue}?pkColumn=id` | Get a row by primary key value. |
+| `POST` | `/api/tables/{name}/rows` | Insert a row. |
+| `PUT` | `/api/tables/{name}/rows/{pkValue}?pkColumn=id` | Update a row by primary key. |
+| `DELETE` | `/api/tables/{name}/rows/{pkValue}?pkColumn=id` | Delete a row by primary key. |
+
+### Indexes
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/indexes` | List indexes. |
+| `POST` | `/api/indexes` | Create an index. |
+| `PUT` | `/api/indexes/{name}` | Update an index definition. |
+| `DELETE` | `/api/indexes/{name}` | Drop an index. |
+
+### Views
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/views` | List views. |
+| `GET` | `/api/views/{name}` | Get a view definition. |
+| `GET` | `/api/views/{name}/rows?page=1&pageSize=50` | Browse rows from a view. |
+| `POST` | `/api/views` | Create a view. |
+| `PUT` | `/api/views/{name}` | Update a view. |
+| `DELETE` | `/api/views/{name}` | Drop a view. |
+
+### Triggers
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/triggers` | List triggers. |
+| `POST` | `/api/triggers` | Create a trigger. |
+| `PUT` | `/api/triggers/{name}` | Update a trigger. |
+| `DELETE` | `/api/triggers/{name}` | Drop a trigger. |
+
+Accepted trigger values:
+
+- `timing`: `before`, `after`
+- `event`: `insert`, `update`, `delete`
+
+### Procedures
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/procedures?includeDisabled=true` | List procedures. |
+| `GET` | `/api/procedures/{name}` | Get a procedure definition. |
+| `POST` | `/api/procedures` | Create a procedure. |
+| `PUT` | `/api/procedures/{name}` | Update a procedure. |
+| `DELETE` | `/api/procedures/{name}` | Delete a procedure. |
+| `POST` | `/api/procedures/{name}/execute` | Execute a procedure. |
+
+### SQL
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `POST` | `/api/sql/execute` | Execute arbitrary SQL. |
+
+This is the main way to create tables today.
+
+### Storage Inspection
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/api/inspect?includePages=false&path=...` | Inspect database storage. |
+| `GET` | `/api/inspect/wal?path=...` | Inspect the WAL. |
+| `GET` | `/api/inspect/page/{id}?hex=false&path=...` | Inspect a page. |
+| `GET` | `/api/inspect/indexes?index=...&sample=...&path=...` | Check indexes. |
+
+## Request Examples
+
+### Create A Table
+
+```http
+POST /api/sql/execute
+Content-Type: application/json
+```
+
+```json
+{
+  "sql": "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT);"
+}
+```
+
+### Insert A Row
+
+```http
+POST /api/tables/users/rows
+Content-Type: application/json
+```
+
+```json
+{
+  "values": {
+    "id": 1,
+    "name": "Max",
+    "email": "max@example.com"
+  }
+}
+```
+
+### Browse Rows
+
+```http
+GET /api/tables/users/rows?page=1&pageSize=50
+```
+
+### Create A View
+
+```http
+POST /api/views
+Content-Type: application/json
+```
+
+```json
+{
+  "viewName": "active_users",
+  "selectSql": "SELECT id, name FROM users;"
+}
+```
+
+### Create A Trigger
+
+```http
+POST /api/triggers
+Content-Type: application/json
+```
+
+```json
+{
+  "triggerName": "users_before_insert",
+  "tableName": "users",
+  "timing": "before",
+  "event": "insert",
+  "bodySql": "SELECT 1;"
+}
+```
+
+### Create A Procedure
+
+```http
+POST /api/procedures
+Content-Type: application/json
+```
+
+```json
+{
+  "name": "get_user_by_id",
+  "bodySql": "SELECT * FROM users WHERE id = @id;",
+  "parameters": [
+    {
+      "name": "id",
+      "type": "Integer",
+      "required": true
+    }
+  ],
+  "description": "Returns one user by id",
+  "isEnabled": true
+}
+```
+
+### Execute A Procedure
+
+```http
+POST /api/procedures/get_user_by_id/execute
+Content-Type: application/json
+```
+
+```json
+{
+  "args": {
+    "id": 1
+  }
+}
+```
+
+## Response Shapes
+
+Some common response shapes:
+
+- `BrowseResponse`: paged tabular data with column names
+- `MutationResponse`: rows affected
+- `SqlResultResponse`: query or non-query SQL execution result
+- `ProcedureExecutionResponse`: multi-statement procedure execution details
+- `DatabaseInfoResponse`: top-level object counts
+
+See `Dtos/Requests.cs`, `Dtos/Responses.cs`, and `Dtos/ProcedureDtos.cs` for the
+current source-of-truth contract types.
+
+## Error Handling
+
+Errors are returned as `application/problem+json`.
+
+Example:
+
+```json
+{
+  "status": 404,
+  "title": "NotFound",
+  "detail": "Table 'users' not found."
+}
+```
+
+Current status mapping:
+
+- `400 BadRequest`
+  - invalid request arguments
+  - SQL syntax errors
+  - type mismatch errors
+  - client configuration errors
+- `404 NotFound`
+  - missing tables
+  - missing columns
+  - missing triggers
+  - endpoint-specific missing resources
+- `409 Conflict`
+  - duplicate keys
+  - existing tables
+  - existing triggers
+- `422 UnprocessableEntity`
+  - constraint violations
+- `503 ServiceUnavailable`
+  - busy database
+- `500 InternalServerError`
+  - unexpected runtime failures
+
+## Development Notes
+
+- the API is currently mapped under `/api`, not `/api/v1`
+- there is no dedicated endpoint yet for creating tables outside raw SQL
+- the API uses the same authoritative client contract as other consumers
+- the API host is suitable for local development and integration testing, but it
+  is not yet production-hardened
+
+## Useful Commands
+
+Build:
+
+```powershell
+dotnet build src/CSharpDB.Api/CSharpDB.Api.csproj
+```
+
+Run:
+
+```powershell
+dotnet run --project src/CSharpDB.Api/CSharpDB.Api.csproj
+```
+
+Run API tests:
+
+```powershell
+dotnet test tests/CSharpDB.Api.Tests/CSharpDB.Api.Tests.csproj
+```

--- a/src/CSharpDB.Cli/CSharpDB.Cli.csproj
+++ b/src/CSharpDB.Cli/CSharpDB.Cli.csproj
@@ -15,7 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CSharpDB.Client\CSharpDB.Client.csproj" />
     <ProjectReference Include="..\CSharpDB.Engine\CSharpDB.Engine.csproj" />
+    <ProjectReference Include="..\CSharpDB.Sql\CSharpDB.Sql.csproj" />
     <ProjectReference Include="..\CSharpDB.Storage.Diagnostics\CSharpDB.Storage.Diagnostics.csproj" />
   </ItemGroup>
 

--- a/src/CSharpDB.Cli/CliShellOptions.cs
+++ b/src/CSharpDB.Cli/CliShellOptions.cs
@@ -1,0 +1,166 @@
+using CSharpDB.Client;
+
+namespace CSharpDB.Cli;
+
+internal sealed class CliShellOptions
+{
+    public required CSharpDbClientOptions ClientOptions { get; init; }
+    public required string DisplayTarget { get; init; }
+    public bool EnableLocalDirectFeatures { get; init; }
+
+    public static bool TryParse(string[] args, out CliShellOptions? options, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        string? endpoint = null;
+        string? positionalTarget = null;
+        CSharpDbTransport? transport = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            string arg = args[i];
+            switch (arg)
+            {
+                case "--endpoint":
+                case "--server":
+                    if (!TryReadValue(args, ref i, arg, out var endpointValue, out error))
+                    {
+                        options = null;
+                        return false;
+                    }
+
+                    endpoint = endpointValue;
+                    break;
+
+                case "--transport":
+                    if (!TryReadValue(args, ref i, arg, out var transportValue, out error))
+                    {
+                        options = null;
+                        return false;
+                    }
+
+                    if (!TryParseTransport(transportValue, out var parsedTransport))
+                    {
+                        error = $"Unknown transport '{transportValue}'.";
+                        options = null;
+                        return false;
+                    }
+
+                    transport = parsedTransport;
+                    break;
+
+                default:
+                    if (arg.StartsWith("-", StringComparison.Ordinal))
+                    {
+                        error = $"Unknown option '{arg}'.";
+                        options = null;
+                        return false;
+                    }
+
+                    if (positionalTarget is not null)
+                    {
+                        error = "Only one database path or endpoint may be provided.";
+                        options = null;
+                        return false;
+                    }
+
+                    positionalTarget = arg;
+                    break;
+            }
+        }
+
+        if (endpoint is not null && positionalTarget is not null)
+        {
+            error = "Specify either a positional database path or --endpoint/--server, not both.";
+            options = null;
+            return false;
+        }
+
+        if (transport is not null && transport != CSharpDbTransport.Direct && endpoint is null)
+        {
+            error = $"Transport '{transport}' requires --endpoint.";
+            options = null;
+            return false;
+        }
+
+        string displayTarget = endpoint ?? positionalTarget ?? "csharpdb.db";
+        options = new CliShellOptions
+        {
+            DisplayTarget = displayTarget,
+            EnableLocalDirectFeatures = IsDirectTarget(transport, displayTarget),
+            ClientOptions = new CSharpDbClientOptions
+            {
+                Transport = transport,
+                Endpoint = endpoint ?? positionalTarget,
+                DataSource = endpoint is null && positionalTarget is null ? "csharpdb.db" : null,
+            },
+        };
+
+        error = null;
+        return true;
+    }
+
+    public static string Usage =>
+        "Usage: csharpdb [database-path] [--endpoint <uri>] [--transport <direct|http|grpc|tcp|namedpipes>]";
+
+    private static bool TryReadValue(
+        string[] args,
+        ref int index,
+        string optionName,
+        out string value,
+        out string? error)
+    {
+        if (index + 1 >= args.Length)
+        {
+            value = string.Empty;
+            error = $"Missing value for {optionName}.";
+            return false;
+        }
+
+        value = args[++index];
+        error = null;
+        return true;
+    }
+
+    private static bool TryParseTransport(string value, out CSharpDbTransport transport)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "direct":
+                transport = CSharpDbTransport.Direct;
+                return true;
+            case "http":
+                transport = CSharpDbTransport.Http;
+                return true;
+            case "grpc":
+                transport = CSharpDbTransport.Grpc;
+                return true;
+            case "tcp":
+                transport = CSharpDbTransport.Tcp;
+                return true;
+            case "namedpipes":
+            case "named-pipes":
+            case "pipe":
+            case "npipe":
+                transport = CSharpDbTransport.NamedPipes;
+                return true;
+            default:
+                transport = default;
+                return false;
+        }
+    }
+
+    private static bool IsDirectTarget(CSharpDbTransport? transport, string target)
+    {
+        if (transport is not null)
+            return transport == CSharpDbTransport.Direct;
+
+        if (Path.IsPathRooted(target))
+            return true;
+
+        if (Uri.TryCreate(target, UriKind.Absolute, out var uri))
+            return string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase);
+
+        return !target.Contains("://", StringComparison.Ordinal);
+    }
+}

--- a/src/CSharpDB.Cli/MetaCommandContext.cs
+++ b/src/CSharpDB.Cli/MetaCommandContext.cs
@@ -1,3 +1,5 @@
+using CSharpDB.Client;
+using CSharpDB.Client.Models;
 using CSharpDB.Core;
 using CSharpDB.Engine;
 using CSharpDB.Execution;
@@ -8,31 +10,47 @@ internal sealed class MetaCommandContext : IDisposable
 {
     private readonly Func<string, CancellationToken, ValueTask<bool>> _executeSql;
     private Database.ReaderSession? _snapshot;
+    private string? _transactionId;
 
     public MetaCommandContext(
-        Database database,
+        ICSharpDbClient client,
+        Database? localDatabase,
         string databasePath,
         Func<string, CancellationToken, ValueTask<bool>> executeSql)
     {
-        Database = database;
+        Client = client;
+        LocalDatabase = localDatabase;
         DatabasePath = databasePath;
         _executeSql = executeSql;
     }
 
-    public Database Database { get; }
+    public ICSharpDbClient Client { get; }
+    public Database? LocalDatabase { get; }
     public string DatabasePath { get; }
     public bool ShowTiming { get; set; } = true;
-    public bool InExplicitTransaction { get; private set; }
+    public bool InExplicitTransaction => _transactionId is not null;
     public bool SnapshotEnabled => _snapshot is not null;
+    public bool SupportsLocalDirectFeatures => LocalDatabase is not null;
 
     public bool PreferSyncPointLookups
     {
-        get => Database.PreferSyncPointLookups;
-        set => Database.PreferSyncPointLookups = value;
+        get => LocalDatabase?.PreferSyncPointLookups ?? false;
+        set
+        {
+            if (LocalDatabase is null)
+                throw new InvalidOperationException("Sync point mode requires direct local access.");
+
+            LocalDatabase.PreferSyncPointLookups = value;
+        }
     }
 
     public async ValueTask<bool> ExecuteSqlAsync(string sql, CancellationToken ct = default)
         => await _executeSql(sql, ct);
+
+    public async ValueTask<SqlExecutionResult> ExecuteDbSqlAsync(string sql, CancellationToken ct = default)
+        => _transactionId is null
+            ? await Client.ExecuteSqlAsync(sql, ct)
+            : await Client.ExecuteInTransactionAsync(_transactionId, sql, ct);
 
     public async ValueTask<QueryResult> ExecuteReadSnapshotAsync(string sql, CancellationToken ct = default)
     {
@@ -43,33 +61,57 @@ internal sealed class MetaCommandContext : IDisposable
 
     public async ValueTask BeginTransactionAsync(CancellationToken ct = default)
     {
-        await Database.BeginTransactionAsync(ct);
-        InExplicitTransaction = true;
+        if (_transactionId is not null)
+            throw new InvalidOperationException("An explicit transaction is already active.");
+
+        var tx = await Client.BeginTransactionAsync(ct);
+        _transactionId = tx.TransactionId;
     }
 
     public async ValueTask CommitAsync(CancellationToken ct = default)
     {
-        await Database.CommitAsync(ct);
-        InExplicitTransaction = false;
+        if (_transactionId is null)
+            throw new InvalidOperationException("No explicit transaction is active.");
+
+        try
+        {
+            await Client.CommitTransactionAsync(_transactionId, ct);
+        }
+        finally
+        {
+            _transactionId = null;
+        }
     }
 
     public async ValueTask RollbackAsync(CancellationToken ct = default)
     {
-        await Database.RollbackAsync(ct);
-        InExplicitTransaction = false;
+        if (_transactionId is null)
+            throw new InvalidOperationException("No explicit transaction is active.");
+
+        try
+        {
+            await Client.RollbackTransactionAsync(_transactionId, ct);
+        }
+        finally
+        {
+            _transactionId = null;
+        }
     }
 
     public async ValueTask CheckpointAsync(CancellationToken ct = default)
     {
-        await Database.CheckpointAsync(ct);
+        await Client.CheckpointAsync(ct);
     }
 
     public void EnableSnapshot()
     {
+        if (LocalDatabase is null)
+            throw new InvalidOperationException("Snapshot mode requires direct local access.");
+
         if (_snapshot is not null)
             throw new CSharpDbException(ErrorCode.Unknown, "Snapshot mode is already enabled.");
 
-        _snapshot = Database.CreateReaderSession();
+        _snapshot = LocalDatabase.CreateReaderSession();
     }
 
     public void DisableSnapshot()

--- a/src/CSharpDB.Cli/MetaCommands.cs
+++ b/src/CSharpDB.Cli/MetaCommands.cs
@@ -1,4 +1,10 @@
+using CSharpDB.Client.Models;
 using CSharpDB.Core;
+using CSharpDB.Sql;
+using ClientColumnDefinition = CSharpDB.Client.Models.ColumnDefinition;
+using ClientIndexSchema = CSharpDB.Client.Models.IndexSchema;
+using ClientTableSchema = CSharpDB.Client.Models.TableSchema;
+using ClientTriggerSchema = CSharpDB.Client.Models.TriggerSchema;
 
 namespace CSharpDB.Cli;
 
@@ -40,24 +46,25 @@ internal sealed class InfoCommand : IMetaCommand
     public string Name => ".info";
     public string Description => "Show database and runtime status";
 
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
-        var userTables = MetaCommandHelpers.GetUserTableNames(context.Database).ToArray();
-        var indexes = context.Database.GetIndexes();
-        var views = context.Database.GetViewNames();
-        var triggers = context.Database.GetTriggers();
-        var collections = context.Database.GetCollectionNames();
+        var info = await context.Client.GetInfoAsync(ct);
+        string snapshotStatus = context.SupportsLocalDirectFeatures
+            ? (context.SnapshotEnabled ? "on" : "off")
+            : "unavailable";
+        string syncPointStatus = context.SupportsLocalDirectFeatures
+            ? (context.PreferSyncPointLookups ? "on" : "off")
+            : "unavailable";
 
         output.WriteLine($"{Ansi.Bold}Database:{Ansi.Reset} {Ansi.Cyan}{context.DatabasePath}{Ansi.Reset}");
         output.WriteLine($"{Ansi.Bold}Objects:{Ansi.Reset} " +
-                         $"tables={userTables.Length}, indexes={indexes.Count}, views={views.Count}, " +
-                         $"triggers={triggers.Count}, collections={collections.Count}");
+                         $"tables={info.TableCount}, indexes={info.IndexCount}, views={info.ViewCount}, " +
+                         $"triggers={info.TriggerCount}, collections={info.CollectionCount}");
         output.WriteLine($"{Ansi.Bold}Modes:{Ansi.Reset} " +
                          $"timing={(context.ShowTiming ? "on" : "off")}, " +
-                         $"snapshot={(context.SnapshotEnabled ? "on" : "off")}, " +
-                         $"syncpoint={(context.PreferSyncPointLookups ? "on" : "off")}, " +
+                         $"snapshot={snapshotStatus}, " +
+                         $"syncpoint={syncPointStatus}, " +
                          $"tx={(context.InExplicitTransaction ? "active" : "none")}");
-        return ValueTask.CompletedTask;
     }
 }
 
@@ -67,71 +74,17 @@ internal sealed class TablesCommand : IMetaCommand
     public string Name => ".tables [PATTERN|--all]";
     public string Description => "List tables (collection backing tables hidden by default)";
 
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
         bool includeInternal = argument.Equals("--all", StringComparison.OrdinalIgnoreCase);
         string? pattern = includeInternal || string.IsNullOrWhiteSpace(argument) ? null : argument.Trim();
 
         IEnumerable<string> names = includeInternal
-            ? context.Database.GetTableNames()
-            : MetaCommandHelpers.GetUserTableNames(context.Database);
+            ? await MetaCommandHelpers.GetTableNamesAsync(context, includeInternal, ct)
+            : await MetaCommandHelpers.GetUserTableNamesAsync(context, ct);
 
         if (!string.IsNullOrWhiteSpace(pattern))
             names = names.Where(n => n.Contains(pattern, StringComparison.OrdinalIgnoreCase));
-
-        var ordered = names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToArray();
-        if (ordered.Length == 0)
-        {
-            output.WriteLine(Ansi.Colorize("No tables.", Ansi.Dim));
-            return ValueTask.CompletedTask;
-        }
-
-        foreach (var name in ordered)
-            output.WriteLine($"  {Ansi.Cyan}{name}{Ansi.Reset}");
-
-        return ValueTask.CompletedTask;
-    }
-}
-
-internal sealed class SchemaCommand : IMetaCommand
-{
-    public IReadOnlyList<string> Aliases => [".schema"];
-    public string Name => ".schema [TABLE|--all]";
-    public string Description => "Show CREATE TABLE schema";
-
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
-    {
-        if (string.IsNullOrWhiteSpace(argument))
-        {
-            PrintAllSchemas(context.Database, output, includeInternal: false);
-            return ValueTask.CompletedTask;
-        }
-
-        if (argument.Equals("--all", StringComparison.OrdinalIgnoreCase))
-        {
-            PrintAllSchemas(context.Database, output, includeInternal: true);
-            return ValueTask.CompletedTask;
-        }
-
-        var schema = context.Database.GetTableSchema(argument);
-        if (schema is null && !argument.StartsWith(MetaCommandHelpers.CollectionPrefix, StringComparison.Ordinal))
-            schema = context.Database.GetTableSchema(MetaCommandHelpers.CollectionPrefix + argument);
-
-        if (schema is null)
-        {
-            output.WriteLine(Ansi.Colorize($"Table '{argument}' not found.", Ansi.Red));
-            return ValueTask.CompletedTask;
-        }
-
-        PrintSingleTableSchema(schema, output);
-        return ValueTask.CompletedTask;
-    }
-
-    private static void PrintAllSchemas(Engine.Database db, TextWriter output, bool includeInternal)
-    {
-        IEnumerable<string> names = includeInternal
-            ? db.GetTableNames()
-            : MetaCommandHelpers.GetUserTableNames(db);
 
         var ordered = names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToArray();
         if (ordered.Length == 0)
@@ -141,15 +94,69 @@ internal sealed class SchemaCommand : IMetaCommand
         }
 
         foreach (var name in ordered)
+            output.WriteLine($"  {Ansi.Cyan}{name}{Ansi.Reset}");
+    }
+}
+
+internal sealed class SchemaCommand : IMetaCommand
+{
+    public IReadOnlyList<string> Aliases => [".schema"];
+    public string Name => ".schema [TABLE|--all]";
+    public string Description => "Show CREATE TABLE schema";
+
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(argument))
         {
-            var schema = db.GetTableSchema(name);
-            if (schema is null) continue;
+            await PrintAllSchemasAsync(context, output, includeInternal: false, ct);
+            return;
+        }
+
+        if (argument.Equals("--all", StringComparison.OrdinalIgnoreCase))
+        {
+            await PrintAllSchemasAsync(context, output, includeInternal: true, ct);
+            return;
+        }
+
+        var schema = await MetaCommandHelpers.GetTableSchemaAsync(context, argument, ct);
+        if (schema is null && !argument.StartsWith(MetaCommandHelpers.CollectionPrefix, StringComparison.Ordinal))
+            schema = await MetaCommandHelpers.GetTableSchemaAsync(context, MetaCommandHelpers.CollectionPrefix + argument, ct);
+
+        if (schema is null)
+        {
+            output.WriteLine(Ansi.Colorize($"Table '{argument}' not found.", Ansi.Red));
+            return;
+        }
+
+        PrintSingleTableSchema(schema, output);
+    }
+
+    private static async ValueTask PrintAllSchemasAsync(
+        MetaCommandContext context,
+        TextWriter output,
+        bool includeInternal,
+        CancellationToken ct)
+    {
+        var names = await MetaCommandHelpers.GetTableNamesAsync(context, includeInternal, ct);
+        var ordered = names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToArray();
+        if (ordered.Length == 0)
+        {
+            output.WriteLine(Ansi.Colorize("No tables.", Ansi.Dim));
+            return;
+        }
+
+        foreach (var name in ordered)
+        {
+            var schema = await MetaCommandHelpers.GetTableSchemaAsync(context, name, ct);
+            if (schema is null)
+                continue;
+
             PrintSingleTableSchema(schema, output);
             output.WriteLine();
         }
     }
 
-    private static void PrintSingleTableSchema(TableSchema schema, TextWriter output)
+    private static void PrintSingleTableSchema(ClientTableSchema schema, TextWriter output)
     {
         output.WriteLine($"{Ansi.Bold}CREATE TABLE{Ansi.Reset} {Ansi.Cyan}{schema.TableName}{Ansi.Reset} (");
 
@@ -176,9 +183,9 @@ internal sealed class IndexesCommand : IMetaCommand
     public string Name => ".indexes [TABLE]";
     public string Description => "List indexes";
 
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
-        var indexes = context.Database.GetIndexes().AsEnumerable();
+        IEnumerable<ClientIndexSchema> indexes = await context.Client.GetIndexesAsync(ct);
         if (!string.IsNullOrWhiteSpace(argument))
             indexes = indexes.Where(i => i.TableName.Equals(argument.Trim(), StringComparison.OrdinalIgnoreCase));
 
@@ -186,7 +193,7 @@ internal sealed class IndexesCommand : IMetaCommand
         if (ordered.Length == 0)
         {
             output.WriteLine(Ansi.Colorize("No indexes.", Ansi.Dim));
-            return ValueTask.CompletedTask;
+            return;
         }
 
         foreach (var idx in ordered)
@@ -195,8 +202,6 @@ internal sealed class IndexesCommand : IMetaCommand
             string cols = string.Join(", ", idx.Columns);
             output.WriteLine($"  {Ansi.Cyan}{idx.IndexName}{Ansi.Reset} ON {idx.TableName} ({cols}){unique}");
         }
-
-        return ValueTask.CompletedTask;
     }
 }
 
@@ -206,22 +211,20 @@ internal sealed class ViewsCommand : IMetaCommand
     public string Name => ".views";
     public string Description => "List views";
 
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
-        var views = context.Database.GetViewNames()
+        var views = (await context.Client.GetViewNamesAsync(ct))
             .OrderBy(v => v, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
         if (views.Length == 0)
         {
             output.WriteLine(Ansi.Colorize("No views.", Ansi.Dim));
-            return ValueTask.CompletedTask;
+            return;
         }
 
         foreach (var view in views)
             output.WriteLine($"  {Ansi.Cyan}{view}{Ansi.Reset}");
-
-        return ValueTask.CompletedTask;
     }
 }
 
@@ -231,25 +234,24 @@ internal sealed class ViewCommand : IMetaCommand
     public string Name => ".view <NAME>";
     public string Description => "Show CREATE VIEW SQL";
 
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(argument))
         {
             output.WriteLine(Ansi.Colorize("Usage: .view <NAME>", Ansi.Yellow));
-            return ValueTask.CompletedTask;
+            return;
         }
 
         string name = argument.Trim();
-        string? sql = context.Database.GetViewSql(name);
+        string? sql = await context.Client.GetViewSqlAsync(name, ct);
         if (sql is null)
         {
             output.WriteLine(Ansi.Colorize($"View '{name}' not found.", Ansi.Red));
-            return ValueTask.CompletedTask;
+            return;
         }
 
         output.WriteLine($"{Ansi.Bold}CREATE VIEW{Ansi.Reset} {Ansi.Cyan}{name}{Ansi.Reset} AS");
         output.WriteLine(sql.Trim().TrimEnd(';') + ";");
-        return ValueTask.CompletedTask;
     }
 }
 
@@ -259,9 +261,9 @@ internal sealed class TriggersCommand : IMetaCommand
     public string Name => ".triggers [TABLE]";
     public string Description => "List triggers";
 
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
-        var triggers = context.Database.GetTriggers().AsEnumerable();
+        IEnumerable<ClientTriggerSchema> triggers = await context.Client.GetTriggersAsync(ct);
         if (!string.IsNullOrWhiteSpace(argument))
             triggers = triggers.Where(t => t.TableName.Equals(argument.Trim(), StringComparison.OrdinalIgnoreCase));
 
@@ -269,7 +271,7 @@ internal sealed class TriggersCommand : IMetaCommand
         if (ordered.Length == 0)
         {
             output.WriteLine(Ansi.Colorize("No triggers.", Ansi.Dim));
-            return ValueTask.CompletedTask;
+            return;
         }
 
         foreach (var trig in ordered)
@@ -278,8 +280,6 @@ internal sealed class TriggersCommand : IMetaCommand
                 $"  {Ansi.Cyan}{trig.TriggerName}{Ansi.Reset} " +
                 $"{trig.Timing.ToString().ToUpperInvariant()} {trig.Event.ToString().ToUpperInvariant()} ON {trig.TableName}");
         }
-
-        return ValueTask.CompletedTask;
     }
 }
 
@@ -289,22 +289,22 @@ internal sealed class TriggerCommand : IMetaCommand
     public string Name => ".trigger <NAME>";
     public string Description => "Show CREATE TRIGGER SQL";
 
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(argument))
         {
             output.WriteLine(Ansi.Colorize("Usage: .trigger <NAME>", Ansi.Yellow));
-            return ValueTask.CompletedTask;
+            return;
         }
 
         string name = argument.Trim();
-        var trigger = context.Database.GetTriggers()
+        var trigger = (await context.Client.GetTriggersAsync(ct))
             .FirstOrDefault(t => t.TriggerName.Equals(name, StringComparison.OrdinalIgnoreCase));
 
         if (trigger is null)
         {
             output.WriteLine(Ansi.Colorize($"Trigger '{name}' not found.", Ansi.Red));
-            return ValueTask.CompletedTask;
+            return;
         }
 
         output.WriteLine(
@@ -313,7 +313,6 @@ internal sealed class TriggerCommand : IMetaCommand
         output.WriteLine("BEGIN");
         output.WriteLine($"  {trigger.BodySql.Trim().TrimEnd(';')};");
         output.WriteLine("END;");
-        return ValueTask.CompletedTask;
     }
 }
 
@@ -323,22 +322,20 @@ internal sealed class CollectionsCommand : IMetaCommand
     public string Name => ".collections";
     public string Description => "List document collections";
 
-    public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
+    public async ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
-        var names = context.Database.GetCollectionNames()
+        var names = (await context.Client.GetCollectionNamesAsync(ct))
             .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
         if (names.Length == 0)
         {
             output.WriteLine(Ansi.Colorize("No collections.", Ansi.Dim));
-            return ValueTask.CompletedTask;
+            return;
         }
 
         foreach (var name in names)
             output.WriteLine($"  {Ansi.Cyan}{name}{Ansi.Reset}");
-
-        return ValueTask.CompletedTask;
     }
 }
 
@@ -402,6 +399,12 @@ internal sealed class SnapshotCommand : IMetaCommand
 
     public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
+        if (!context.SupportsLocalDirectFeatures)
+        {
+            output.WriteLine(Ansi.Colorize("Snapshot mode requires direct local access.", Ansi.Yellow));
+            return ValueTask.CompletedTask;
+        }
+
         string arg = argument.Trim().ToLowerInvariant();
         if (arg.Length == 0 || arg == "status")
         {
@@ -449,6 +452,12 @@ internal sealed class SyncPointCommand : IMetaCommand
 
     public ValueTask ExecuteAsync(MetaCommandContext context, string argument, TextWriter output, CancellationToken ct = default)
     {
+        if (!context.SupportsLocalDirectFeatures)
+        {
+            output.WriteLine(Ansi.Colorize("Sync point mode requires direct local access.", Ansi.Yellow));
+            return ValueTask.CompletedTask;
+        }
+
         string arg = argument.Trim().ToLowerInvariant();
         if (arg.Length == 0 || arg == "status")
         {
@@ -537,7 +546,12 @@ internal sealed class ReadCommand : IMetaCommand
 
         try
         {
-            statements = SqlScriptParser.SplitAllStatements(sqlText);
+            if (sqlText.AsSpan().TrimEnd().Length > 0 && sqlText.AsSpan().TrimEnd()[^1] != ';')
+                throw new CSharpDbException(
+                    ErrorCode.SyntaxError,
+                    "SQL script ended with an incomplete statement (missing semicolon).");
+
+            statements = SqlScriptSplitter.SplitExecutableStatements(sqlText);
         }
         catch (CSharpDbException ex)
         {
@@ -583,9 +597,68 @@ internal static class MetaCommandHelpers
 {
     internal const string CollectionPrefix = "_col_";
 
-    internal static IEnumerable<string> GetUserTableNames(Engine.Database db)
+    internal static async Task<IReadOnlyList<string>> GetTableNamesAsync(
+        MetaCommandContext context,
+        bool includeInternal,
+        CancellationToken ct)
     {
-        return db.GetTableNames()
-            .Where(n => !n.StartsWith(CollectionPrefix, StringComparison.Ordinal));
+        if (includeInternal && context.LocalDatabase is not null)
+        {
+            return context.LocalDatabase.GetTableNames()
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        return await context.Client.GetTableNamesAsync(ct);
     }
+
+    internal static async Task<IReadOnlyList<string>> GetUserTableNamesAsync(
+        MetaCommandContext context,
+        CancellationToken ct)
+    {
+        return await context.Client.GetTableNamesAsync(ct);
+    }
+
+    internal static async Task<ClientTableSchema?> GetTableSchemaAsync(
+        MetaCommandContext context,
+        string tableName,
+        CancellationToken ct)
+    {
+        var schema = await context.Client.GetTableSchemaAsync(tableName, ct);
+        if (schema is not null)
+            return schema;
+
+        if (context.LocalDatabase is null)
+            return null;
+
+        var localSchema = context.LocalDatabase.GetTableSchema(tableName);
+        return localSchema is null ? null : MapTableSchema(localSchema);
+    }
+
+    private static ClientTableSchema MapTableSchema(CSharpDB.Core.TableSchema schema)
+    {
+        return new ClientTableSchema
+        {
+            TableName = schema.TableName,
+            Columns = schema.Columns
+                .Select(column => new ClientColumnDefinition
+                {
+                    Name = column.Name,
+                    Type = MapDbType(column.Type),
+                    Nullable = column.Nullable,
+                    IsPrimaryKey = column.IsPrimaryKey,
+                    IsIdentity = column.IsIdentity,
+                })
+                .ToArray(),
+        };
+    }
+
+    private static CSharpDB.Client.Models.DbType MapDbType(CSharpDB.Core.DbType type) => type switch
+    {
+        CSharpDB.Core.DbType.Integer => CSharpDB.Client.Models.DbType.Integer,
+        CSharpDB.Core.DbType.Real => CSharpDB.Client.Models.DbType.Real,
+        CSharpDB.Core.DbType.Text => CSharpDB.Client.Models.DbType.Text,
+        CSharpDB.Core.DbType.Blob => CSharpDB.Client.Models.DbType.Blob,
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
+    };
 }

--- a/src/CSharpDB.Cli/Program.cs
+++ b/src/CSharpDB.Cli/Program.cs
@@ -1,4 +1,6 @@
 using CSharpDB.Cli;
+using CSharpDB.Client;
+using CSharpDB.Client.Internal;
 using CSharpDB.Engine;
 
 Ansi.EnableVirtualTerminal();
@@ -6,17 +8,28 @@ Ansi.EnableVirtualTerminal();
 if (args.Length > 0 && InspectorCommandRunner.IsKnownCommand(args[0]))
     return await InspectorCommandRunner.RunAsync(args, Console.Out, Console.Error);
 
-string dbPath = args.Length > 0 ? args[0] : "csharpdb.db";
+if (!CliShellOptions.TryParse(args, out var shellOptions, out var parseError))
+{
+    Console.Error.WriteLine(Ansi.Colorize($"Error: {parseError}", Ansi.Red));
+    Console.Error.WriteLine(Ansi.Colorize(CliShellOptions.Usage, Ansi.Yellow));
+    return 1;
+}
+
+string displayTarget = shellOptions!.DisplayTarget;
 
 Console.WriteLine($"{Ansi.Bold}{Ansi.Cyan}CSharpDB{Ansi.Reset} - Interactive SQL Shell");
-Console.WriteLine($"{Ansi.Dim}Database: {dbPath}{Ansi.Reset}");
+Console.WriteLine($"{Ansi.Dim}Database: {displayTarget}{Ansi.Reset}");
 Console.WriteLine($"{Ansi.Dim}Type .help for commands, .quit to exit.{Ansi.Reset}");
 Console.WriteLine();
 
-Database db;
+ICSharpDbClient client;
+Database? localDatabase = null;
 try
 {
-    db = await Database.OpenAsync(dbPath);
+    client = CSharpDbClient.Create(shellOptions.ClientOptions);
+
+    if (shellOptions.EnableLocalDirectFeatures && client is IEngineBackedClient engineBacked)
+        localDatabase = await engineBacked.TryGetDatabaseAsync();
 }
 catch (Exception ex)
 {
@@ -24,7 +37,7 @@ catch (Exception ex)
     return 1;
 }
 
-await using (db)
+await using (client)
 {
     // Build the command registry.
     var commands = new List<IMetaCommand>();
@@ -48,7 +61,7 @@ await using (db)
     commands.Add(new TimingCommand());
     commands.Add(new ReadCommand());
 
-    using var repl = new Repl(db, dbPath, Console.Out, commands);
+    using var repl = new Repl(client, localDatabase, displayTarget, Console.Out, commands);
     await repl.RunAsync();
 }
 

--- a/src/CSharpDB.Cli/Repl.cs
+++ b/src/CSharpDB.Cli/Repl.cs
@@ -1,3 +1,4 @@
+using CSharpDB.Client;
 using System.Diagnostics;
 using System.Text;
 using CSharpDB.Core;
@@ -12,18 +13,16 @@ namespace CSharpDB.Cli;
 /// </summary>
 internal sealed class Repl : IDisposable
 {
-    private readonly Database _db;
     private readonly TextWriter _out;
     private readonly TableFormatter _tableFormatter;
     private readonly Dictionary<string, IMetaCommand> _commands;
     private readonly MetaCommandContext _context;
 
-    public Repl(Database db, string databasePath, TextWriter output, IReadOnlyList<IMetaCommand> commands)
+    public Repl(ICSharpDbClient client, Database? localDatabase, string databasePath, TextWriter output, IReadOnlyList<IMetaCommand> commands)
     {
-        _db = db;
         _out = output;
         _tableFormatter = new TableFormatter(output);
-        _context = new MetaCommandContext(db, databasePath, ExecuteSqlAsync);
+        _context = new MetaCommandContext(client, localDatabase, databasePath, ExecuteSqlAsync);
 
         _commands = new Dictionary<string, IMetaCommand>(StringComparer.OrdinalIgnoreCase);
         foreach (var cmd in commands)
@@ -67,7 +66,7 @@ internal sealed class Repl : IDisposable
             hasPendingSql = true;
 
             string bufferedSql = sqlBuffer.ToString();
-            bool splitOk = SqlScriptParser.TrySplitCompleteStatements(
+            bool splitOk = SqlScriptSplitter.TrySplitCompleteStatements(
                 bufferedSql,
                 out var statements,
                 out var remainder,
@@ -105,12 +104,10 @@ internal sealed class Repl : IDisposable
     {
         Stopwatch? sw = _context.ShowTiming ? Stopwatch.StartNew() : null;
 
-        Statement statement;
+        SqlStatementClassification classification;
         try
         {
-            statement = Parser.TryParseSimpleSelect(sql, out var fastStmt)
-                ? fastStmt
-                : Parser.Parse(sql);
+            classification = SqlStatementClassifier.Classify(sql);
         }
         catch (CSharpDbException ex)
         {
@@ -121,7 +118,7 @@ internal sealed class Repl : IDisposable
 
         try
         {
-            if (_context.SnapshotEnabled && statement is not SelectStatement)
+            if (_context.SnapshotEnabled && !classification.IsReadOnly)
             {
                 _out.WriteLine(Ansi.Colorize(
                     "Snapshot mode is read-only. Run '.snapshot off' to execute writes.",
@@ -130,32 +127,69 @@ internal sealed class Repl : IDisposable
                 return false;
             }
 
-            await using var result = _context.SnapshotEnabled
-                ? await _context.ExecuteReadSnapshotAsync(sql, ct)
-                : await _db.ExecuteAsync(statement, ct);
-
-            sw?.Stop();
-            string timingSuffix = _context.ShowTiming && sw is not null
-                ? $" ({sw.ElapsedMilliseconds}ms)"
-                : string.Empty;
-
-            if (result.IsQuery)
+            if (_context.SnapshotEnabled)
             {
-                var rows = await result.ToListAsync(ct);
-                if (result.Schema.Length > 0)
-                    _tableFormatter.PrintTable(result.Schema, rows);
+                await using var snapshotResult = await _context.ExecuteReadSnapshotAsync(sql, ct);
 
-                int count = rows.Count;
-                _out.WriteLine(Ansi.Colorize(
-                    $"{count} {(count == 1 ? "row" : "rows")}{timingSuffix}",
-                    Ansi.Dim));
+                sw?.Stop();
+                string timingSuffix = _context.ShowTiming && sw is not null
+                    ? $" ({sw.ElapsedMilliseconds}ms)"
+                    : string.Empty;
+
+                if (snapshotResult.IsQuery)
+                {
+                    var rows = await snapshotResult.ToListAsync(ct);
+                    if (snapshotResult.Schema.Length > 0)
+                        _tableFormatter.PrintTable(snapshotResult.Schema, rows);
+
+                    int count = rows.Count;
+                    _out.WriteLine(Ansi.Colorize(
+                        $"{count} {(count == 1 ? "row" : "rows")}{timingSuffix}",
+                        Ansi.Dim));
+                }
+                else
+                {
+                    int n = snapshotResult.RowsAffected;
+                    _out.WriteLine(Ansi.Colorize(
+                        $"{n} {(n == 1 ? "row" : "rows")} affected{timingSuffix}",
+                        Ansi.Dim));
+                }
             }
             else
             {
-                int n = result.RowsAffected;
-                _out.WriteLine(Ansi.Colorize(
-                    $"{n} {(n == 1 ? "row" : "rows")} affected{timingSuffix}",
-                    Ansi.Dim));
+                var result = await _context.ExecuteDbSqlAsync(sql, ct);
+
+                sw?.Stop();
+                string timingSuffix = _context.ShowTiming && sw is not null
+                    ? $" ({sw.ElapsedMilliseconds}ms)"
+                    : string.Empty;
+
+                if (!string.IsNullOrWhiteSpace(result.Error))
+                {
+                    _out.WriteLine(Ansi.Colorize($"Error: {result.Error}", Ansi.Red));
+                    _out.WriteLine();
+                    return false;
+                }
+
+                if (result.IsQuery)
+                {
+                    var rows = result.Rows ?? [];
+                    var columns = result.ColumnNames ?? [];
+                    if (columns.Length > 0)
+                        _tableFormatter.PrintTable(columns, rows);
+
+                    int count = rows.Count;
+                    _out.WriteLine(Ansi.Colorize(
+                        $"{count} {(count == 1 ? "row" : "rows")}{timingSuffix}",
+                        Ansi.Dim));
+                }
+                else
+                {
+                    int n = result.RowsAffected;
+                    _out.WriteLine(Ansi.Colorize(
+                        $"{n} {(n == 1 ? "row" : "rows")} affected{timingSuffix}",
+                        Ansi.Dim));
+                }
             }
 
             _out.WriteLine();

--- a/src/CSharpDB.Cli/TableFormatter.cs
+++ b/src/CSharpDB.Cli/TableFormatter.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.Json;
 using CSharpDB.Core;
 
 namespace CSharpDB.Cli;
@@ -81,6 +83,67 @@ internal sealed class TableFormatter
         PrintBorderLine(widths, border, '└', '┴', '┘');
     }
 
+    public void PrintTable(string[] columnNames, List<object?[]> rows)
+    {
+        int colCount = columnNames.Length;
+        if (colCount == 0) return;
+
+        var widths = new int[colCount];
+        for (int c = 0; c < colCount; c++)
+            widths[c] = columnNames[c].Length;
+
+        foreach (var row in rows)
+        {
+            for (int c = 0; c < colCount && c < row.Length; c++)
+            {
+                int len = FormatObjectValue(row[c]).Length;
+                if (len > widths[c]) widths[c] = len;
+            }
+        }
+
+        const int maxWidth = 40;
+        for (int c = 0; c < colCount; c++)
+            widths[c] = Math.Min(widths[c], maxWidth);
+
+        string border = Ansi.Dim + Ansi.BrightBlack;
+
+        PrintBorderLine(widths, border, '┌', '┬', '┐');
+
+        _out.Write(border + "│" + Ansi.Reset);
+        for (int c = 0; c < colCount; c++)
+        {
+            string header = columnNames[c].PadRight(widths[c]);
+            _out.Write(" " + Ansi.Bold + Ansi.White + header + Ansi.Reset + " ");
+            _out.Write(border + "│" + Ansi.Reset);
+        }
+        _out.WriteLine();
+
+        PrintBorderLine(widths, border, '├', '┼', '┤');
+
+        foreach (var row in rows)
+        {
+            _out.Write(border + "│" + Ansi.Reset);
+            for (int c = 0; c < colCount; c++)
+            {
+                object? value = c < row.Length ? row[c] : null;
+                string text = FormatObjectValue(value);
+                if (text.Length > widths[c])
+                    text = text[..(widths[c] - 1)] + "…";
+
+                string padded = IsNumericValue(value)
+                    ? text.PadLeft(widths[c])
+                    : text.PadRight(widths[c]);
+
+                string color = GetValueColor(value);
+                _out.Write(" " + color + padded + Ansi.Reset + " ");
+                _out.Write(border + "│" + Ansi.Reset);
+            }
+            _out.WriteLine();
+        }
+
+        PrintBorderLine(widths, border, '└', '┴', '┘');
+    }
+
     private void PrintBorderLine(int[] widths, string border, char left, char mid, char right)
     {
         _out.Write(border);
@@ -95,6 +158,16 @@ internal sealed class TableFormatter
     }
 
     private static string FormatValue(DbValue value) => value.ToString();
+    private static string FormatObjectValue(object? value) => value switch
+    {
+        null => "NULL",
+        byte[] bytes => $"BLOB({bytes.Length} bytes)",
+        JsonElement element => element.ValueKind == JsonValueKind.String
+            ? element.GetString() ?? string.Empty
+            : element.GetRawText(),
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty,
+        _ => value.ToString() ?? string.Empty,
+    };
 
     private static string GetValueColor(DbValue value) => value.Type switch
     {
@@ -103,5 +176,28 @@ internal sealed class TableFormatter
         DbType.Text => Ansi.Green,
         DbType.Blob => Ansi.Magenta,
         _ => "",
+    };
+
+    private static string GetValueColor(object? value) => value switch
+    {
+        null => Ansi.Dim + Ansi.Italic,
+        byte[] => Ansi.Magenta,
+        sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal => Ansi.Yellow,
+        string => Ansi.Green,
+        JsonElement element => element.ValueKind switch
+        {
+            JsonValueKind.Null or JsonValueKind.Undefined => Ansi.Dim + Ansi.Italic,
+            JsonValueKind.Number => Ansi.Yellow,
+            JsonValueKind.String => Ansi.Green,
+            _ => "",
+        },
+        _ => "",
+    };
+
+    private static bool IsNumericValue(object? value) => value switch
+    {
+        sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal => true,
+        JsonElement element when element.ValueKind == JsonValueKind.Number => true,
+        _ => false,
     };
 }

--- a/src/CSharpDB.Client/CSharpDB.Client.csproj
+++ b/src/CSharpDB.Client/CSharpDB.Client.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>CSharpDB.Client</RootNamespace>
+    <Description>Unified CSharpDB client SDK with pluggable transports (Direct, HTTP, gRPC, TCP, Named Pipes).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpDB.Engine\CSharpDB.Engine.csproj" />
+    <ProjectReference Include="..\CSharpDB.Sql\CSharpDB.Sql.csproj" />
+    <ProjectReference Include="..\CSharpDB.Storage.Diagnostics\CSharpDB.Storage.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.*" />
+  </ItemGroup>
+
+</Project>

--- a/src/CSharpDB.Client/CSharpDbClient.cs
+++ b/src/CSharpDB.Client/CSharpDbClient.cs
@@ -1,0 +1,85 @@
+using CSharpDB.Client.Internal;
+using CSharpDB.Client.Models;
+using CSharpDB.Engine;
+using CSharpDB.Storage.Diagnostics;
+
+namespace CSharpDB.Client;
+
+public sealed class CSharpDbClient : ICSharpDbClient, IEngineBackedClient
+{
+    private readonly ICSharpDbClient _inner;
+
+    private CSharpDbClient(ICSharpDbClient inner)
+    {
+        _inner = inner;
+    }
+
+    public static ICSharpDbClient Create(CSharpDbClientOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return new CSharpDbClient(ClientTransportResolver.Create(options));
+    }
+
+    public string DataSource => _inner.DataSource;
+    public Task<DatabaseInfo> GetInfoAsync(CancellationToken ct = default) => _inner.GetInfoAsync(ct);
+    public Task<IReadOnlyList<string>> GetTableNamesAsync(CancellationToken ct = default) => _inner.GetTableNamesAsync(ct);
+    public Task<TableSchema?> GetTableSchemaAsync(string tableName, CancellationToken ct = default) => _inner.GetTableSchemaAsync(tableName, ct);
+    public Task<int> GetRowCountAsync(string tableName, CancellationToken ct = default) => _inner.GetRowCountAsync(tableName, ct);
+    public Task<TableBrowseResult> BrowseTableAsync(string tableName, int page = 1, int pageSize = 50, CancellationToken ct = default) => _inner.BrowseTableAsync(tableName, page, pageSize, ct);
+    public Task<Dictionary<string, object?>?> GetRowByPkAsync(string tableName, string pkColumn, object pkValue, CancellationToken ct = default) => _inner.GetRowByPkAsync(tableName, pkColumn, pkValue, ct);
+    public Task<int> InsertRowAsync(string tableName, Dictionary<string, object?> values, CancellationToken ct = default) => _inner.InsertRowAsync(tableName, values, ct);
+    public Task<int> UpdateRowAsync(string tableName, string pkColumn, object pkValue, Dictionary<string, object?> values, CancellationToken ct = default) => _inner.UpdateRowAsync(tableName, pkColumn, pkValue, values, ct);
+    public Task<int> DeleteRowAsync(string tableName, string pkColumn, object pkValue, CancellationToken ct = default) => _inner.DeleteRowAsync(tableName, pkColumn, pkValue, ct);
+    public Task DropTableAsync(string tableName, CancellationToken ct = default) => _inner.DropTableAsync(tableName, ct);
+    public Task RenameTableAsync(string tableName, string newTableName, CancellationToken ct = default) => _inner.RenameTableAsync(tableName, newTableName, ct);
+    public Task AddColumnAsync(string tableName, string columnName, DbType type, bool notNull, CancellationToken ct = default) => _inner.AddColumnAsync(tableName, columnName, type, notNull, ct);
+    public Task DropColumnAsync(string tableName, string columnName, CancellationToken ct = default) => _inner.DropColumnAsync(tableName, columnName, ct);
+    public Task RenameColumnAsync(string tableName, string oldColumnName, string newColumnName, CancellationToken ct = default) => _inner.RenameColumnAsync(tableName, oldColumnName, newColumnName, ct);
+    public Task<IReadOnlyList<IndexSchema>> GetIndexesAsync(CancellationToken ct = default) => _inner.GetIndexesAsync(ct);
+    public Task CreateIndexAsync(string indexName, string tableName, string columnName, bool isUnique, CancellationToken ct = default) => _inner.CreateIndexAsync(indexName, tableName, columnName, isUnique, ct);
+    public Task UpdateIndexAsync(string existingIndexName, string newIndexName, string tableName, string columnName, bool isUnique, CancellationToken ct = default) => _inner.UpdateIndexAsync(existingIndexName, newIndexName, tableName, columnName, isUnique, ct);
+    public Task DropIndexAsync(string indexName, CancellationToken ct = default) => _inner.DropIndexAsync(indexName, ct);
+    public Task<IReadOnlyList<string>> GetViewNamesAsync(CancellationToken ct = default) => _inner.GetViewNamesAsync(ct);
+    public Task<IReadOnlyList<ViewDefinition>> GetViewsAsync(CancellationToken ct = default) => _inner.GetViewsAsync(ct);
+    public Task<ViewDefinition?> GetViewAsync(string viewName, CancellationToken ct = default) => _inner.GetViewAsync(viewName, ct);
+    public Task<string?> GetViewSqlAsync(string viewName, CancellationToken ct = default) => _inner.GetViewSqlAsync(viewName, ct);
+    public Task<ViewBrowseResult> BrowseViewAsync(string viewName, int page = 1, int pageSize = 50, CancellationToken ct = default) => _inner.BrowseViewAsync(viewName, page, pageSize, ct);
+    public Task CreateViewAsync(string viewName, string selectSql, CancellationToken ct = default) => _inner.CreateViewAsync(viewName, selectSql, ct);
+    public Task UpdateViewAsync(string existingViewName, string newViewName, string selectSql, CancellationToken ct = default) => _inner.UpdateViewAsync(existingViewName, newViewName, selectSql, ct);
+    public Task DropViewAsync(string viewName, CancellationToken ct = default) => _inner.DropViewAsync(viewName, ct);
+    public Task<IReadOnlyList<TriggerSchema>> GetTriggersAsync(CancellationToken ct = default) => _inner.GetTriggersAsync(ct);
+    public Task CreateTriggerAsync(string triggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql, CancellationToken ct = default) => _inner.CreateTriggerAsync(triggerName, tableName, timing, triggerEvent, bodySql, ct);
+    public Task UpdateTriggerAsync(string existingTriggerName, string newTriggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql, CancellationToken ct = default) => _inner.UpdateTriggerAsync(existingTriggerName, newTriggerName, tableName, timing, triggerEvent, bodySql, ct);
+    public Task DropTriggerAsync(string triggerName, CancellationToken ct = default) => _inner.DropTriggerAsync(triggerName, ct);
+    public Task<IReadOnlyList<SavedQueryDefinition>> GetSavedQueriesAsync(CancellationToken ct = default) => _inner.GetSavedQueriesAsync(ct);
+    public Task<SavedQueryDefinition?> GetSavedQueryAsync(string name, CancellationToken ct = default) => _inner.GetSavedQueryAsync(name, ct);
+    public Task<SavedQueryDefinition> UpsertSavedQueryAsync(string name, string sqlText, CancellationToken ct = default) => _inner.UpsertSavedQueryAsync(name, sqlText, ct);
+    public Task DeleteSavedQueryAsync(string name, CancellationToken ct = default) => _inner.DeleteSavedQueryAsync(name, ct);
+    public Task<IReadOnlyList<ProcedureDefinition>> GetProceduresAsync(bool includeDisabled = true, CancellationToken ct = default) => _inner.GetProceduresAsync(includeDisabled, ct);
+    public Task<ProcedureDefinition?> GetProcedureAsync(string name, CancellationToken ct = default) => _inner.GetProcedureAsync(name, ct);
+    public Task CreateProcedureAsync(ProcedureDefinition definition, CancellationToken ct = default) => _inner.CreateProcedureAsync(definition, ct);
+    public Task UpdateProcedureAsync(string existingName, ProcedureDefinition definition, CancellationToken ct = default) => _inner.UpdateProcedureAsync(existingName, definition, ct);
+    public Task DeleteProcedureAsync(string name, CancellationToken ct = default) => _inner.DeleteProcedureAsync(name, ct);
+    public Task<ProcedureExecutionResult> ExecuteProcedureAsync(string name, IReadOnlyDictionary<string, object?> args, CancellationToken ct = default) => _inner.ExecuteProcedureAsync(name, args, ct);
+    public Task<SqlExecutionResult> ExecuteSqlAsync(string sql, CancellationToken ct = default) => _inner.ExecuteSqlAsync(sql, ct);
+    public Task<TransactionSessionInfo> BeginTransactionAsync(CancellationToken ct = default) => _inner.BeginTransactionAsync(ct);
+    public Task<SqlExecutionResult> ExecuteInTransactionAsync(string transactionId, string sql, CancellationToken ct = default) => _inner.ExecuteInTransactionAsync(transactionId, sql, ct);
+    public Task CommitTransactionAsync(string transactionId, CancellationToken ct = default) => _inner.CommitTransactionAsync(transactionId, ct);
+    public Task RollbackTransactionAsync(string transactionId, CancellationToken ct = default) => _inner.RollbackTransactionAsync(transactionId, ct);
+    public Task<IReadOnlyList<string>> GetCollectionNamesAsync(CancellationToken ct = default) => _inner.GetCollectionNamesAsync(ct);
+    public Task<int> GetCollectionCountAsync(string collectionName, CancellationToken ct = default) => _inner.GetCollectionCountAsync(collectionName, ct);
+    public Task<CollectionBrowseResult> BrowseCollectionAsync(string collectionName, int page = 1, int pageSize = 50, CancellationToken ct = default) => _inner.BrowseCollectionAsync(collectionName, page, pageSize, ct);
+    public Task<System.Text.Json.JsonElement?> GetDocumentAsync(string collectionName, string key, CancellationToken ct = default) => _inner.GetDocumentAsync(collectionName, key, ct);
+    public Task PutDocumentAsync(string collectionName, string key, System.Text.Json.JsonElement document, CancellationToken ct = default) => _inner.PutDocumentAsync(collectionName, key, document, ct);
+    public Task<bool> DeleteDocumentAsync(string collectionName, string key, CancellationToken ct = default) => _inner.DeleteDocumentAsync(collectionName, key, ct);
+    public Task CheckpointAsync(CancellationToken ct = default) => _inner.CheckpointAsync(ct);
+    public Task<DatabaseInspectReport> InspectStorageAsync(string? databasePath = null, bool includePages = false, CancellationToken ct = default) => _inner.InspectStorageAsync(databasePath, includePages, ct);
+    public Task<WalInspectReport> CheckWalAsync(string? databasePath = null, CancellationToken ct = default) => _inner.CheckWalAsync(databasePath, ct);
+    public Task<PageInspectReport> InspectPageAsync(uint pageId, bool includeHex = false, string? databasePath = null, CancellationToken ct = default) => _inner.InspectPageAsync(pageId, includeHex, databasePath, ct);
+    public Task<IndexInspectReport> CheckIndexesAsync(string? databasePath = null, string? indexName = null, int? sampleSize = null, CancellationToken ct = default) => _inner.CheckIndexesAsync(databasePath, indexName, sampleSize, ct);
+    public ValueTask DisposeAsync() => _inner.DisposeAsync();
+    public ValueTask<Database?> TryGetDatabaseAsync(CancellationToken ct = default)
+        => _inner is IEngineBackedClient engineBacked
+            ? engineBacked.TryGetDatabaseAsync(ct)
+            : ValueTask.FromResult<Database?>(null);
+}

--- a/src/CSharpDB.Client/CSharpDbClientConfigurationException.cs
+++ b/src/CSharpDB.Client/CSharpDbClientConfigurationException.cs
@@ -1,0 +1,9 @@
+namespace CSharpDB.Client;
+
+public sealed class CSharpDbClientConfigurationException : CSharpDbClientException
+{
+    public CSharpDbClientConfigurationException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/CSharpDB.Client/CSharpDbClientException.cs
+++ b/src/CSharpDB.Client/CSharpDbClientException.cs
@@ -1,0 +1,14 @@
+namespace CSharpDB.Client;
+
+public class CSharpDbClientException : Exception
+{
+    public CSharpDbClientException(string message)
+        : base(message)
+    {
+    }
+
+    public CSharpDbClientException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/CSharpDB.Client/CSharpDbClientOptions.cs
+++ b/src/CSharpDB.Client/CSharpDbClientOptions.cs
@@ -1,0 +1,10 @@
+namespace CSharpDB.Client;
+
+public sealed class CSharpDbClientOptions
+{
+    public CSharpDbTransport? Transport { get; init; }
+    public string? Endpoint { get; init; }
+    public string? ConnectionString { get; init; }
+    public string? DataSource { get; init; }
+    public HttpClient? HttpClient { get; init; }
+}

--- a/src/CSharpDB.Client/CSharpDbTransport.cs
+++ b/src/CSharpDB.Client/CSharpDbTransport.cs
@@ -1,0 +1,10 @@
+namespace CSharpDB.Client;
+
+public enum CSharpDbTransport
+{
+    Direct = 0,
+    Http = 1,
+    Grpc = 2,
+    Tcp = 3,
+    NamedPipes = 4,
+}

--- a/src/CSharpDB.Client/ICSharpDbClient.cs
+++ b/src/CSharpDB.Client/ICSharpDbClient.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using CSharpDB.Client.Models;
+using CSharpDB.Storage.Diagnostics;
+
+namespace CSharpDB.Client;
+
+public interface ICSharpDbClient : IAsyncDisposable
+{
+    string DataSource { get; }
+
+    Task<DatabaseInfo> GetInfoAsync(CancellationToken ct = default);
+
+    Task<IReadOnlyList<string>> GetTableNamesAsync(CancellationToken ct = default);
+    Task<TableSchema?> GetTableSchemaAsync(string tableName, CancellationToken ct = default);
+    Task<int> GetRowCountAsync(string tableName, CancellationToken ct = default);
+    Task<TableBrowseResult> BrowseTableAsync(string tableName, int page = 1, int pageSize = 50, CancellationToken ct = default);
+    Task<Dictionary<string, object?>?> GetRowByPkAsync(string tableName, string pkColumn, object pkValue, CancellationToken ct = default);
+    Task<int> InsertRowAsync(string tableName, Dictionary<string, object?> values, CancellationToken ct = default);
+    Task<int> UpdateRowAsync(string tableName, string pkColumn, object pkValue, Dictionary<string, object?> values, CancellationToken ct = default);
+    Task<int> DeleteRowAsync(string tableName, string pkColumn, object pkValue, CancellationToken ct = default);
+
+    Task DropTableAsync(string tableName, CancellationToken ct = default);
+    Task RenameTableAsync(string tableName, string newTableName, CancellationToken ct = default);
+    Task AddColumnAsync(string tableName, string columnName, DbType type, bool notNull, CancellationToken ct = default);
+    Task DropColumnAsync(string tableName, string columnName, CancellationToken ct = default);
+    Task RenameColumnAsync(string tableName, string oldColumnName, string newColumnName, CancellationToken ct = default);
+
+    Task<IReadOnlyList<IndexSchema>> GetIndexesAsync(CancellationToken ct = default);
+    Task CreateIndexAsync(string indexName, string tableName, string columnName, bool isUnique, CancellationToken ct = default);
+    Task UpdateIndexAsync(string existingIndexName, string newIndexName, string tableName, string columnName, bool isUnique, CancellationToken ct = default);
+    Task DropIndexAsync(string indexName, CancellationToken ct = default);
+
+    Task<IReadOnlyList<string>> GetViewNamesAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<ViewDefinition>> GetViewsAsync(CancellationToken ct = default);
+    Task<ViewDefinition?> GetViewAsync(string viewName, CancellationToken ct = default);
+    Task<string?> GetViewSqlAsync(string viewName, CancellationToken ct = default);
+    Task<ViewBrowseResult> BrowseViewAsync(string viewName, int page = 1, int pageSize = 50, CancellationToken ct = default);
+    Task CreateViewAsync(string viewName, string selectSql, CancellationToken ct = default);
+    Task UpdateViewAsync(string existingViewName, string newViewName, string selectSql, CancellationToken ct = default);
+    Task DropViewAsync(string viewName, CancellationToken ct = default);
+
+    Task<IReadOnlyList<TriggerSchema>> GetTriggersAsync(CancellationToken ct = default);
+    Task CreateTriggerAsync(string triggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql, CancellationToken ct = default);
+    Task UpdateTriggerAsync(string existingTriggerName, string newTriggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql, CancellationToken ct = default);
+    Task DropTriggerAsync(string triggerName, CancellationToken ct = default);
+
+    Task<IReadOnlyList<SavedQueryDefinition>> GetSavedQueriesAsync(CancellationToken ct = default);
+    Task<SavedQueryDefinition?> GetSavedQueryAsync(string name, CancellationToken ct = default);
+    Task<SavedQueryDefinition> UpsertSavedQueryAsync(string name, string sqlText, CancellationToken ct = default);
+    Task DeleteSavedQueryAsync(string name, CancellationToken ct = default);
+
+    Task<IReadOnlyList<ProcedureDefinition>> GetProceduresAsync(bool includeDisabled = true, CancellationToken ct = default);
+    Task<ProcedureDefinition?> GetProcedureAsync(string name, CancellationToken ct = default);
+    Task CreateProcedureAsync(ProcedureDefinition definition, CancellationToken ct = default);
+    Task UpdateProcedureAsync(string existingName, ProcedureDefinition definition, CancellationToken ct = default);
+    Task DeleteProcedureAsync(string name, CancellationToken ct = default);
+    Task<ProcedureExecutionResult> ExecuteProcedureAsync(string name, IReadOnlyDictionary<string, object?> args, CancellationToken ct = default);
+
+    Task<SqlExecutionResult> ExecuteSqlAsync(string sql, CancellationToken ct = default);
+
+    Task<TransactionSessionInfo> BeginTransactionAsync(CancellationToken ct = default);
+    Task<SqlExecutionResult> ExecuteInTransactionAsync(string transactionId, string sql, CancellationToken ct = default);
+    Task CommitTransactionAsync(string transactionId, CancellationToken ct = default);
+    Task RollbackTransactionAsync(string transactionId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<string>> GetCollectionNamesAsync(CancellationToken ct = default);
+    Task<int> GetCollectionCountAsync(string collectionName, CancellationToken ct = default);
+    Task<CollectionBrowseResult> BrowseCollectionAsync(string collectionName, int page = 1, int pageSize = 50, CancellationToken ct = default);
+    Task<JsonElement?> GetDocumentAsync(string collectionName, string key, CancellationToken ct = default);
+    Task PutDocumentAsync(string collectionName, string key, JsonElement document, CancellationToken ct = default);
+    Task<bool> DeleteDocumentAsync(string collectionName, string key, CancellationToken ct = default);
+
+    Task CheckpointAsync(CancellationToken ct = default);
+    Task<DatabaseInspectReport> InspectStorageAsync(string? databasePath = null, bool includePages = false, CancellationToken ct = default);
+    Task<WalInspectReport> CheckWalAsync(string? databasePath = null, CancellationToken ct = default);
+    Task<PageInspectReport> InspectPageAsync(uint pageId, bool includeHex = false, string? databasePath = null, CancellationToken ct = default);
+    Task<IndexInspectReport> CheckIndexesAsync(string? databasePath = null, string? indexName = null, int? sampleSize = null, CancellationToken ct = default);
+}

--- a/src/CSharpDB.Client/Internal/ClientTransportResolver.cs
+++ b/src/CSharpDB.Client/Internal/ClientTransportResolver.cs
@@ -1,0 +1,241 @@
+using System.Data.Common;
+
+namespace CSharpDB.Client.Internal;
+
+internal static class ClientTransportResolver
+{
+    public static ICSharpDbClient Create(CSharpDbClientOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var resolution = Resolve(options);
+        return resolution.Transport switch
+        {
+            CSharpDbTransport.Direct => new EngineTransportClient(resolution.DatabasePath!),
+            CSharpDbTransport.Http => throw CreateNotImplementedTransportException(CSharpDbTransport.Http),
+            CSharpDbTransport.Grpc => throw CreateNotImplementedTransportException(CSharpDbTransport.Grpc),
+            CSharpDbTransport.Tcp => throw CreateNotImplementedTransportException(CSharpDbTransport.Tcp),
+            CSharpDbTransport.NamedPipes => throw CreateNotImplementedTransportException(CSharpDbTransport.NamedPipes),
+            _ => throw new CSharpDbClientConfigurationException($"Unsupported transport '{resolution.Transport}'."),
+        };
+    }
+
+    private static Resolution Resolve(CSharpDbClientOptions options)
+    {
+        string? endpoint = string.IsNullOrWhiteSpace(options.Endpoint) ? null : options.Endpoint.Trim();
+        Uri? endpointUri = null;
+        if (endpoint is not null && Uri.TryCreate(endpoint, UriKind.Absolute, out var parsedEndpointUri))
+            endpointUri = parsedEndpointUri;
+
+        var transport = options.Transport ?? InferTransport(endpoint, endpointUri);
+        return transport switch
+        {
+            CSharpDbTransport.Direct => ResolveDirect(options, ResolveDirectEndpointPath(endpoint, endpointUri)),
+            CSharpDbTransport.Http => ResolveHttp(options, endpointUri),
+            CSharpDbTransport.Grpc => ResolveGrpc(options, endpointUri),
+            CSharpDbTransport.Tcp => ResolveTcp(options, endpointUri),
+            CSharpDbTransport.NamedPipes => ResolveNamedPipes(options, endpointUri),
+            _ => throw new CSharpDbClientConfigurationException($"Unsupported transport '{transport}'."),
+        };
+    }
+
+    private static Resolution ResolveDirect(CSharpDbClientOptions options, string? endpointPath)
+    {
+        string? dataSource = string.IsNullOrWhiteSpace(options.DataSource)
+            ? null
+            : NormalizePath(options.DataSource);
+
+        string? connectionString = string.IsNullOrWhiteSpace(options.ConnectionString)
+            ? null
+            : options.ConnectionString.Trim();
+
+        string? connectionStringPath = null;
+        if (connectionString is not null)
+        {
+            var builder = new DbConnectionStringBuilder
+            {
+                ConnectionString = connectionString,
+            };
+
+            if (!TryGetDataSource(builder, out string? dataSourceValue) || string.IsNullOrWhiteSpace(dataSourceValue))
+                throw new CSharpDbClientConfigurationException("ConnectionString must include a Data Source.");
+
+            connectionStringPath = NormalizePath(dataSourceValue);
+        }
+
+        string? resolvedPath = endpointPath ?? dataSource ?? connectionStringPath;
+        if (resolvedPath is null)
+            throw new CSharpDbClientConfigurationException("Direct transport requires Endpoint, DataSource, or ConnectionString.");
+
+        if (dataSource is not null && !PathsEqual(resolvedPath, dataSource))
+            throw new CSharpDbClientConfigurationException("DataSource does not match the resolved direct target.");
+
+        if (connectionStringPath is not null && !PathsEqual(resolvedPath, connectionStringPath))
+            throw new CSharpDbClientConfigurationException("ConnectionString Data Source does not match the resolved direct target.");
+
+        return new Resolution
+        {
+            Transport = CSharpDbTransport.Direct,
+            DatabasePath = resolvedPath,
+        };
+    }
+
+    private static Resolution ResolveHttp(CSharpDbClientOptions options, Uri? endpointUri)
+    {
+        EnsureNoDirectInputs(options, CSharpDbTransport.Http);
+        EnsureEndpointScheme(endpointUri, CSharpDbTransport.Http, Uri.UriSchemeHttp, Uri.UriSchemeHttps);
+
+        return new Resolution
+        {
+            Transport = CSharpDbTransport.Http,
+        };
+    }
+
+    private static Resolution ResolveGrpc(CSharpDbClientOptions options, Uri? endpointUri)
+    {
+        EnsureNoDirectInputs(options, CSharpDbTransport.Grpc);
+        EnsureEndpointScheme(endpointUri, CSharpDbTransport.Grpc, Uri.UriSchemeHttp, Uri.UriSchemeHttps);
+
+        return new Resolution
+        {
+            Transport = CSharpDbTransport.Grpc,
+        };
+    }
+
+    private static Resolution ResolveTcp(CSharpDbClientOptions options, Uri? endpointUri)
+    {
+        EnsureNoDirectInputs(options, CSharpDbTransport.Tcp);
+        EnsureEndpointScheme(endpointUri, CSharpDbTransport.Tcp, "tcp");
+
+        return new Resolution
+        {
+            Transport = CSharpDbTransport.Tcp,
+        };
+    }
+
+    private static Resolution ResolveNamedPipes(CSharpDbClientOptions options, Uri? endpointUri)
+    {
+        EnsureNoDirectInputs(options, CSharpDbTransport.NamedPipes);
+        EnsureEndpointScheme(endpointUri, CSharpDbTransport.NamedPipes, "pipe", "npipe");
+
+        return new Resolution
+        {
+            Transport = CSharpDbTransport.NamedPipes,
+        };
+    }
+
+    private static CSharpDbTransport InferTransport(string? endpoint, Uri? endpointUri)
+    {
+        if (endpointUri is not null)
+        {
+            if (string.Equals(endpointUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+                return CSharpDbTransport.Direct;
+
+            if (endpointUri.Scheme is "http" or "https")
+                return CSharpDbTransport.Http;
+
+            if (string.Equals(endpointUri.Scheme, "tcp", StringComparison.OrdinalIgnoreCase))
+                return CSharpDbTransport.Tcp;
+
+            if (endpointUri.Scheme is "pipe" or "npipe")
+                return CSharpDbTransport.NamedPipes;
+
+            throw new CSharpDbClientConfigurationException($"Unsupported endpoint scheme '{endpointUri.Scheme}'.");
+        }
+
+        if (endpoint is not null && !LooksLikeFilePath(endpoint))
+            throw new CSharpDbClientConfigurationException("Transport could not be inferred from Endpoint. Set Transport explicitly.");
+
+        return CSharpDbTransport.Direct;
+    }
+
+    private static string? ResolveDirectEndpointPath(string? endpoint, Uri? endpointUri)
+    {
+        if (endpoint is null)
+            return null;
+
+        if (endpointUri is not null)
+        {
+            if (string.Equals(endpointUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+                return NormalizePath(endpointUri.LocalPath);
+
+            throw new CSharpDbClientConfigurationException("Transport 'Direct' requires a file path or file:// endpoint.");
+        }
+
+        if (!LooksLikeFilePath(endpoint))
+            throw new CSharpDbClientConfigurationException("Transport 'Direct' requires a file path or file:// endpoint.");
+
+        return NormalizePath(endpoint);
+    }
+
+    private static void EnsureNoDirectInputs(CSharpDbClientOptions options, CSharpDbTransport transport)
+    {
+        if (!string.IsNullOrWhiteSpace(options.DataSource) || !string.IsNullOrWhiteSpace(options.ConnectionString))
+        {
+            throw new CSharpDbClientConfigurationException(
+                $"Transport '{transport}' does not use DataSource or ConnectionString. Use Endpoint instead.");
+        }
+    }
+
+    private static void EnsureEndpointScheme(Uri? endpointUri, CSharpDbTransport transport, params string[] allowedSchemes)
+    {
+        if (endpointUri is null)
+        {
+            throw new CSharpDbClientConfigurationException(
+                $"Transport '{transport}' requires an Endpoint with one of: {string.Join(", ", allowedSchemes)}.");
+        }
+
+        if (allowedSchemes.Any(scheme => string.Equals(endpointUri.Scheme, scheme, StringComparison.OrdinalIgnoreCase)))
+            return;
+
+        throw new CSharpDbClientConfigurationException(
+            $"Transport '{transport}' requires an Endpoint with one of: {string.Join(", ", allowedSchemes)}.");
+    }
+
+    private static CSharpDbClientConfigurationException CreateNotImplementedTransportException(CSharpDbTransport transport)
+        => new($"Transport '{transport}' is not implemented in CSharpDB.Client yet.");
+
+    private static bool TryGetDataSource(DbConnectionStringBuilder builder, out string? dataSource)
+    {
+        foreach (string key in builder.Keys.Cast<string>())
+        {
+            if (!key.Equals("Data Source", StringComparison.OrdinalIgnoreCase) &&
+                !key.Equals("DataSource", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            dataSource = Convert.ToString(builder[key], System.Globalization.CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        dataSource = null;
+        return false;
+    }
+
+    private static bool LooksLikeFilePath(string value)
+    {
+        if (Path.IsPathRooted(value))
+            return true;
+
+        return !value.Contains("://", StringComparison.Ordinal)
+            && (value.Contains(Path.DirectorySeparatorChar)
+                || value.Contains(Path.AltDirectorySeparatorChar)
+                || value.StartsWith(".", StringComparison.Ordinal)
+                || value.EndsWith(".db", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizePath(string value)
+        => Path.GetFullPath(value);
+
+    private static bool PathsEqual(string left, string right)
+        => string.Equals(left, right, OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal);
+
+    private sealed class Resolution
+    {
+        public required CSharpDbTransport Transport { get; init; }
+        public string? DatabasePath { get; init; }
+    }
+}

--- a/src/CSharpDB.Client/Internal/EngineTransportClient.Metadata.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.Metadata.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using CSharpDB.Client.Models;
+using CSharpDB.Engine;
+
+namespace CSharpDB.Client.Internal;
+
+internal sealed partial class EngineTransportClient
+{
+    private const string ProcedureEnabledIndexName = "idx___procedures_is_enabled";
+    private const string SavedQueryNameIndexName = "idx___saved_queries_name";
+
+    public async Task<IReadOnlyList<string>> GetViewNamesAsync(CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            return db.GetViewNames()
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task<string?> GetViewSqlAsync(string viewName, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            string normalizedViewName = RequireIdentifier(viewName, nameof(viewName));
+            return (await GetDatabaseAsync(ct)).GetViewSql(normalizedViewName);
+        }
+        finally { _lock.Release(); }
+    }
+
+    private async Task<DatabaseInfo> GetInfoCoreAsync(CancellationToken ct)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+
+            return new DatabaseInfo
+            {
+                DataSource = _databasePath,
+                TableCount = db.GetTableNames().Count(name => !IsInternalTable(name)),
+                IndexCount = db.GetIndexes().Count,
+                ViewCount = db.GetViewNames().Count,
+                TriggerCount = db.GetTriggers().Count,
+                ProcedureCount = await CountRowsViaScalarAsync(db, ProcedureTableName, ct),
+                CollectionCount = db.GetCollectionNames().Count,
+                SavedQueryCount = await CountRowsViaScalarAsync(db, SavedQueryTableName, ct),
+            };
+        }
+        finally { _lock.Release(); }
+    }
+
+    private async Task EnsureCatalogsInitializedAsync(CancellationToken ct)
+    {
+        if (_catalogsInitialized)
+            return;
+
+        var db = await GetDatabaseAsync(ct);
+        await EnsureProcedureCatalogAsync(db, ct);
+        await EnsureSavedQueryCatalogAsync(db, ct);
+        _catalogsInitialized = true;
+    }
+
+    private async Task EnsureProcedureCatalogAsync(Database db, CancellationToken ct)
+    {
+        await ExecuteStatementAsync(db, $"""
+            CREATE TABLE IF NOT EXISTS {ProcedureTableName} (
+                name TEXT PRIMARY KEY,
+                body_sql TEXT NOT NULL,
+                params_json TEXT NOT NULL,
+                description TEXT,
+                is_enabled INTEGER NOT NULL,
+                created_utc TEXT NOT NULL,
+                updated_utc TEXT NOT NULL
+            );
+            """, ct);
+
+        await ExecuteStatementAsync(db, $"""
+            CREATE INDEX IF NOT EXISTS {ProcedureEnabledIndexName}
+            ON {ProcedureTableName} (is_enabled);
+            """, ct);
+    }
+
+    private async Task EnsureSavedQueryCatalogAsync(Database db, CancellationToken ct)
+    {
+        await ExecuteStatementAsync(db, $"""
+            CREATE TABLE IF NOT EXISTS {SavedQueryTableName} (
+                id INTEGER PRIMARY KEY IDENTITY,
+                name TEXT NOT NULL,
+                sql_text TEXT NOT NULL,
+                created_utc TEXT NOT NULL,
+                updated_utc TEXT NOT NULL
+            );
+            """, ct);
+
+        await ExecuteStatementAsync(db, $"""
+            CREATE UNIQUE INDEX IF NOT EXISTS {SavedQueryNameIndexName}
+            ON {SavedQueryTableName} (name);
+            """, ct);
+    }
+
+    private static async Task<int> CountRowsViaScalarAsync(Database db, string tableName, CancellationToken ct)
+    {
+        var result = await ExecuteQueryAsync(db, $"SELECT COUNT(*) FROM {tableName};", ct);
+        if (result.Rows is null || result.Rows.Count == 0 || result.Rows[0].Length == 0 || result.Rows[0][0] is null)
+            return 0;
+
+        return Convert.ToInt32(result.Rows[0][0], CultureInfo.InvariantCulture);
+    }
+}

--- a/src/CSharpDB.Client/Internal/EngineTransportClient.ProcedureHelpers.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.ProcedureHelpers.cs
@@ -1,0 +1,364 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using CSharpDB.Client.Models;
+using CSharpDB.Engine;
+using CSharpDB.Sql;
+
+namespace CSharpDB.Client.Internal;
+
+internal sealed partial class EngineTransportClient
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private static IReadOnlyList<ProcedureParameterDefinition> NormalizeProcedureParameters(IReadOnlyList<ProcedureParameterDefinition> parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        var normalized = new List<ProcedureParameterDefinition>(parameters.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var parameter in parameters)
+        {
+            if (parameter is null)
+                throw new ArgumentException("Procedure parameter entry cannot be null.");
+
+            string name = NormalizeProcedureParameterName(parameter.Name);
+            if (!seen.Add(name))
+                throw new ArgumentException($"Duplicate parameter '{name}' in procedure definition.");
+
+            object? normalizedDefault = parameter.Default is JsonElement element
+                ? ConvertJsonElement(element)
+                : parameter.Default;
+
+            normalized.Add(new ProcedureParameterDefinition
+            {
+                Name = name,
+                Type = parameter.Type,
+                Required = parameter.Required,
+                Default = normalizedDefault,
+                Description = string.IsNullOrWhiteSpace(parameter.Description) ? null : parameter.Description.Trim(),
+            });
+        }
+
+        return normalized;
+    }
+
+    private static void ValidateProcedureBodyReferences(string bodySql, IReadOnlyList<ProcedureParameterDefinition> parameters)
+    {
+        var defined = new HashSet<string>(parameters.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
+        foreach (string bodyParameter in ExtractParameterNamesFromSql(bodySql))
+        {
+            if (!defined.Contains(bodyParameter))
+            {
+                throw new ArgumentException(
+                    $"Procedure SQL references parameter '@{bodyParameter}' but it is missing from params metadata.");
+            }
+        }
+    }
+
+    private static Dictionary<string, object?> BindProcedureArguments(ProcedureDefinition procedure, IReadOnlyDictionary<string, object?> args)
+    {
+        var incoming = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (rawName, rawValue) in args)
+        {
+            string normalized = NormalizeProcedureParameterName(rawName);
+            incoming[normalized] = rawValue is JsonElement element ? ConvertJsonElement(element) : rawValue;
+        }
+
+        var known = new HashSet<string>(procedure.Parameters.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
+        foreach (string provided in incoming.Keys)
+        {
+            if (!known.Contains(provided))
+                throw new ArgumentException($"Unknown argument '{provided}'.");
+        }
+
+        var bound = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var parameter in procedure.Parameters)
+        {
+            if (incoming.TryGetValue(parameter.Name, out var providedValue))
+            {
+                bound[parameter.Name] = providedValue is null
+                    ? parameter.Default is not null
+                        ? CoerceProcedureParameterValue(parameter.Name, parameter.Type, parameter.Default)
+                        : parameter.Required
+                            ? throw new ArgumentException($"Required parameter '{parameter.Name}' cannot be null.")
+                            : null
+                    : CoerceProcedureParameterValue(parameter.Name, parameter.Type, providedValue);
+                continue;
+            }
+
+            if (parameter.Default is not null)
+            {
+                bound[parameter.Name] = CoerceProcedureParameterValue(parameter.Name, parameter.Type, parameter.Default);
+                continue;
+            }
+
+            if (parameter.Required)
+                throw new ArgumentException($"Missing required parameter '{parameter.Name}'.");
+
+            bound[parameter.Name] = null;
+        }
+
+        return bound;
+    }
+
+    private static async Task<ProcedureStatementExecutionResult> ExecuteSingleStatementWithArgumentsAsync(
+        Database db,
+        int statementIndex,
+        string sql,
+        IReadOnlyDictionary<string, object?> args,
+        CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        string resolvedSql = SubstituteSqlParameters(sql, args);
+        var result = await ExecuteQueryAsync(db, resolvedSql, ct);
+        stopwatch.Stop();
+
+        return new ProcedureStatementExecutionResult
+        {
+            StatementIndex = statementIndex,
+            StatementText = sql,
+            IsQuery = result.IsQuery,
+            ColumnNames = result.ColumnNames,
+            Rows = result.Rows,
+            RowsAffected = result.RowsAffected,
+            Elapsed = stopwatch.Elapsed,
+        };
+    }
+
+    private static string SubstituteSqlParameters(string sql, IReadOnlyDictionary<string, object?> args)
+    {
+        var tokens = new Tokenizer(sql).Tokenize();
+        var builder = new StringBuilder(sql.Length);
+        int cursor = 0;
+
+        foreach (var token in tokens)
+        {
+            if (token.Type != TokenType.Parameter)
+                continue;
+
+            builder.Append(sql, cursor, token.Position - cursor);
+
+            if (!args.TryGetValue(token.Value, out object? value))
+                throw new ArgumentException($"Missing argument for SQL parameter '@{token.Value}'.");
+
+            builder.Append(FormatSqlLiteral(NormalizeParameterValue(value)));
+            cursor = token.Position + token.Value.Length + 1;
+        }
+
+        builder.Append(sql, cursor, sql.Length - cursor);
+        return builder.ToString();
+    }
+
+    private static string SerializeProcedureParameters(IReadOnlyList<ProcedureParameterDefinition> parameters)
+    {
+        var storage = parameters.Select(parameter => new ProcedureParameterStorage
+        {
+            Name = parameter.Name,
+            Type = parameter.Type.ToString().ToUpperInvariant(),
+            Required = parameter.Required,
+            Default = parameter.Type == DbType.Blob && parameter.Default is byte[] bytes
+                ? Convert.ToBase64String(bytes)
+                : parameter.Default,
+            Description = parameter.Description,
+        });
+
+        return JsonSerializer.Serialize(storage, s_jsonOptions);
+    }
+
+    private static IReadOnlyList<ProcedureParameterDefinition> DeserializeProcedureParameters(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        List<ProcedureParameterStorage>? storage;
+        try
+        {
+            storage = JsonSerializer.Deserialize<List<ProcedureParameterStorage>>(json, s_jsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException($"Invalid procedure params_json payload: {ex.Message}");
+        }
+
+        if (storage is null || storage.Count == 0)
+            return [];
+
+        return NormalizeProcedureParameters(storage
+            .Where(item => item is not null)
+            .Select(item => new ProcedureParameterDefinition
+            {
+                Name = NormalizeProcedureParameterName(item!.Name ?? string.Empty),
+                Type = Enum.TryParse<DbType>(item.Type, ignoreCase: true, out var parsedType)
+                    ? parsedType
+                    : throw new ArgumentException($"Unsupported parameter type '{item.Type}' in params_json."),
+                Required = item.Required,
+                Default = item.Default is JsonElement element ? ConvertJsonElement(element) : item.Default,
+                Description = string.IsNullOrWhiteSpace(item.Description) ? null : item.Description.Trim(),
+            })
+            .ToList());
+    }
+
+    private static string NormalizeProcedureParameterName(string rawName)
+    {
+        if (string.IsNullOrWhiteSpace(rawName))
+            throw new ArgumentException("Procedure parameter name is required.");
+
+        string trimmed = rawName.Trim();
+        if (trimmed.StartsWith('@'))
+            trimmed = trimmed[1..];
+
+        ValidateIdentifier(trimmed, "procedure parameter name");
+        return trimmed;
+    }
+
+    private static HashSet<string> ExtractParameterNamesFromSql(string sql)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var token in new Tokenizer(sql).Tokenize())
+        {
+            if (token.Type == TokenType.Parameter)
+                names.Add(token.Value);
+        }
+
+        return names;
+    }
+
+    private static string NormalizeSavedQueryName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("saved query name is required.");
+
+        string trimmed = name.Trim();
+        if (trimmed.Length > 256)
+            throw new ArgumentException("saved query name cannot exceed 256 characters.");
+        if (trimmed.Any(char.IsControl))
+            throw new ArgumentException("saved query name cannot contain control characters.");
+
+        return trimmed;
+    }
+
+    private static string NormalizeSqlFragment(string sql, string label)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+            throw new ArgumentException($"{label} is required.");
+
+        string trimmed = sql.Trim();
+        if (trimmed.EndsWith(';'))
+            trimmed = trimmed.TrimEnd(';').TrimEnd();
+        if (trimmed.Length == 0)
+            throw new ArgumentException($"{label} is required.");
+
+        return trimmed;
+    }
+
+    private static DateTime ParseStoredUtc(string rawValue, DateTime fallback)
+    {
+        return DateTime.TryParse(
+            rawValue,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var parsed)
+            ? parsed
+            : fallback;
+    }
+
+    private static object? NormalizeParameterValue(object? value)
+        => value is JsonElement element ? ConvertJsonElement(element) : value;
+
+    private static object? ConvertJsonElement(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.Null => null,
+        JsonValueKind.String => element.GetString(),
+        JsonValueKind.Number => element.TryGetInt64(out long integer) ? integer : element.GetDouble(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        _ => element.ToString(),
+    };
+
+    private static object? CoerceProcedureParameterValue(string name, DbType type, object? value)
+    {
+        if (value is null)
+            return null;
+
+        object? normalized = NormalizeParameterValue(value);
+        return type switch
+        {
+            DbType.Integer when TryCoerceInteger(normalized, out long integerValue) => integerValue,
+            DbType.Real when TryCoerceReal(normalized, out double realValue) => realValue,
+            DbType.Text when normalized is string textValue => textValue,
+            DbType.Blob when normalized is byte[] blob => blob,
+            DbType.Blob when normalized is string base64 => Convert.FromBase64String(base64),
+            DbType.Integer => throw new ArgumentException($"Parameter '{name}' expects INTEGER."),
+            DbType.Real => throw new ArgumentException($"Parameter '{name}' expects REAL."),
+            DbType.Text => throw new ArgumentException($"Parameter '{name}' expects TEXT."),
+            DbType.Blob => throw new ArgumentException($"Parameter '{name}' expects BLOB."),
+            _ => throw new ArgumentException($"Unsupported parameter type '{type}' for '{name}'."),
+        };
+    }
+
+    private static bool TryCoerceInteger(object? value, out long result)
+    {
+        switch (value)
+        {
+            case long l: result = l; return true;
+            case int i: result = i; return true;
+            case short s: result = s; return true;
+            case byte b: result = b; return true;
+            case sbyte sb: result = sb; return true;
+            case uint ui: result = ui; return true;
+            case ulong ul when ul <= long.MaxValue: result = (long)ul; return true;
+            case double d when IsWholeNumberInRange(d): result = (long)d; return true;
+            case float f when IsWholeNumberInRange(f): result = (long)f; return true;
+            case decimal m when m >= long.MinValue && m <= long.MaxValue && decimal.Truncate(m) == m: result = (long)m; return true;
+            case string text when long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long parsed): result = parsed; return true;
+            default: result = 0; return false;
+        }
+    }
+
+    private static bool TryCoerceReal(object? value, out double result)
+    {
+        switch (value)
+        {
+            case double d: result = d; return true;
+            case float f: result = f; return true;
+            case decimal m: result = (double)m; return true;
+            case long l: result = l; return true;
+            case int i: result = i; return true;
+            case short s: result = s; return true;
+            case byte b: result = b; return true;
+            case sbyte sb: result = sb; return true;
+            case uint ui: result = ui; return true;
+            case ulong ul: result = ul; return true;
+            case string text when double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double parsed): result = parsed; return true;
+            default: result = 0; return false;
+        }
+    }
+
+    private static bool IsWholeNumberInRange(double value)
+        => !double.IsNaN(value)
+           && !double.IsInfinity(value)
+           && value >= long.MinValue
+           && value <= long.MaxValue
+           && Math.Truncate(value) == value;
+
+    private static bool IsWholeNumberInRange(float value)
+        => !float.IsNaN(value)
+           && !float.IsInfinity(value)
+           && value >= long.MinValue
+           && value <= long.MaxValue
+           && MathF.Truncate(value) == value;
+
+    private sealed class ProcedureParameterStorage
+    {
+        public string? Name { get; init; }
+        public string? Type { get; init; }
+        public bool Required { get; init; }
+        public object? Default { get; init; }
+        public string? Description { get; init; }
+    }
+}

--- a/src/CSharpDB.Client/Internal/EngineTransportClient.Procedures.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.Procedures.cs
@@ -1,0 +1,277 @@
+using System.Diagnostics;
+using System.Globalization;
+using CSharpDB.Client.Models;
+using CSharpDB.Engine;
+using CSharpDB.Sql;
+
+namespace CSharpDB.Client.Internal;
+
+internal sealed partial class EngineTransportClient
+{
+    public async Task<IReadOnlyList<ProcedureDefinition>> GetProceduresAsync(bool includeDisabled = true, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            string sql = includeDisabled
+                ? $"SELECT name, body_sql, params_json, description, is_enabled, created_utc, updated_utc FROM {ProcedureTableName} ORDER BY name;"
+                : $"SELECT name, body_sql, params_json, description, is_enabled, created_utc, updated_utc FROM {ProcedureTableName} WHERE is_enabled = 1 ORDER BY name;";
+
+            var result = await ExecuteQueryAsync(db, sql, ct);
+            return (result.Rows ?? [])
+                .Select(ReadProcedureDefinition)
+                .ToArray();
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task<ProcedureDefinition?> GetProcedureAsync(string name, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            ValidateIdentifier(name, "procedure name");
+            return await GetProcedureInternalAsync(await GetDatabaseAsync(ct), name, ct);
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task CreateProcedureAsync(ProcedureDefinition definition, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            var normalized = NormalizeProcedureDefinition(definition, DateTime.UtcNow);
+            if (await GetProcedureInternalAsync(db, normalized.Name, ct) is not null)
+                throw new ArgumentException($"Procedure '{normalized.Name}' already exists.");
+
+            await ExecuteStatementAsync(
+                db,
+                $"""
+                INSERT INTO {ProcedureTableName}
+                    (name, body_sql, params_json, description, is_enabled, created_utc, updated_utc)
+                VALUES
+                    ({FormatSqlLiteral(normalized.Name)},
+                     {FormatSqlLiteral(normalized.BodySql)},
+                     {FormatSqlLiteral(SerializeProcedureParameters(normalized.Parameters))},
+                     {FormatSqlLiteral(normalized.Description)},
+                     {(normalized.IsEnabled ? "1" : "0")},
+                     {FormatSqlLiteral(normalized.CreatedUtc.ToString("O", CultureInfo.InvariantCulture))},
+                     {FormatSqlLiteral(normalized.UpdatedUtc.ToString("O", CultureInfo.InvariantCulture))});
+                """,
+                ct);
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task UpdateProcedureAsync(string existingName, ProcedureDefinition definition, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            ValidateIdentifier(existingName, "existing procedure name");
+            var existing = await GetProcedureInternalAsync(db, existingName, ct);
+            if (existing is null)
+                throw new ArgumentException($"Procedure '{existingName}' not found.");
+
+            var normalized = NormalizeProcedureDefinition(definition, existing.CreatedUtc);
+            int affected = await ExecuteNonQueryAsync(
+                db,
+                $"""
+                UPDATE {ProcedureTableName}
+                SET name = {FormatSqlLiteral(normalized.Name)},
+                    body_sql = {FormatSqlLiteral(normalized.BodySql)},
+                    params_json = {FormatSqlLiteral(SerializeProcedureParameters(normalized.Parameters))},
+                    description = {FormatSqlLiteral(normalized.Description)},
+                    is_enabled = {(normalized.IsEnabled ? "1" : "0")},
+                    created_utc = {FormatSqlLiteral(normalized.CreatedUtc.ToString("O", CultureInfo.InvariantCulture))},
+                    updated_utc = {FormatSqlLiteral(normalized.UpdatedUtc.ToString("O", CultureInfo.InvariantCulture))}
+                WHERE name = {FormatSqlLiteral(existingName)};
+                """,
+                ct);
+
+            if (affected == 0)
+                throw new ArgumentException($"Procedure '{existingName}' not found.");
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task DeleteProcedureAsync(string name, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            ValidateIdentifier(name, "procedure name");
+            int affected = await ExecuteNonQueryAsync(
+                await GetDatabaseAsync(ct),
+                $"DELETE FROM {ProcedureTableName} WHERE name = {FormatSqlLiteral(name)};",
+                ct);
+
+            if (affected == 0)
+                throw new ArgumentException($"Procedure '{name}' not found.");
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task<ProcedureExecutionResult> ExecuteProcedureAsync(string name, IReadOnlyDictionary<string, object?> args, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            ValidateIdentifier(name, "procedure name");
+
+            var procedure = await GetProcedureInternalAsync(db, name, ct);
+            if (procedure is null)
+                throw new ArgumentException($"Procedure '{name}' not found.");
+
+            if (!procedure.IsEnabled)
+            {
+                return new ProcedureExecutionResult
+                {
+                    ProcedureName = name,
+                    Succeeded = false,
+                    Error = $"Procedure '{name}' is disabled.",
+                    Elapsed = TimeSpan.Zero,
+                };
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            Dictionary<string, object?> boundArgs;
+            try
+            {
+                boundArgs = BindProcedureArguments(procedure, args);
+            }
+            catch (ArgumentException ex)
+            {
+                stopwatch.Stop();
+                return new ProcedureExecutionResult
+                {
+                    ProcedureName = name,
+                    Succeeded = false,
+                    Error = ex.Message,
+                    Elapsed = stopwatch.Elapsed,
+                };
+            }
+
+            IReadOnlyList<string> statements;
+            try
+            {
+                statements = SqlScriptSplitter.SplitExecutableStatements(procedure.BodySql);
+            }
+            catch (CSharpDB.Core.CSharpDbException ex)
+            {
+                stopwatch.Stop();
+                return new ProcedureExecutionResult
+                {
+                    ProcedureName = name,
+                    Succeeded = false,
+                    Error = ex.Message,
+                    Elapsed = stopwatch.Elapsed,
+                };
+            }
+
+            var results = new List<ProcedureStatementExecutionResult>(statements.Count);
+            await db.BeginTransactionAsync(ct);
+            try
+            {
+                for (int i = 0; i < statements.Count; i++)
+                    results.Add(await ExecuteSingleStatementWithArgumentsAsync(db, i, statements[i], boundArgs, ct));
+
+                await db.CommitAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                await db.RollbackAsync(ct);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                await db.RollbackAsync(ct);
+                stopwatch.Stop();
+                return new ProcedureExecutionResult
+                {
+                    ProcedureName = name,
+                    Succeeded = false,
+                    Statements = results,
+                    Error = ex.Message,
+                    FailedStatementIndex = results.Count,
+                    Elapsed = stopwatch.Elapsed,
+                };
+            }
+
+            stopwatch.Stop();
+            return new ProcedureExecutionResult
+            {
+                ProcedureName = name,
+                Succeeded = true,
+                Statements = results,
+                Elapsed = stopwatch.Elapsed,
+            };
+        }
+        finally { _lock.Release(); }
+    }
+
+    private static async Task<ProcedureDefinition?> GetProcedureInternalAsync(Database db, string name, CancellationToken ct)
+    {
+        var result = await ExecuteQueryAsync(
+            db,
+            $"""
+            SELECT name, body_sql, params_json, description, is_enabled, created_utc, updated_utc
+            FROM {ProcedureTableName}
+            WHERE name = {FormatSqlLiteral(name)};
+            """,
+            ct);
+
+        return result.Rows is { Count: > 0 } ? ReadProcedureDefinition(result.Rows[0]) : null;
+    }
+
+    private static ProcedureDefinition ReadProcedureDefinition(object?[] row)
+    {
+        return new ProcedureDefinition
+        {
+            Name = Convert.ToString(row[0], CultureInfo.InvariantCulture) ?? string.Empty,
+            BodySql = Convert.ToString(row[1], CultureInfo.InvariantCulture) ?? string.Empty,
+            Parameters = DeserializeProcedureParameters(Convert.ToString(row[2], CultureInfo.InvariantCulture) ?? string.Empty),
+            Description = row[3] is null ? null : Convert.ToString(row[3], CultureInfo.InvariantCulture),
+            IsEnabled = row[4] is not null && Convert.ToInt64(row[4], CultureInfo.InvariantCulture) != 0,
+            CreatedUtc = ParseStoredUtc(Convert.ToString(row[5], CultureInfo.InvariantCulture) ?? string.Empty, DateTime.UtcNow),
+            UpdatedUtc = ParseStoredUtc(Convert.ToString(row[6], CultureInfo.InvariantCulture) ?? string.Empty, DateTime.UtcNow),
+        };
+    }
+
+    private ProcedureDefinition NormalizeProcedureDefinition(ProcedureDefinition definition, DateTime defaultCreatedUtc)
+    {
+        ValidateIdentifier(definition.Name, "procedure name");
+
+        string normalizedBody = NormalizeSqlFragment(definition.BodySql, "procedure body");
+        var normalizedParameters = NormalizeProcedureParameters(definition.Parameters);
+        ValidateProcedureBodyReferences(normalizedBody, normalizedParameters);
+
+        return new ProcedureDefinition
+        {
+            Name = definition.Name.Trim(),
+            BodySql = normalizedBody,
+            Parameters = normalizedParameters,
+            Description = string.IsNullOrWhiteSpace(definition.Description) ? null : definition.Description.Trim(),
+            IsEnabled = definition.IsEnabled,
+            CreatedUtc = defaultCreatedUtc,
+            UpdatedUtc = DateTime.UtcNow,
+        };
+    }
+}

--- a/src/CSharpDB.Client/Internal/EngineTransportClient.SavedQueries.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.SavedQueries.cs
@@ -1,0 +1,131 @@
+using System.Globalization;
+using CSharpDB.Client.Models;
+using CSharpDB.Engine;
+
+namespace CSharpDB.Client.Internal;
+
+internal sealed partial class EngineTransportClient
+{
+    public async Task<IReadOnlyList<SavedQueryDefinition>> GetSavedQueriesAsync(CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            var result = await ExecuteQueryAsync(
+                db,
+                $"""
+                SELECT id, name, sql_text, created_utc, updated_utc
+                FROM {SavedQueryTableName}
+                ORDER BY name;
+                """,
+                ct);
+
+            return (result.Rows ?? [])
+                .Select(ReadSavedQueryDefinition)
+                .ToArray();
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task<SavedQueryDefinition?> GetSavedQueryAsync(string name, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            return await GetSavedQueryInternalAsync(db, NormalizeSavedQueryName(name), ct);
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task<SavedQueryDefinition> UpsertSavedQueryAsync(string name, string sqlText, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            string normalizedName = NormalizeSavedQueryName(name);
+            string normalizedSql = NormalizeSqlFragment(sqlText, "saved query SQL");
+
+            var existing = await GetSavedQueryInternalAsync(db, normalizedName, ct);
+            string nowText = DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+
+            if (existing is null)
+            {
+                await ExecuteStatementAsync(
+                    db,
+                    $"""
+                    INSERT INTO {SavedQueryTableName} (name, sql_text, created_utc, updated_utc)
+                    VALUES ({FormatSqlLiteral(normalizedName)}, {FormatSqlLiteral(normalizedSql)}, {FormatSqlLiteral(nowText)}, {FormatSqlLiteral(nowText)});
+                    """,
+                    ct);
+            }
+            else
+            {
+                await ExecuteStatementAsync(
+                    db,
+                    $"""
+                    UPDATE {SavedQueryTableName}
+                    SET sql_text = {FormatSqlLiteral(normalizedSql)},
+                        updated_utc = {FormatSqlLiteral(nowText)}
+                    WHERE name = {FormatSqlLiteral(normalizedName)};
+                    """,
+                    ct);
+            }
+
+            return await GetSavedQueryInternalAsync(db, normalizedName, ct)
+                ?? throw new InvalidOperationException($"Saved query '{normalizedName}' could not be loaded after save.");
+        }
+        finally { _lock.Release(); }
+    }
+
+    public async Task DeleteSavedQueryAsync(string name, CancellationToken ct = default)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            string normalizedName = NormalizeSavedQueryName(name);
+            int affected = await ExecuteNonQueryAsync(
+                db,
+                $"DELETE FROM {SavedQueryTableName} WHERE name = {FormatSqlLiteral(normalizedName)};",
+                ct);
+
+            if (affected == 0)
+                throw new ArgumentException($"Saved query '{normalizedName}' not found.");
+        }
+        finally { _lock.Release(); }
+    }
+
+    private static async Task<SavedQueryDefinition?> GetSavedQueryInternalAsync(Database db, string normalizedName, CancellationToken ct)
+    {
+        var result = await ExecuteQueryAsync(
+            db,
+            $"""
+            SELECT id, name, sql_text, created_utc, updated_utc
+            FROM {SavedQueryTableName}
+            WHERE name = {FormatSqlLiteral(normalizedName)};
+            """,
+            ct);
+
+        return result.Rows is { Count: > 0 } ? ReadSavedQueryDefinition(result.Rows[0]) : null;
+    }
+
+    private static SavedQueryDefinition ReadSavedQueryDefinition(object?[] row)
+    {
+        long id = Convert.ToInt64(row[0], CultureInfo.InvariantCulture);
+        return new SavedQueryDefinition
+        {
+            Id = id,
+            Name = Convert.ToString(row[1], CultureInfo.InvariantCulture) ?? string.Empty,
+            SqlText = Convert.ToString(row[2], CultureInfo.InvariantCulture) ?? string.Empty,
+            CreatedUtc = ParseStoredUtc(Convert.ToString(row[3], CultureInfo.InvariantCulture) ?? string.Empty, DateTime.UtcNow),
+            UpdatedUtc = ParseStoredUtc(Convert.ToString(row[4], CultureInfo.InvariantCulture) ?? string.Empty, DateTime.UtcNow),
+        };
+    }
+}

--- a/src/CSharpDB.Client/Internal/EngineTransportClient.SqlAndDiagnostics.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.SqlAndDiagnostics.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using CSharpDB.Client.Models;
+using CSharpDB.Sql;
+using CSharpDB.Storage.Diagnostics;
+
+namespace CSharpDB.Client.Internal;
+
+internal sealed partial class EngineTransportClient
+{
+    public Task<DatabaseInspectReport> InspectStorageAsync(string? databasePath = null, bool includePages = false, CancellationToken ct = default)
+        => InspectStorageCoreAsync(databasePath, includePages);
+
+    public Task<WalInspectReport> CheckWalAsync(string? databasePath = null, CancellationToken ct = default)
+        => WalInspector.InspectAsync(ResolveDatabasePath(databasePath)).AsTask();
+
+    public Task<PageInspectReport> InspectPageAsync(uint pageId, bool includeHex = false, string? databasePath = null, CancellationToken ct = default)
+        => DatabaseInspector.InspectPageAsync(ResolveDatabasePath(databasePath), pageId, includeHex).AsTask();
+
+    public Task<IndexInspectReport> CheckIndexesAsync(string? databasePath = null, string? indexName = null, int? sampleSize = null, CancellationToken ct = default)
+        => IndexInspector.CheckAsync(ResolveDatabasePath(databasePath), indexName, sampleSize).AsTask();
+
+    private async Task<DatabaseInspectReport> InspectStorageCoreAsync(string? databasePath, bool includePages)
+    {
+        string dbPath = ResolveDatabasePath(databasePath);
+        return await DatabaseInspector.InspectAsync(dbPath, new DatabaseInspectOptions { IncludePages = includePages });
+    }
+
+    private async Task<SqlExecutionResult> ExecuteSqlCoreAsync(string sql, CancellationToken ct)
+    {
+        await _lock.WaitAsync(ct);
+        try
+        {
+            await EnsureCatalogsInitializedAsync(ct);
+            var db = await GetDatabaseAsync(ct);
+            var stopwatch = Stopwatch.StartNew();
+            IReadOnlyList<string> statements;
+            try
+            {
+                statements = SqlScriptSplitter.SplitExecutableStatements(sql);
+            }
+            catch (CSharpDB.Core.CSharpDbException ex)
+            {
+                stopwatch.Stop();
+                return new SqlExecutionResult { Error = ex.Message, Elapsed = stopwatch.Elapsed };
+            }
+
+            if (statements.Count == 0)
+            {
+                stopwatch.Stop();
+                return new SqlExecutionResult { IsQuery = false, RowsAffected = 0, Elapsed = stopwatch.Elapsed };
+            }
+
+            SqlExecutionResult? lastResult = null;
+            int totalRowsAffected = 0;
+
+            for (int i = 0; i < statements.Count; i++)
+            {
+                try
+                {
+                    var singleResult = await ExecuteQueryAsync(db, statements[i], ct);
+                    lastResult = singleResult;
+                    if (!singleResult.IsQuery)
+                        totalRowsAffected += singleResult.RowsAffected;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    stopwatch.Stop();
+                    string error = statements.Count > 1 ? $"Statement {i + 1} failed: {ex.Message}" : ex.Message;
+                    return new SqlExecutionResult { Error = error, Elapsed = stopwatch.Elapsed };
+                }
+            }
+
+            stopwatch.Stop();
+            if (lastResult is null)
+                return new SqlExecutionResult { IsQuery = false, RowsAffected = 0, Elapsed = stopwatch.Elapsed };
+
+            return lastResult.IsQuery
+                ? new SqlExecutionResult
+                {
+                    IsQuery = true,
+                    ColumnNames = lastResult.ColumnNames,
+                    Rows = lastResult.Rows,
+                    RowsAffected = lastResult.RowsAffected,
+                    Elapsed = stopwatch.Elapsed,
+                }
+                : new SqlExecutionResult
+                {
+                    IsQuery = false,
+                    RowsAffected = totalRowsAffected,
+                    Elapsed = stopwatch.Elapsed,
+                };
+        }
+        finally { _lock.Release(); }
+    }
+
+    private string ResolveDatabasePath(string? databasePath)
+    {
+        string path = string.IsNullOrWhiteSpace(databasePath) ? _databasePath : databasePath.Trim();
+        return Path.GetFullPath(path);
+    }
+}

--- a/src/CSharpDB.Client/Internal/EngineTransportClient.Validation.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.Validation.cs
@@ -1,0 +1,9 @@
+namespace CSharpDB.Client.Internal;
+
+internal sealed partial class EngineTransportClient
+{
+    private static void ValidateIdentifier(string value, string label)
+    {
+        _ = RequireIdentifier(value, label);
+    }
+}

--- a/src/CSharpDB.Client/Internal/EngineTransportClient.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.cs
@@ -398,11 +398,38 @@ internal sealed partial class EngineTransportClient : ICSharpDbClient, IEngineBa
 
     private Task<Database> GetDatabaseAsync(CancellationToken ct)
     {
+        Task<Database> openTask;
         lock (_databaseGate)
         {
-            _databaseTask ??= Database.OpenAsync(_databasePath, ct).AsTask();
-            return _databaseTask;
+            if (_databaseTask is null)
+            {
+                Task<Database>? createdTask = null;
+                createdTask = OpenDatabaseCoreAsync();
+                _databaseTask = createdTask;
+
+                async Task<Database> OpenDatabaseCoreAsync()
+                {
+                    try
+                    {
+                        return await Database.OpenAsync(_databasePath, CancellationToken.None);
+                    }
+                    catch
+                    {
+                        lock (_databaseGate)
+                        {
+                            if (ReferenceEquals(_databaseTask, createdTask))
+                                _databaseTask = null;
+                        }
+
+                        throw;
+                    }
+                }
+            }
+
+            openTask = _databaseTask;
         }
+
+        return openTask.WaitAsync(ct);
     }
 
     public async ValueTask<Database?> TryGetDatabaseAsync(CancellationToken ct = default)

--- a/src/CSharpDB.Client/Internal/EngineTransportClient.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.cs
@@ -1,0 +1,704 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using CSharpDB.Client.Models;
+using CSharpDB.Engine;
+using CoreColumnDefinition = CSharpDB.Core.ColumnDefinition;
+using CoreDbType = CSharpDB.Core.DbType;
+using CoreIndexSchema = CSharpDB.Core.IndexSchema;
+using CoreTableSchema = CSharpDB.Core.TableSchema;
+using CoreTriggerEvent = CSharpDB.Core.TriggerEvent;
+using CoreTriggerSchema = CSharpDB.Core.TriggerSchema;
+using CoreTriggerTiming = CSharpDB.Core.TriggerTiming;
+
+namespace CSharpDB.Client.Internal;
+
+internal sealed partial class EngineTransportClient : ICSharpDbClient, IEngineBackedClient
+{
+    private const string CollectionPrefix = "_col_";
+    private const string ProcedureTableName = "__procedures";
+    private const string SavedQueryTableName = "__saved_queries";
+    private static readonly Regex s_identifierPattern = new("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled);
+
+    private readonly string _databasePath;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private readonly object _databaseGate = new();
+    private readonly ConcurrentDictionary<string, Database> _transactions = new(StringComparer.Ordinal);
+    private Task<Database>? _databaseTask;
+    private bool _catalogsInitialized;
+
+    public EngineTransportClient(string databasePath)
+    {
+        _databasePath = Path.GetFullPath(databasePath);
+    }
+
+    public string DataSource => _databasePath;
+
+    public Task<DatabaseInfo> GetInfoAsync(CancellationToken ct = default)
+        => GetInfoCoreAsync(ct);
+
+    public async Task<IReadOnlyList<string>> GetTableNamesAsync(CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        return db.GetTableNames()
+            .Where(name => !IsInternalTable(name))
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task<TableSchema?> GetTableSchemaAsync(string tableName, CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        if (IsInternalTable(tableName))
+            return null;
+
+        var schema = db.GetTableSchema(RequireIdentifier(tableName, nameof(tableName)));
+        return schema is null ? null : MapTableSchema(schema);
+    }
+
+    public async Task<int> GetRowCountAsync(string tableName, CancellationToken ct = default)
+    {
+        var browse = await BrowseTableInternalAsync(await GetDatabaseAsync(ct), tableName, ct);
+        return browse.Rows.Count;
+    }
+
+    public async Task<TableBrowseResult> BrowseTableAsync(string tableName, int page = 1, int pageSize = 50, CancellationToken ct = default)
+    {
+        var full = await BrowseTableInternalAsync(await GetDatabaseAsync(ct), tableName, ct);
+        return PageTableResult(full, page, pageSize);
+    }
+
+    public async Task<Dictionary<string, object?>?> GetRowByPkAsync(string tableName, string pkColumn, object pkValue, CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        string normalizedTableName = RequireIdentifier(tableName, nameof(tableName));
+        string normalizedPkColumn = RequireIdentifier(pkColumn, nameof(pkColumn));
+
+        await using var result = await db.ExecuteAsync($"SELECT * FROM {normalizedTableName}", ct);
+        int pkIndex = Array.FindIndex(result.Schema, column => string.Equals(column.Name, normalizedPkColumn, StringComparison.OrdinalIgnoreCase));
+        if (pkIndex < 0)
+            throw new CSharpDbClientException($"Column '{normalizedPkColumn}' was not found in table '{normalizedTableName}'.");
+
+        while (await result.MoveNextAsync(ct))
+        {
+            var row = result.Current;
+            if (ValuesEqual(row[pkIndex], pkValue))
+                return ToRowDictionary(result.Schema, row);
+        }
+
+        return null;
+    }
+
+    public async Task<int> InsertRowAsync(string tableName, Dictionary<string, object?> values, CancellationToken ct = default)
+    {
+        if (values.Count == 0)
+            throw new CSharpDbClientException("Insert requires at least one value.");
+
+        string normalizedTableName = RequireIdentifier(tableName, nameof(tableName));
+        var assignments = values.Select(kvp => new KeyValuePair<string, object?>(RequireIdentifier(kvp.Key, nameof(values)), kvp.Value)).ToArray();
+        string columns = string.Join(", ", assignments.Select(item => item.Key));
+        string literals = string.Join(", ", assignments.Select(item => FormatSqlLiteral(item.Value)));
+        return await ExecuteNonQueryAsync(await GetDatabaseAsync(ct), $"INSERT INTO {normalizedTableName} ({columns}) VALUES ({literals})", ct);
+    }
+
+    public async Task<int> UpdateRowAsync(string tableName, string pkColumn, object pkValue, Dictionary<string, object?> values, CancellationToken ct = default)
+    {
+        if (values.Count == 0)
+            return 0;
+
+        string normalizedTableName = RequireIdentifier(tableName, nameof(tableName));
+        string normalizedPkColumn = RequireIdentifier(pkColumn, nameof(pkColumn));
+        string setClause = string.Join(", ", values.Select(kvp => $"{RequireIdentifier(kvp.Key, nameof(values))} = {FormatSqlLiteral(kvp.Value)}"));
+        string sql = $"UPDATE {normalizedTableName} SET {setClause} WHERE {normalizedPkColumn} = {FormatSqlLiteral(pkValue)}";
+        return await ExecuteNonQueryAsync(await GetDatabaseAsync(ct), sql, ct);
+    }
+
+    public async Task<int> DeleteRowAsync(string tableName, string pkColumn, object pkValue, CancellationToken ct = default)
+    {
+        string normalizedTableName = RequireIdentifier(tableName, nameof(tableName));
+        string normalizedPkColumn = RequireIdentifier(pkColumn, nameof(pkColumn));
+        string sql = $"DELETE FROM {normalizedTableName} WHERE {normalizedPkColumn} = {FormatSqlLiteral(pkValue)}";
+        return await ExecuteNonQueryAsync(await GetDatabaseAsync(ct), sql, ct);
+    }
+
+    public async Task DropTableAsync(string tableName, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), $"DROP TABLE {RequireIdentifier(tableName, nameof(tableName))}", ct);
+
+    public async Task RenameTableAsync(string tableName, string newTableName, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), $"ALTER TABLE {RequireIdentifier(tableName, nameof(tableName))} RENAME TO {RequireIdentifier(newTableName, nameof(newTableName))}", ct);
+
+    public async Task AddColumnAsync(string tableName, string columnName, Models.DbType type, bool notNull, CancellationToken ct = default)
+    {
+        string sql = $"ALTER TABLE {RequireIdentifier(tableName, nameof(tableName))} ADD COLUMN {RequireIdentifier(columnName, nameof(columnName))} {MapDbType(type)}";
+        if (notNull)
+            sql += " NOT NULL";
+
+        await ExecuteStatementAsync(await GetDatabaseAsync(ct), sql, ct);
+    }
+
+    public async Task DropColumnAsync(string tableName, string columnName, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), $"ALTER TABLE {RequireIdentifier(tableName, nameof(tableName))} DROP COLUMN {RequireIdentifier(columnName, nameof(columnName))}", ct);
+
+    public async Task RenameColumnAsync(string tableName, string oldColumnName, string newColumnName, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), $"ALTER TABLE {RequireIdentifier(tableName, nameof(tableName))} RENAME COLUMN {RequireIdentifier(oldColumnName, nameof(oldColumnName))} TO {RequireIdentifier(newColumnName, nameof(newColumnName))}", ct);
+
+    public async Task<IReadOnlyList<IndexSchema>> GetIndexesAsync(CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        return db.GetIndexes()
+            .Select(MapIndexSchema)
+            .OrderBy(index => index.IndexName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task CreateIndexAsync(string indexName, string tableName, string columnName, bool isUnique, CancellationToken ct = default)
+    {
+        string unique = isUnique ? "UNIQUE " : string.Empty;
+        string sql = $"CREATE {unique}INDEX {RequireIdentifier(indexName, nameof(indexName))} ON {RequireIdentifier(tableName, nameof(tableName))} ({RequireIdentifier(columnName, nameof(columnName))})";
+        await ExecuteStatementAsync(await GetDatabaseAsync(ct), sql, ct);
+    }
+
+    public async Task UpdateIndexAsync(string existingIndexName, string newIndexName, string tableName, string columnName, bool isUnique, CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        await ExecuteInSingleTransactionAsync(db, ct,
+            $"DROP INDEX {RequireIdentifier(existingIndexName, nameof(existingIndexName))}",
+            BuildCreateIndexSql(newIndexName, tableName, columnName, isUnique));
+    }
+
+    public async Task DropIndexAsync(string indexName, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), $"DROP INDEX {RequireIdentifier(indexName, nameof(indexName))}", ct);
+
+    public async Task<IReadOnlyList<ViewDefinition>> GetViewsAsync(CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        return db.GetViewNames()
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .Select(name => new ViewDefinition
+            {
+                Name = name,
+                Sql = db.GetViewSql(name) ?? string.Empty,
+            })
+            .ToArray();
+    }
+
+    public async Task<ViewDefinition?> GetViewAsync(string viewName, CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        string normalizedViewName = RequireIdentifier(viewName, nameof(viewName));
+        string? sql = db.GetViewSql(normalizedViewName);
+        return sql is null ? null : new ViewDefinition { Name = normalizedViewName, Sql = sql };
+    }
+
+    public async Task<ViewBrowseResult> BrowseViewAsync(string viewName, int page = 1, int pageSize = 50, CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        string normalizedViewName = RequireIdentifier(viewName, nameof(viewName));
+        var result = await ExecuteQueryAsync(db, $"SELECT * FROM {normalizedViewName}", ct);
+        return PageViewResult(
+            new ViewBrowseResult
+            {
+                ViewName = normalizedViewName,
+                ColumnNames = result.ColumnNames ?? [],
+                Rows = result.Rows ?? [],
+                TotalRows = result.Rows?.Count ?? 0,
+                Page = 1,
+                PageSize = Math.Max(result.Rows?.Count ?? 0, 1),
+            },
+            page,
+            pageSize);
+    }
+
+    public async Task CreateViewAsync(string viewName, string selectSql, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), $"CREATE VIEW {RequireIdentifier(viewName, nameof(viewName))} AS {NormalizeEmbeddedSql(selectSql)}", ct);
+
+    public async Task UpdateViewAsync(string existingViewName, string newViewName, string selectSql, CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        await ExecuteInSingleTransactionAsync(db, ct,
+            $"DROP VIEW {RequireIdentifier(existingViewName, nameof(existingViewName))}",
+            $"CREATE VIEW {RequireIdentifier(newViewName, nameof(newViewName))} AS {NormalizeEmbeddedSql(selectSql)}");
+    }
+
+    public async Task DropViewAsync(string viewName, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), $"DROP VIEW {RequireIdentifier(viewName, nameof(viewName))}", ct);
+
+    public async Task<IReadOnlyList<TriggerSchema>> GetTriggersAsync(CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        return db.GetTriggers()
+            .Select(MapTriggerSchema)
+            .OrderBy(trigger => trigger.TriggerName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task CreateTriggerAsync(string triggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), BuildCreateTriggerSql(triggerName, tableName, timing, triggerEvent, bodySql), ct);
+
+    public async Task UpdateTriggerAsync(string existingTriggerName, string newTriggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql, CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        await ExecuteInSingleTransactionAsync(db, ct,
+            $"DROP TRIGGER {RequireIdentifier(existingTriggerName, nameof(existingTriggerName))}",
+            BuildCreateTriggerSql(newTriggerName, tableName, timing, triggerEvent, bodySql));
+    }
+
+    public async Task DropTriggerAsync(string triggerName, CancellationToken ct = default)
+        => await ExecuteStatementAsync(await GetDatabaseAsync(ct), $"DROP TRIGGER {RequireIdentifier(triggerName, nameof(triggerName))}", ct);
+
+    public Task<SqlExecutionResult> ExecuteSqlAsync(string sql, CancellationToken ct = default)
+        => ExecuteSqlCoreAsync(sql, ct);
+
+    public async Task<TransactionSessionInfo> BeginTransactionAsync(CancellationToken ct = default)
+    {
+        var database = await Database.OpenAsync(_databasePath, ct);
+        try
+        {
+            await database.BeginTransactionAsync(ct);
+        }
+        catch
+        {
+            await database.DisposeAsync();
+            throw;
+        }
+
+        string transactionId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+        if (!_transactions.TryAdd(transactionId, database))
+        {
+            await database.RollbackAsync(ct);
+            await database.DisposeAsync();
+            throw new CSharpDbClientException("Failed to register the transaction session.");
+        }
+
+        return new TransactionSessionInfo
+        {
+            TransactionId = transactionId,
+            ExpiresAtUtc = DateTime.MaxValue,
+        };
+    }
+
+    public async Task<SqlExecutionResult> ExecuteInTransactionAsync(string transactionId, string sql, CancellationToken ct = default)
+        => await ExecuteQueryAsync(GetTransactionDatabase(transactionId), sql, ct);
+
+    public async Task CommitTransactionAsync(string transactionId, CancellationToken ct = default)
+    {
+        var db = TakeTransactionDatabase(transactionId);
+        try
+        {
+            await db.CommitAsync(ct);
+        }
+        finally
+        {
+            await db.DisposeAsync();
+        }
+    }
+
+    public async Task RollbackTransactionAsync(string transactionId, CancellationToken ct = default)
+    {
+        var db = TakeTransactionDatabase(transactionId);
+        try
+        {
+            await db.RollbackAsync(ct);
+        }
+        finally
+        {
+            await db.DisposeAsync();
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> GetCollectionNamesAsync(CancellationToken ct = default)
+    {
+        var db = await GetDatabaseAsync(ct);
+        return db.GetCollectionNames()
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task<int> GetCollectionCountAsync(string collectionName, CancellationToken ct = default)
+    {
+        var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(RequireIdentifier(collectionName, nameof(collectionName)), ct);
+        return checked((int)await collection.CountAsync(ct));
+    }
+
+    public async Task<CollectionBrowseResult> BrowseCollectionAsync(string collectionName, int page = 1, int pageSize = 50, CancellationToken ct = default)
+    {
+        string normalizedName = RequireIdentifier(collectionName, nameof(collectionName));
+        var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(normalizedName, ct);
+        var documents = new List<CollectionDocument>();
+        await foreach (var item in collection.ScanAsync(ct))
+        {
+            documents.Add(new CollectionDocument
+            {
+                Key = item.Key,
+                Document = item.Value,
+            });
+        }
+
+        documents.Sort((left, right) => string.Compare(left.Key, right.Key, StringComparison.OrdinalIgnoreCase));
+        int normalizedPage = NormalizePage(page);
+        int normalizedPageSize = NormalizePageSize(pageSize);
+        int skip = (normalizedPage - 1) * normalizedPageSize;
+
+        return new CollectionBrowseResult
+        {
+            CollectionName = normalizedName,
+            Documents = documents.Skip(skip).Take(normalizedPageSize).ToArray(),
+            TotalCount = documents.Count,
+            Page = normalizedPage,
+            PageSize = normalizedPageSize,
+        };
+    }
+
+    public async Task<JsonElement?> GetDocumentAsync(string collectionName, string key, CancellationToken ct = default)
+    {
+        var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(RequireIdentifier(collectionName, nameof(collectionName)), ct);
+        var document = await collection.GetAsync(key, ct);
+        return document.ValueKind == JsonValueKind.Undefined ? null : document;
+    }
+
+    public async Task PutDocumentAsync(string collectionName, string key, JsonElement document, CancellationToken ct = default)
+    {
+        var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(RequireIdentifier(collectionName, nameof(collectionName)), ct);
+        await collection.PutAsync(key, document, ct);
+    }
+
+    public async Task<bool> DeleteDocumentAsync(string collectionName, string key, CancellationToken ct = default)
+    {
+        var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(RequireIdentifier(collectionName, nameof(collectionName)), ct);
+        return await collection.DeleteAsync(key, ct);
+    }
+
+    public async Task CheckpointAsync(CancellationToken ct = default)
+        => await (await GetDatabaseAsync(ct)).CheckpointAsync(ct);
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var pair in _transactions.ToArray())
+        {
+            if (_transactions.TryRemove(pair.Key, out var transactionDb))
+                await transactionDb.DisposeAsync();
+        }
+
+        if (_databaseTask is null)
+            return;
+
+        try
+        {
+            var db = await _databaseTask;
+            await db.DisposeAsync();
+        }
+        catch
+        {
+            // ignore lazy-init failures during dispose
+        }
+        _lock.Dispose();
+    }
+
+    private Task<Database> GetDatabaseAsync(CancellationToken ct)
+    {
+        lock (_databaseGate)
+        {
+            _databaseTask ??= Database.OpenAsync(_databasePath, ct).AsTask();
+            return _databaseTask;
+        }
+    }
+
+    public async ValueTask<Database?> TryGetDatabaseAsync(CancellationToken ct = default)
+        => await GetDatabaseAsync(ct);
+
+    private static TableSchema MapTableSchema(CoreTableSchema schema)
+        => new()
+        {
+            TableName = schema.TableName,
+            Columns = schema.Columns.Select(MapColumnDefinition).ToArray(),
+        };
+
+    private static ColumnDefinition MapColumnDefinition(CoreColumnDefinition column)
+        => new()
+        {
+            Name = column.Name,
+            Type = column.Type switch
+            {
+                CoreDbType.Integer => Models.DbType.Integer,
+                CoreDbType.Real => Models.DbType.Real,
+                CoreDbType.Text => Models.DbType.Text,
+                CoreDbType.Blob => Models.DbType.Blob,
+                _ => throw new CSharpDbClientException($"Unsupported column type '{column.Type}'."),
+            },
+            Nullable = column.Nullable,
+            IsPrimaryKey = column.IsPrimaryKey,
+            IsIdentity = column.IsIdentity,
+        };
+
+    private static IndexSchema MapIndexSchema(CoreIndexSchema index)
+        => new()
+        {
+            IndexName = index.IndexName,
+            TableName = index.TableName,
+            Columns = index.Columns.ToArray(),
+            IsUnique = index.IsUnique,
+        };
+
+    private static TriggerSchema MapTriggerSchema(CoreTriggerSchema trigger)
+        => new()
+        {
+            TriggerName = trigger.TriggerName,
+            TableName = trigger.TableName,
+            Timing = trigger.Timing == CoreTriggerTiming.Before ? TriggerTiming.Before : TriggerTiming.After,
+            Event = trigger.Event switch
+            {
+                CoreTriggerEvent.Insert => TriggerEvent.Insert,
+                CoreTriggerEvent.Update => TriggerEvent.Update,
+                CoreTriggerEvent.Delete => TriggerEvent.Delete,
+                _ => throw new CSharpDbClientException($"Unsupported trigger event '{trigger.Event}'."),
+            },
+            BodySql = trigger.BodySql,
+        };
+
+    private static async Task<SqlExecutionResult> ExecuteQueryAsync(Database db, string sql, CancellationToken ct)
+    {
+        await using var result = await db.ExecuteAsync(sql, ct);
+        var rows = await result.ToListAsync(ct);
+        return new SqlExecutionResult
+        {
+            IsQuery = result.IsQuery,
+            ColumnNames = result.IsQuery ? result.Schema.Select(column => column.Name).ToArray() : null,
+            Rows = result.IsQuery ? rows.Select(ToObjects).ToList() : null,
+            RowsAffected = result.IsQuery ? rows.Count : result.RowsAffected,
+        };
+    }
+
+    private static async Task ExecuteStatementAsync(Database db, string sql, CancellationToken ct)
+    {
+        await using var result = await db.ExecuteAsync(sql, ct);
+        if (result.IsQuery)
+            await result.ToListAsync(ct);
+    }
+
+    private static async Task<int> ExecuteNonQueryAsync(Database db, string sql, CancellationToken ct)
+    {
+        await using var result = await db.ExecuteAsync(sql, ct);
+        if (result.IsQuery)
+            await result.ToListAsync(ct);
+        return result.RowsAffected;
+    }
+
+    private static async Task ExecuteInSingleTransactionAsync(Database db, CancellationToken ct, params string[] statements)
+    {
+        await db.BeginTransactionAsync(ct);
+        try
+        {
+            foreach (string statement in statements)
+                await ExecuteStatementAsync(db, statement, ct);
+
+            await db.CommitAsync(ct);
+        }
+        catch
+        {
+            await db.RollbackAsync(ct);
+            throw;
+        }
+    }
+
+    private static TableBrowseResult PageTableResult(TableBrowseResult result, int page, int pageSize)
+    {
+        int normalizedPage = NormalizePage(page);
+        int normalizedPageSize = NormalizePageSize(pageSize);
+        int skip = (normalizedPage - 1) * normalizedPageSize;
+
+        return new TableBrowseResult
+        {
+            TableName = result.TableName,
+            Schema = result.Schema,
+            Rows = result.Rows.Skip(skip).Take(normalizedPageSize).ToList(),
+            TotalRows = result.Rows.Count,
+            Page = normalizedPage,
+            PageSize = normalizedPageSize,
+        };
+    }
+
+    private static ViewBrowseResult PageViewResult(ViewBrowseResult result, int page, int pageSize)
+    {
+        int normalizedPage = NormalizePage(page);
+        int normalizedPageSize = NormalizePageSize(pageSize);
+        int skip = (normalizedPage - 1) * normalizedPageSize;
+
+        return new ViewBrowseResult
+        {
+            ViewName = result.ViewName,
+            ColumnNames = result.ColumnNames,
+            Rows = result.Rows.Skip(skip).Take(normalizedPageSize).ToList(),
+            TotalRows = result.Rows.Count,
+            Page = normalizedPage,
+            PageSize = normalizedPageSize,
+        };
+    }
+
+    private static async Task<TableBrowseResult> BrowseTableInternalAsync(Database db, string tableName, CancellationToken ct)
+    {
+        string normalizedTableName = RequireIdentifier(tableName, nameof(tableName));
+        var schema = db.GetTableSchema(normalizedTableName);
+        if (schema is null || IsInternalTable(normalizedTableName))
+            throw new CSharpDbClientException($"Table '{normalizedTableName}' was not found.");
+
+        var query = await ExecuteQueryAsync(db, $"SELECT * FROM {normalizedTableName}", ct);
+        return new TableBrowseResult
+        {
+            TableName = normalizedTableName,
+            Schema = MapTableSchema(schema),
+            Rows = query.Rows ?? [],
+            TotalRows = query.Rows?.Count ?? 0,
+            Page = 1,
+            PageSize = Math.Max(query.Rows?.Count ?? 0, 1),
+        };
+    }
+
+    private static Dictionary<string, object?> ToRowDictionary(CoreColumnDefinition[] schema, CSharpDB.Core.DbValue[] row)
+    {
+        var values = new Dictionary<string, object?>(schema.Length, StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < schema.Length && i < row.Length; i++)
+            values[schema[i].Name] = ToObject(row[i]);
+        return values;
+    }
+
+    private static List<object?[]> ToObjects(List<CSharpDB.Core.DbValue[]> rows)
+        => rows.Select(ToObjects).ToList();
+
+    private static object?[] ToObjects(CSharpDB.Core.DbValue[] row)
+    {
+        var values = new object?[row.Length];
+        for (int i = 0; i < row.Length; i++)
+            values[i] = ToObject(row[i]);
+        return values;
+    }
+
+    private static object? ToObject(CSharpDB.Core.DbValue value) => value.Type switch
+    {
+        CoreDbType.Null => null,
+        CoreDbType.Integer => value.AsInteger,
+        CoreDbType.Real => value.AsReal,
+        CoreDbType.Text => value.AsText,
+        CoreDbType.Blob => value.AsBlob,
+        _ => throw new CSharpDbClientException($"Unsupported DbValue type '{value.Type}'."),
+    };
+
+    private static bool ValuesEqual(CSharpDB.Core.DbValue value, object candidate)
+    {
+        object? normalized = NormalizeValue(candidate);
+        if (normalized is null)
+            return value.Type == CoreDbType.Null;
+
+        return value.Type switch
+        {
+            CoreDbType.Integer when normalized is long integer => value.AsInteger == integer,
+            CoreDbType.Real when normalized is double real => Math.Abs(value.AsReal - real) < double.Epsilon,
+            CoreDbType.Text when normalized is string text => string.Equals(value.AsText, text, StringComparison.Ordinal),
+            CoreDbType.Blob when normalized is byte[] blob => value.AsBlob.AsSpan().SequenceEqual(blob),
+            CoreDbType.Integer when normalized is double real => Math.Abs(value.AsReal - real) < double.Epsilon,
+            CoreDbType.Real when normalized is long integer => Math.Abs(value.AsReal - integer) < double.Epsilon,
+            _ => false,
+        };
+    }
+
+    private static object? NormalizeValue(object? value) => value switch
+    {
+        null => null,
+        JsonElement json => NormalizeJsonElement(json),
+        bool boolean => boolean ? 1L : 0L,
+        byte or sbyte or short or ushort or int or uint or long => Convert.ToInt64(value, CultureInfo.InvariantCulture),
+        float or double or decimal => Convert.ToDouble(value, CultureInfo.InvariantCulture),
+        string text => text,
+        byte[] blob => blob,
+        _ => Convert.ToString(value, CultureInfo.InvariantCulture),
+    };
+
+    private static object? NormalizeJsonElement(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.Null => null,
+        JsonValueKind.String => value.GetString(),
+        JsonValueKind.False => 0L,
+        JsonValueKind.True => 1L,
+        JsonValueKind.Number when value.TryGetInt64(out long integer) => integer,
+        JsonValueKind.Number => value.GetDouble(),
+        _ => value.GetRawText(),
+    };
+
+    private static string FormatSqlLiteral(object? value)
+    {
+        object? normalized = NormalizeValue(value);
+        return normalized switch
+        {
+            null => "NULL",
+            long integer => integer.ToString(CultureInfo.InvariantCulture),
+            double real => real.ToString(CultureInfo.InvariantCulture),
+            string text => $"'{text.Replace("'", "''", StringComparison.Ordinal)}'",
+            byte[] => throw new CSharpDbClientException("BLOB literals are not supported by the engine-only client."),
+            _ => $"'{Convert.ToString(normalized, CultureInfo.InvariantCulture)?.Replace("'", "''", StringComparison.Ordinal) ?? string.Empty}'",
+        };
+    }
+
+    private static string RequireIdentifier(string value, string paramName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value, paramName);
+        if (!s_identifierPattern.IsMatch(value))
+            throw new CSharpDbClientException($"Identifier '{value}' is not supported by the engine-only client.");
+        return value;
+    }
+
+    private static bool IsInternalTable(string tableName)
+        => tableName.StartsWith(CollectionPrefix, StringComparison.Ordinal)
+           || string.Equals(tableName, ProcedureTableName, StringComparison.OrdinalIgnoreCase)
+           || string.Equals(tableName, SavedQueryTableName, StringComparison.OrdinalIgnoreCase);
+
+    private static int NormalizePage(int page) => page < 1 ? 1 : page;
+
+    private static int NormalizePageSize(int pageSize)
+    {
+        if (pageSize < 1)
+            return 50;
+        return Math.Min(pageSize, 1000);
+    }
+
+    private static string BuildCreateIndexSql(string indexName, string tableName, string columnName, bool isUnique)
+    {
+        string unique = isUnique ? "UNIQUE " : string.Empty;
+        return $"CREATE {unique}INDEX {RequireIdentifier(indexName, nameof(indexName))} ON {RequireIdentifier(tableName, nameof(tableName))} ({RequireIdentifier(columnName, nameof(columnName))})";
+    }
+
+    private static string BuildCreateTriggerSql(string triggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql)
+    {
+        string normalizedBody = NormalizeEmbeddedSql(bodySql);
+        return $"CREATE TRIGGER {RequireIdentifier(triggerName, nameof(triggerName))} {timing.ToString().ToUpperInvariant()} {triggerEvent.ToString().ToUpperInvariant()} ON {RequireIdentifier(tableName, nameof(tableName))} BEGIN {normalizedBody}; END";
+    }
+
+    private static string NormalizeEmbeddedSql(string sql)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sql);
+        return sql.Trim().TrimEnd(';');
+    }
+
+    private static string MapDbType(Models.DbType type) => type switch
+    {
+        Models.DbType.Integer => "INTEGER",
+        Models.DbType.Real => "REAL",
+        Models.DbType.Text => "TEXT",
+        Models.DbType.Blob => "BLOB",
+        _ => throw new CSharpDbClientException($"Unsupported DbType '{type}'."),
+    };
+
+    private Database GetTransactionDatabase(string transactionId)
+    {
+        if (!_transactions.TryGetValue(transactionId, out var db))
+            throw new CSharpDbClientException($"Transaction '{transactionId}' was not found.");
+        return db;
+    }
+
+    private Database TakeTransactionDatabase(string transactionId)
+    {
+        if (!_transactions.TryRemove(transactionId, out var db))
+            throw new CSharpDbClientException($"Transaction '{transactionId}' was not found.");
+        return db;
+    }
+}

--- a/src/CSharpDB.Client/Internal/IEngineBackedClient.cs
+++ b/src/CSharpDB.Client/Internal/IEngineBackedClient.cs
@@ -1,0 +1,8 @@
+using CSharpDB.Engine;
+
+namespace CSharpDB.Client.Internal;
+
+internal interface IEngineBackedClient
+{
+    ValueTask<Database?> TryGetDatabaseAsync(CancellationToken ct = default);
+}

--- a/src/CSharpDB.Client/Models/CollectionModels.cs
+++ b/src/CSharpDB.Client/Models/CollectionModels.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+
+namespace CSharpDB.Client.Models;
+
+public sealed class CollectionDocument
+{
+    public required string Key { get; init; }
+    public required JsonElement Document { get; init; }
+}
+
+public sealed class CollectionBrowseResult
+{
+    public required string CollectionName { get; init; }
+    public required IReadOnlyList<CollectionDocument> Documents { get; init; }
+    public required int TotalCount { get; init; }
+    public required int Page { get; init; }
+    public required int PageSize { get; init; }
+    public int TotalPages => Math.Max(1, (int)Math.Ceiling((double)TotalCount / PageSize));
+}

--- a/src/CSharpDB.Client/Models/DataModels.cs
+++ b/src/CSharpDB.Client/Models/DataModels.cs
@@ -1,0 +1,45 @@
+namespace CSharpDB.Client.Models;
+
+public sealed class TableBrowseResult
+{
+    public required string TableName { get; init; }
+    public required TableSchema Schema { get; init; }
+    public required List<object?[]> Rows { get; init; }
+    public required int TotalRows { get; init; }
+    public required int Page { get; init; }
+    public required int PageSize { get; init; }
+    public int TotalPages => Math.Max(1, (int)Math.Ceiling((double)TotalRows / PageSize));
+}
+
+public sealed class ViewBrowseResult
+{
+    public required string ViewName { get; init; }
+    public required string[] ColumnNames { get; init; }
+    public required List<object?[]> Rows { get; init; }
+    public required int TotalRows { get; init; }
+    public required int Page { get; init; }
+    public required int PageSize { get; init; }
+    public int TotalPages => Math.Max(1, (int)Math.Ceiling((double)TotalRows / PageSize));
+}
+
+public sealed class SqlExecutionResult
+{
+    public bool IsQuery { get; init; }
+    public string[]? ColumnNames { get; init; }
+    public List<object?[]>? Rows { get; init; }
+    public int RowsAffected { get; init; }
+    public string? Error { get; init; }
+    public TimeSpan Elapsed { get; init; }
+}
+
+public sealed class DatabaseInfo
+{
+    public required string DataSource { get; init; }
+    public int TableCount { get; init; }
+    public int IndexCount { get; init; }
+    public int ViewCount { get; init; }
+    public int TriggerCount { get; init; }
+    public int ProcedureCount { get; init; }
+    public int CollectionCount { get; init; }
+    public int SavedQueryCount { get; init; }
+}

--- a/src/CSharpDB.Client/Models/ProcedureModels.cs
+++ b/src/CSharpDB.Client/Models/ProcedureModels.cs
@@ -1,0 +1,51 @@
+namespace CSharpDB.Client.Models;
+
+public sealed class ProcedureDefinition
+{
+    public required string Name { get; init; }
+    public required string BodySql { get; init; }
+    public IReadOnlyList<ProcedureParameterDefinition> Parameters { get; init; } = [];
+    public string? Description { get; init; }
+    public bool IsEnabled { get; init; } = true;
+    public DateTime CreatedUtc { get; init; }
+    public DateTime UpdatedUtc { get; init; }
+}
+
+public sealed class ProcedureParameterDefinition
+{
+    public required string Name { get; init; }
+    public DbType Type { get; init; }
+    public bool Required { get; init; }
+    public object? Default { get; init; }
+    public string? Description { get; init; }
+}
+
+public sealed class ProcedureExecutionResult
+{
+    public required string ProcedureName { get; init; }
+    public bool Succeeded { get; init; }
+    public IReadOnlyList<ProcedureStatementExecutionResult> Statements { get; init; } = [];
+    public string? Error { get; init; }
+    public int? FailedStatementIndex { get; init; }
+    public TimeSpan Elapsed { get; init; }
+}
+
+public sealed class ProcedureStatementExecutionResult
+{
+    public int StatementIndex { get; init; }
+    public string StatementText { get; init; } = string.Empty;
+    public bool IsQuery { get; init; }
+    public string[]? ColumnNames { get; init; }
+    public List<object?[]>? Rows { get; init; }
+    public int RowsAffected { get; init; }
+    public TimeSpan Elapsed { get; init; }
+}
+
+public sealed class SavedQueryDefinition
+{
+    public long Id { get; init; }
+    public required string Name { get; init; }
+    public required string SqlText { get; init; }
+    public DateTime CreatedUtc { get; init; }
+    public DateTime UpdatedUtc { get; init; }
+}

--- a/src/CSharpDB.Client/Models/SchemaModels.cs
+++ b/src/CSharpDB.Client/Models/SchemaModels.cs
@@ -1,0 +1,60 @@
+namespace CSharpDB.Client.Models;
+
+public enum DbType
+{
+    Integer,
+    Real,
+    Text,
+    Blob,
+}
+
+public sealed class ColumnDefinition
+{
+    public required string Name { get; init; }
+    public required DbType Type { get; init; }
+    public bool Nullable { get; init; } = true;
+    public bool IsPrimaryKey { get; init; }
+    public bool IsIdentity { get; init; }
+}
+
+public sealed class TableSchema
+{
+    public required string TableName { get; init; }
+    public required IReadOnlyList<ColumnDefinition> Columns { get; init; }
+}
+
+public sealed class IndexSchema
+{
+    public required string IndexName { get; init; }
+    public required string TableName { get; init; }
+    public required IReadOnlyList<string> Columns { get; init; }
+    public bool IsUnique { get; init; }
+}
+
+public sealed class ViewDefinition
+{
+    public required string Name { get; init; }
+    public required string Sql { get; init; }
+}
+
+public enum TriggerTiming
+{
+    Before,
+    After,
+}
+
+public enum TriggerEvent
+{
+    Insert,
+    Update,
+    Delete,
+}
+
+public sealed class TriggerSchema
+{
+    public required string TriggerName { get; init; }
+    public required string TableName { get; init; }
+    public required TriggerTiming Timing { get; init; }
+    public required TriggerEvent Event { get; init; }
+    public required string BodySql { get; init; }
+}

--- a/src/CSharpDB.Client/Models/TransactionModels.cs
+++ b/src/CSharpDB.Client/Models/TransactionModels.cs
@@ -1,0 +1,7 @@
+namespace CSharpDB.Client.Models;
+
+public sealed class TransactionSessionInfo
+{
+    public required string TransactionId { get; init; }
+    public required DateTime ExpiresAtUtc { get; init; }
+}

--- a/src/CSharpDB.Client/Properties/AssemblyInfo.cs
+++ b/src/CSharpDB.Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("csharpdb")]
+[assembly: InternalsVisibleTo("CSharpDB.Cli.Tests")]

--- a/src/CSharpDB.Client/README.md
+++ b/src/CSharpDB.Client/README.md
@@ -1,0 +1,103 @@
+# CSharpDB.Client
+
+`CSharpDB.Client` is the authoritative database API for CSharpDB.
+
+It owns the public client contract used to talk to a database, while transport and lower-level implementation details stay behind that boundary.
+
+## Current Direction
+
+- `CSharpDB.Client` is now the real implementation layer for database access.
+- `CSharpDB.Service` is a compatibility facade over the client while the repo retires direct service usage.
+- The current transport implementation is direct/local.
+- `Http`, `Grpc`, `Tcp`, and `NamedPipes` are part of the public client transport model, but only `Direct` is implemented today.
+
+## Current Transport Model
+
+Create the client with `CSharpDbClientOptions`:
+
+```csharp
+var client = CSharpDbClient.Create(new CSharpDbClientOptions
+{
+    Transport = CSharpDbTransport.Direct,
+    DataSource = "csharpdb.db"
+});
+```
+
+The transport can be selected explicitly with `Transport`. If it is omitted, the client infers it from `Endpoint` and otherwise defaults to direct.
+
+Direct resolution currently accepts:
+
+- `Endpoint` as a file path
+- `Endpoint` as `file://...`
+- `DataSource`
+- `ConnectionString` containing `Data Source=...`
+
+Resolution rules:
+
+- direct is the default when transport cannot be inferred from a network endpoint
+- supplied direct inputs must resolve to the same target
+- `http://` and `https://` infer `Http` unless `Transport = CSharpDbTransport.Grpc` is set explicitly
+- `tcp://`, `pipe://`, and `npipe://` infer their corresponding future transport
+- `Http`, `Grpc`, `Tcp`, and `NamedPipes` validate their endpoint shape and then fail with a not-implemented error for now
+- `HttpClient` is reserved for future `Http` and `Grpc` transports
+
+Example gRPC selection:
+
+```csharp
+var client = CSharpDbClient.Create(new CSharpDbClientOptions
+{
+    Transport = CSharpDbTransport.Grpc,
+    Endpoint = "https://localhost:5001"
+});
+```
+
+This currently fails with a transport-not-implemented error because the repo does not yet expose a gRPC server transport.
+
+## Supported Surface
+
+The current `ICSharpDbClient` includes:
+
+- database info and data source metadata
+- tables, schemas, row counts, browse, and primary-key lookup
+- row insert, update, and delete
+- table and column DDL
+- indexes, views, and triggers
+- saved queries
+- procedures and procedure execution
+- SQL execution with multi-statement splitting
+- client-managed transaction sessions
+- document collections
+- checkpoint
+- storage diagnostics
+
+## Implementation Notes
+
+- The direct client depends on `CSharpDB.Engine`, `CSharpDB.Sql`, and `CSharpDB.Storage.Diagnostics`.
+- `CSharpDB.Client` does not reference `CSharpDB.Data`.
+- Schema, data, procedure, and saved-query operations all run through direct engine access.
+- Collection access and client-managed transaction sessions use direct engine instances.
+- Internal tables such as `__procedures`, `__saved_queries`, and collection backing tables are hidden from normal table listing.
+
+## Dependency Injection
+
+```csharp
+services.AddCSharpDbClient(new CSharpDbClientOptions
+{
+    DataSource = "csharpdb.db"
+});
+```
+
+or
+
+```csharp
+services.AddCSharpDbClient(sp => new CSharpDbClientOptions
+{
+    ConnectionString = "Data Source=csharpdb.db"
+});
+```
+
+## Design Rule
+
+New database-facing functionality should be added here first.
+
+Host-specific concerns should not create a second authoritative API beside `CSharpDB.Client`.

--- a/src/CSharpDB.Client/ServiceCollectionExtensions.cs
+++ b/src/CSharpDB.Client/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CSharpDB.Client;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddCSharpDbClient(
+        this IServiceCollection services,
+        CSharpDbClientOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(options);
+
+        services.AddSingleton(options);
+        services.AddSingleton<ICSharpDbClient>(_ => CSharpDbClient.Create(options));
+        return services;
+    }
+
+    public static IServiceCollection AddCSharpDbClient(
+        this IServiceCollection services,
+        Func<IServiceProvider, CSharpDbClientOptions> optionsFactory)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(optionsFactory);
+
+        services.AddSingleton<ICSharpDbClient>(sp => CSharpDbClient.Create(optionsFactory(sp)));
+        return services;
+    }
+}

--- a/src/CSharpDB.Core/CSharpDB.Core.csproj
+++ b/src/CSharpDB.Core/CSharpDB.Core.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <PackageId>CSharpDB.Primitives</PackageId>
     <Description>Internal/shared primitives for the CSharpDB package family: value system, schema definitions, and error codes.</Description>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/CSharpDB.Engine/CSharpDB.Engine.csproj
+++ b/src/CSharpDB.Engine/CSharpDB.Engine.csproj
@@ -18,6 +18,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Lightweight embedded SQL database engine for .NET. Single-file storage, WAL durability, concurrent readers, and a typed Collection&lt;T&gt; NoSQL API.</Description>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/CSharpDB.Engine/Collection.cs
+++ b/src/CSharpDB.Engine/Collection.cs
@@ -199,6 +199,8 @@ public sealed class Collection<T>
         return hash & 0x7FFFFFFFFFFFFFFF; // ensure positive
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Collection<T> JSON serialization requires reflection. Use SQL API for NativeAOT scenarios.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Collection<T> JSON serialization requires runtime code generation. Use SQL API for NativeAOT scenarios.")]
     private byte[] EncodeDocument(string key, T document)
     {
         string json = JsonSerializer.Serialize(document, s_jsonOptions);
@@ -206,6 +208,8 @@ public sealed class Collection<T>
         return _recordSerializer.Encode(values);
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Collection<T> JSON deserialization requires reflection. Use SQL API for NativeAOT scenarios.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Collection<T> JSON deserialization requires runtime code generation. Use SQL API for NativeAOT scenarios.")]
     private (string key, T document) DecodeDocument(ReadOnlySpan<byte> payload)
     {
         var values = _recordSerializer.Decode(payload);

--- a/src/CSharpDB.Execution/CSharpDB.Execution.csproj
+++ b/src/CSharpDB.Execution/CSharpDB.Execution.csproj
@@ -15,6 +15,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Query planner, operator tree, and expression evaluator for the CSharpDB embedded database.</Description>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/CSharpDB.Mcp/CSharpDB.Mcp.csproj
+++ b/src/CSharpDB.Mcp/CSharpDB.Mcp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CSharpDB.Service\CSharpDB.Service.csproj" />
+    <ProjectReference Include="..\CSharpDB.Client\CSharpDB.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CSharpDB.Mcp/Program.cs
+++ b/src/CSharpDB.Mcp/Program.cs
@@ -1,4 +1,4 @@
-using CSharpDB.Service;
+using CSharpDB.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -6,31 +6,67 @@ using ModelContextProtocol;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-// ─── Database path configuration ────────────────────────────────────
-// Priority: --database CLI arg > CSHARPDB_DATABASE env var > appsettings.json > default
+// ─── Client target configuration ────────────────────────────────────
+// Priority:
+//   endpoint: --endpoint CLI arg > CSHARPDB_ENDPOINT env var
+//   database: --database CLI arg > CSHARPDB_DATABASE env var > appsettings.json > default
+//   transport: --transport CLI arg > CSHARPDB_TRANSPORT env var
+string? endpoint = null;
 string? dbPath = null;
+CSharpDbTransport? transport = null;
 
 for (int i = 0; i < args.Length - 1; i++)
 {
     if (args[i] is "--database" or "-d")
     {
         dbPath = args[i + 1];
-        break;
+        continue;
+    }
+
+    if (args[i] is "--endpoint" or "-e")
+    {
+        endpoint = args[i + 1];
+        continue;
+    }
+
+    if (args[i] is "--transport" or "-t")
+    {
+        transport = ParseTransport(args[i + 1]);
     }
 }
 
+endpoint ??= Environment.GetEnvironmentVariable("CSHARPDB_ENDPOINT");
 dbPath ??= Environment.GetEnvironmentVariable("CSHARPDB_DATABASE");
-
-if (dbPath is not null)
-{
-    builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
-    {
-        ["ConnectionStrings:CSharpDB"] = $"Data Source={dbPath}",
-    });
-}
+transport ??= ParseTransport(Environment.GetEnvironmentVariable("CSHARPDB_TRANSPORT"));
 
 // ─── Services ───────────────────────────────────────────────────────
-builder.Services.AddSingleton<CSharpDbService>();
+builder.Services.AddCSharpDbClient(sp =>
+{
+    if (!string.IsNullOrWhiteSpace(endpoint))
+    {
+        return new CSharpDbClientOptions
+        {
+            Transport = transport,
+            Endpoint = endpoint,
+        };
+    }
+
+    if (!string.IsNullOrWhiteSpace(dbPath))
+    {
+        return new CSharpDbClientOptions
+        {
+            Transport = transport,
+            DataSource = dbPath,
+        };
+    }
+
+    return new CSharpDbClientOptions
+    {
+        Transport = transport,
+        ConnectionString = sp.GetRequiredService<IConfiguration>().GetConnectionString("CSharpDB")
+            ?? "Data Source=csharpdb.db",
+    };
+});
 
 builder.Services
     .AddMcpServer(options =>
@@ -47,7 +83,29 @@ builder.Services
 var host = builder.Build();
 
 // Initialize the database connection before accepting requests
-var dbService = host.Services.GetRequiredService<CSharpDbService>();
-await dbService.InitializeAsync();
+await using (var scope = host.Services.CreateAsyncScope())
+{
+    var dbClient = scope.ServiceProvider.GetRequiredService<ICSharpDbClient>();
+    _ = await dbClient.GetInfoAsync();
+}
 
 await host.RunAsync();
+
+static CSharpDbTransport? ParseTransport(string? value)
+{
+    if (string.IsNullOrWhiteSpace(value))
+        return null;
+
+    return value.Trim().ToLowerInvariant() switch
+    {
+        "direct" => CSharpDbTransport.Direct,
+        "http" => CSharpDbTransport.Http,
+        "grpc" => CSharpDbTransport.Grpc,
+        "tcp" => CSharpDbTransport.Tcp,
+        "namedpipes" => CSharpDbTransport.NamedPipes,
+        "named-pipes" => CSharpDbTransport.NamedPipes,
+        "npipe" => CSharpDbTransport.NamedPipes,
+        "pipe" => CSharpDbTransport.NamedPipes,
+        _ => throw new InvalidOperationException($"Unsupported transport '{value}'."),
+    };
+}

--- a/src/CSharpDB.Mcp/Tools/DataTools.cs
+++ b/src/CSharpDB.Mcp/Tools/DataTools.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
+using CSharpDB.Client;
 using CSharpDB.Mcp.Helpers;
-using CSharpDB.Service;
 using ModelContextProtocol.Server;
 
 namespace CSharpDB.Mcp.Tools;
@@ -11,7 +11,7 @@ public static class DataTools
     [McpServerTool, Description(
         "Browse rows in a table with pagination. Returns rows, schema, and total count.")]
     public static async Task<string> BrowseTable(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("Name of the table to browse.")] string tableName,
         [Description("Page number (1-based). Defaults to 1.")] int page = 1,
         [Description("Rows per page. Defaults to 50.")] int pageSize = 50)
@@ -42,7 +42,7 @@ public static class DataTools
     [McpServerTool, Description(
         "Browse rows in a view with pagination. Returns rows and total count.")]
     public static async Task<string> BrowseView(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("Name of the view to browse.")] string viewName,
         [Description("Page number (1-based). Defaults to 1.")] int page = 1,
         [Description("Rows per page. Defaults to 50.")] int pageSize = 50)
@@ -63,7 +63,7 @@ public static class DataTools
 
     [McpServerTool, Description("Get a single row by primary key value.")]
     public static async Task<string> GetRowByPk(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("Name of the table.")] string tableName,
         [Description("Name of the primary key column.")] string pkColumn,
         [Description("Primary key value to look up.")] string pkValue)
@@ -80,7 +80,7 @@ public static class DataTools
 
     [McpServerTool, Description("Get the total number of rows in a table.")]
     public static async Task<string> GetRowCount(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("Name of the table.")] string tableName)
     {
         int count = await db.GetRowCountAsync(tableName);

--- a/src/CSharpDB.Mcp/Tools/MutationTools.cs
+++ b/src/CSharpDB.Mcp/Tools/MutationTools.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
+using CSharpDB.Client;
 using CSharpDB.Mcp.Helpers;
-using CSharpDB.Service;
 using ModelContextProtocol.Server;
 
 namespace CSharpDB.Mcp.Tools;
@@ -11,7 +11,7 @@ public static class MutationTools
     [McpServerTool, Description(
         "Insert a row into a table. Pass column values as a JSON object string.")]
     public static async Task<string> InsertRow(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("Name of the table.")] string tableName,
         [Description("JSON object with column names as keys and values, e.g. {\"name\":\"Alice\",\"age\":30}.")] string valuesJson)
     {
@@ -30,7 +30,7 @@ public static class MutationTools
     [McpServerTool, Description(
         "Update a row in a table by primary key. Pass new column values as a JSON object string.")]
     public static async Task<string> UpdateRow(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("Name of the table.")] string tableName,
         [Description("Name of the primary key column.")] string pkColumn,
         [Description("Primary key value of the row to update.")] string pkValue,
@@ -51,7 +51,7 @@ public static class MutationTools
 
     [McpServerTool, Description("Delete a row from a table by primary key.")]
     public static async Task<string> DeleteRow(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("Name of the table.")] string tableName,
         [Description("Name of the primary key column.")] string pkColumn,
         [Description("Primary key value of the row to delete.")] string pkValue)

--- a/src/CSharpDB.Mcp/Tools/SchemaTools.cs
+++ b/src/CSharpDB.Mcp/Tools/SchemaTools.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
+using CSharpDB.Client;
 using CSharpDB.Mcp.Helpers;
-using CSharpDB.Service;
 using ModelContextProtocol.Server;
 
 namespace CSharpDB.Mcp.Tools;
@@ -9,13 +9,13 @@ namespace CSharpDB.Mcp.Tools;
 public static class SchemaTools
 {
     [McpServerTool, Description("Get the database file path and basic info.")]
-    public static string GetDatabaseInfo(CSharpDbService db)
+    public static string GetDatabaseInfo(ICSharpDbClient db)
     {
         return JsonHelper.Serialize(new { dataSource = db.DataSource });
     }
 
     [McpServerTool, Description("List all table names in the database.")]
-    public static async Task<string> ListTables(CSharpDbService db)
+    public static async Task<string> ListTables(ICSharpDbClient db)
     {
         var tables = await db.GetTableNamesAsync();
         return JsonHelper.Serialize(tables);
@@ -24,7 +24,7 @@ public static class SchemaTools
     [McpServerTool, Description(
         "Get the schema (columns, types, constraints) of a table.")]
     public static async Task<string> DescribeTable(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("Name of the table to describe.")] string tableName)
     {
         var schema = await db.GetTableSchemaAsync(tableName);
@@ -44,7 +44,7 @@ public static class SchemaTools
     }
 
     [McpServerTool, Description("List all indexes in the database with their table, columns, and uniqueness.")]
-    public static async Task<string> ListIndexes(CSharpDbService db)
+    public static async Task<string> ListIndexes(ICSharpDbClient db)
     {
         var indexes = await db.GetIndexesAsync();
         var result = indexes.Select(i => new
@@ -58,7 +58,7 @@ public static class SchemaTools
     }
 
     [McpServerTool, Description("List all view names in the database.")]
-    public static async Task<string> ListViews(CSharpDbService db)
+    public static async Task<string> ListViews(ICSharpDbClient db)
     {
         var views = await db.GetViewsAsync();
         var result = views.Select(v => new
@@ -70,7 +70,7 @@ public static class SchemaTools
     }
 
     [McpServerTool, Description("List all triggers in the database with their table, timing, event, and body.")]
-    public static async Task<string> ListTriggers(CSharpDbService db)
+    public static async Task<string> ListTriggers(ICSharpDbClient db)
     {
         var triggers = await db.GetTriggersAsync();
         var result = triggers.Select(t => new

--- a/src/CSharpDB.Mcp/Tools/SqlTools.cs
+++ b/src/CSharpDB.Mcp/Tools/SqlTools.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
+using CSharpDB.Client;
 using CSharpDB.Mcp.Helpers;
-using CSharpDB.Service;
 using ModelContextProtocol.Server;
 
 namespace CSharpDB.Mcp.Tools;
@@ -14,7 +14,7 @@ public static class SqlTools
         "ALTER TABLE, DROP, INSERT, UPDATE, DELETE, and any other SQL statement. " +
         "Returns query results for SELECT or rows-affected count for DML/DDL.")]
     public static async Task<string> ExecuteSql(
-        CSharpDbService db,
+        ICSharpDbClient db,
         [Description("The SQL statement to execute.")] string sql)
     {
         var result = await db.ExecuteSqlAsync(sql);

--- a/src/CSharpDB.Native/BlobCache.cs
+++ b/src/CSharpDB.Native/BlobCache.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+
+namespace CSharpDB.Native;
+
+/// <summary>
+/// Manages unmanaged blob pointers returned to foreign callers.
+/// Blob data for the current row is pinned and freed on the next row advance or result free.
+/// </summary>
+internal static class BlobCache
+{
+    private static readonly ConcurrentDictionary<(IntPtr, int), GCHandle> s_pinnedBlobs = new();
+
+    /// <summary>
+    /// Pin the blob byte array and return a pointer to its data.
+    /// Frees any previously pinned blob for the same (result, column).
+    /// </summary>
+    public static IntPtr SetCurrentRowBlob(IntPtr resultHandle, int columnIndex, byte[] data)
+    {
+        var key = (resultHandle, columnIndex);
+
+        // Free previous pinned blob for this slot
+        if (s_pinnedBlobs.TryRemove(key, out var oldHandle))
+            oldHandle.Free();
+
+        var pinned = GCHandle.Alloc(data, GCHandleType.Pinned);
+        s_pinnedBlobs[key] = pinned;
+        return pinned.AddrOfPinnedObject();
+    }
+
+    /// <summary>
+    /// Free all pinned blobs associated with a result handle.
+    /// </summary>
+    public static void Remove(IntPtr resultHandle)
+    {
+        foreach (var key in s_pinnedBlobs.Keys)
+        {
+            if (key.Item1 == resultHandle && s_pinnedBlobs.TryRemove(key, out var handle))
+                handle.Free();
+        }
+    }
+}

--- a/src/CSharpDB.Native/CSharpDB.Native.csproj
+++ b/src/CSharpDB.Native/CSharpDB.Native.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    This project requires NativeAOT tooling (C++ linker / clang) to publish.
+    It is excluded from the default solution build so that cloning and building
+    the repo works without extra prerequisites.
+
+    Build this project explicitly:
+      dotnet build  src/CSharpDB.Native/CSharpDB.Native.csproj
+      dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r win-x64
+
+    Or include it in a solution build by passing -p:BuildNative=true:
+      dotnet build CSharpDB.slnx -p:BuildNative=true
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <OutputType>Library</OutputType>
+    <Description>NativeAOT shared library exposing CSharpDB as a C-compatible API for cross-language consumption via FFI.</Description>
+    <!-- Produce a shared library (.dll/.so/.dylib) instead of an executable -->
+    <NativeLib>Shared</NativeLib>
+    <!-- Strip symbols for smaller binary in release -->
+    <StripSymbols>true</StripSymbols>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpDB.Engine\CSharpDB.Engine.csproj" />
+    <ProjectReference Include="..\CSharpDB.Execution\CSharpDB.Execution.csproj" />
+    <ProjectReference Include="..\CSharpDB.Core\CSharpDB.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CSharpDB.Native/CSharpDB.Native.csproj
+++ b/src/CSharpDB.Native/CSharpDB.Native.csproj
@@ -28,6 +28,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="CSharpDB.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CSharpDB.Engine\CSharpDB.Engine.csproj" />
     <ProjectReference Include="..\CSharpDB.Execution\CSharpDB.Execution.csproj" />
     <ProjectReference Include="..\CSharpDB.Core\CSharpDB.Core.csproj" />

--- a/src/CSharpDB.Native/ErrorState.cs
+++ b/src/CSharpDB.Native/ErrorState.cs
@@ -1,0 +1,60 @@
+using System.Runtime.InteropServices;
+using CSharpDB.Core;
+
+namespace CSharpDB.Native;
+
+/// <summary>
+/// Thread-local error state for the native API.
+/// Follows the errno/GetLastError pattern: the last error is stored per-thread
+/// and can be retrieved after any API call that returns an error indicator.
+/// </summary>
+internal static class ErrorState
+{
+    [ThreadStatic]
+    private static string? t_message;
+
+    [ThreadStatic]
+    private static int t_code;
+
+    [ThreadStatic]
+    private static IntPtr t_messagePtr;
+
+    public static void Set(Exception ex)
+    {
+        t_message = ex.Message;
+        t_code = ex is CSharpDbException cex ? (int)cex.Code : -1;
+
+        // Free previous unmanaged string if any
+        if (t_messagePtr != IntPtr.Zero)
+        {
+            Marshal.FreeHGlobal(t_messagePtr);
+            t_messagePtr = IntPtr.Zero;
+        }
+    }
+
+    public static IntPtr GetMessagePtr()
+    {
+        if (t_message == null)
+            return IntPtr.Zero;
+
+        // Lazily allocate the unmanaged string
+        if (t_messagePtr == IntPtr.Zero)
+            t_messagePtr = Marshal.StringToHGlobalAnsi(t_message);
+
+        return t_messagePtr;
+    }
+
+    public static int GetCode() => t_code;
+
+    public static void Clear()
+    {
+        t_message = null;
+        t_code = 0;
+
+        if (t_messagePtr != IntPtr.Zero)
+        {
+            Marshal.FreeHGlobal(t_messagePtr);
+            t_messagePtr = IntPtr.Zero;
+        }
+    }
+}

--- a/src/CSharpDB.Native/ErrorState.cs
+++ b/src/CSharpDB.Native/ErrorState.cs
@@ -39,7 +39,7 @@ internal static class ErrorState
 
         // Lazily allocate the unmanaged string
         if (t_messagePtr == IntPtr.Zero)
-            t_messagePtr = Marshal.StringToHGlobalAnsi(t_message);
+            t_messagePtr = Utf8StringMemory.Allocate(t_message);
 
         return t_messagePtr;
     }

--- a/src/CSharpDB.Native/HandleTable.cs
+++ b/src/CSharpDB.Native/HandleTable.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+
+namespace CSharpDB.Native;
+
+/// <summary>
+/// Maps opaque IntPtr handles to managed objects via GCHandle.
+/// This prevents the GC from collecting objects while foreign code holds a reference.
+/// </summary>
+internal static class HandleTable
+{
+    /// <summary>
+    /// Pin a managed object and return an opaque handle.
+    /// </summary>
+    public static IntPtr Alloc(object obj)
+    {
+        var handle = GCHandle.Alloc(obj);
+        return GCHandle.ToIntPtr(handle);
+    }
+
+    /// <summary>
+    /// Retrieve the managed object behind an opaque handle.
+    /// </summary>
+    public static T Get<T>(IntPtr ptr) where T : class
+    {
+        var handle = GCHandle.FromIntPtr(ptr);
+        return (T)handle.Target!;
+    }
+
+    /// <summary>
+    /// Free a handle, allowing the managed object to be collected.
+    /// </summary>
+    public static void Free(IntPtr ptr)
+    {
+        var handle = GCHandle.FromIntPtr(ptr);
+        handle.Free();
+    }
+}

--- a/src/CSharpDB.Native/NativeExports.cs
+++ b/src/CSharpDB.Native/NativeExports.cs
@@ -1,0 +1,427 @@
+using System.Runtime.InteropServices;
+using CSharpDB.Core;
+using CSharpDB.Engine;
+using CSharpDB.Execution;
+
+namespace CSharpDB.Native;
+
+/// <summary>
+/// C-compatible entry points exported from the NativeAOT shared library.
+/// Every public method marked [UnmanagedCallersOnly] becomes a symbol in
+/// the resulting .dll / .so / .dylib that any language can call via FFI.
+///
+/// Handles are opaque IntPtr wrappers around GCHandle, preventing the GC
+/// from collecting managed objects while foreign code holds a reference.
+/// </summary>
+public static class NativeExports
+{
+    // ================================================================
+    //  Database lifecycle
+    // ================================================================
+
+    /// <summary>
+    /// Open or create a database file.
+    /// Returns an opaque database handle, or IntPtr.Zero on error
+    /// (call csharpdb_last_error for details).
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_open")]
+    public static IntPtr Open(IntPtr pathPtr)
+    {
+        try
+        {
+            string path = Marshal.PtrToStringUTF8(pathPtr)!;
+            var db = Database.OpenAsync(path).AsTask().GetAwaiter().GetResult();
+            return HandleTable.Alloc(db);
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Close a database and free its handle. Safe to call with IntPtr.Zero.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_close")]
+    public static void Close(IntPtr dbHandle)
+    {
+        if (dbHandle == IntPtr.Zero) return;
+
+        try
+        {
+            var db = HandleTable.Get<Database>(dbHandle);
+            db.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            HandleTable.Free(dbHandle);
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+        }
+    }
+
+    // ================================================================
+    //  SQL execution
+    // ================================================================
+
+    /// <summary>
+    /// Execute a SQL statement. Returns a result handle.
+    /// For DML/DDL the result contains rows-affected count.
+    /// For SELECT the result contains rows that must be iterated.
+    /// Returns IntPtr.Zero on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_execute")]
+    public static IntPtr Execute(IntPtr dbHandle, IntPtr sqlPtr)
+    {
+        try
+        {
+            var db = HandleTable.Get<Database>(dbHandle);
+            string sql = Marshal.PtrToStringUTF8(sqlPtr)!;
+            var result = db.ExecuteAsync(sql).AsTask().GetAwaiter().GetResult();
+            return HandleTable.Alloc(result);
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return IntPtr.Zero;
+        }
+    }
+
+    // ================================================================
+    //  Result navigation
+    // ================================================================
+
+    /// <summary>
+    /// Returns 1 if the result is a query (SELECT), 0 otherwise.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_is_query")]
+    public static int ResultIsQuery(IntPtr resultHandle)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            return result.IsQuery ? 1 : 0;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of rows affected by a DML/DDL statement.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_rows_affected")]
+    public static int ResultRowsAffected(IntPtr resultHandle)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            return result.RowsAffected;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of columns in the result schema.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_column_count")]
+    public static int ResultColumnCount(IntPtr resultHandle)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            return result.Schema.Length;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Returns the name of a column by index. Caller must NOT free the pointer.
+    /// The string is valid until the result is freed.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_column_name")]
+    public static IntPtr ResultColumnName(IntPtr resultHandle, int columnIndex)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            if (columnIndex < 0 || columnIndex >= result.Schema.Length)
+                return IntPtr.Zero;
+
+            string name = result.Schema[columnIndex].Name;
+            return StringCache.GetOrAdd(resultHandle, columnIndex, name);
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Advance to the next row. Returns 1 if a row is available, 0 at end, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_next")]
+    public static int ResultNext(IntPtr resultHandle)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            bool hasRow = result.MoveNextAsync().AsTask().GetAwaiter().GetResult();
+            return hasRow ? 1 : 0;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Returns the DbType of the value at the given column in the current row.
+    /// 0=Null, 1=Integer, 2=Real, 3=Text, 4=Blob. Returns -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_column_type")]
+    public static int ResultColumnType(IntPtr resultHandle, int columnIndex)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            var row = result.Current;
+            if (columnIndex < 0 || columnIndex >= row.Length)
+                return -1;
+            return (int)row[columnIndex].Type;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Returns 1 if the column value is NULL, 0 otherwise.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_is_null")]
+    public static int ResultIsNull(IntPtr resultHandle, int columnIndex)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            var row = result.Current;
+            if (columnIndex < 0 || columnIndex >= row.Length)
+                return 1;
+            return row[columnIndex].IsNull ? 1 : 0;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Read an integer value from the current row at the given column index.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_get_int64")]
+    public static long ResultGetInt64(IntPtr resultHandle, int columnIndex)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            return result.Current[columnIndex].AsInteger;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Read a real (double) value from the current row at the given column index.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_get_double")]
+    public static double ResultGetDouble(IntPtr resultHandle, int columnIndex)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            return result.Current[columnIndex].AsReal;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return 0.0;
+        }
+    }
+
+    /// <summary>
+    /// Read a text value from the current row. Returns a UTF-8 string pointer.
+    /// The pointer is valid until the next call to csharpdb_result_next or csharpdb_result_free.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_get_text")]
+    public static IntPtr ResultGetText(IntPtr resultHandle, int columnIndex)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            string text = result.Current[columnIndex].AsText;
+            return StringCache.SetCurrentRowText(resultHandle, columnIndex, text);
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Read a blob value from the current row. Writes the blob size to outSize.
+    /// Returns a pointer to the blob data. Valid until next row or result free.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_get_blob")]
+    public static IntPtr ResultGetBlob(IntPtr resultHandle, int columnIndex, IntPtr outSize)
+    {
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            byte[] blob = result.Current[columnIndex].AsBlob;
+            if (outSize != IntPtr.Zero)
+                Marshal.WriteInt32(outSize, blob.Length);
+            return BlobCache.SetCurrentRowBlob(resultHandle, columnIndex, blob);
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            if (outSize != IntPtr.Zero)
+                Marshal.WriteInt32(outSize, 0);
+            return IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Free a result handle. Safe to call with IntPtr.Zero.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_result_free")]
+    public static void ResultFree(IntPtr resultHandle)
+    {
+        if (resultHandle == IntPtr.Zero) return;
+
+        try
+        {
+            var result = HandleTable.Get<QueryResult>(resultHandle);
+            result.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            StringCache.Remove(resultHandle);
+            BlobCache.Remove(resultHandle);
+            HandleTable.Free(resultHandle);
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+        }
+    }
+
+    // ================================================================
+    //  Transactions
+    // ================================================================
+
+    /// <summary>
+    /// Begin an explicit transaction. Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_begin")]
+    public static int Begin(IntPtr dbHandle)
+    {
+        try
+        {
+            var db = HandleTable.Get<Database>(dbHandle);
+            db.BeginTransactionAsync().AsTask().GetAwaiter().GetResult();
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Commit the current transaction. Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_commit")]
+    public static int Commit(IntPtr dbHandle)
+    {
+        try
+        {
+            var db = HandleTable.Get<Database>(dbHandle);
+            db.CommitAsync().AsTask().GetAwaiter().GetResult();
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// Rollback the current transaction. Returns 0 on success, -1 on error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_rollback")]
+    public static int Rollback(IntPtr dbHandle)
+    {
+        try
+        {
+            var db = HandleTable.Get<Database>(dbHandle);
+            db.RollbackAsync().AsTask().GetAwaiter().GetResult();
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            ErrorState.Set(ex);
+            return -1;
+        }
+    }
+
+    // ================================================================
+    //  Error reporting
+    // ================================================================
+
+    /// <summary>
+    /// Returns the last error message as a UTF-8 string, or IntPtr.Zero if no error.
+    /// The pointer is valid until the next API call on the same thread.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_last_error")]
+    public static IntPtr LastError()
+    {
+        return ErrorState.GetMessagePtr();
+    }
+
+    /// <summary>
+    /// Returns the last error code. 0 = no error.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_last_error_code")]
+    public static int LastErrorCode()
+    {
+        return ErrorState.GetCode();
+    }
+
+    /// <summary>
+    /// Clear the last error state.
+    /// </summary>
+    [UnmanagedCallersOnly(EntryPoint = "csharpdb_clear_error")]
+    public static void ClearError()
+    {
+        ErrorState.Clear();
+    }
+}

--- a/src/CSharpDB.Native/README.md
+++ b/src/CSharpDB.Native/README.md
@@ -1,0 +1,1660 @@
+# CSharpDB Native Library
+
+A NativeAOT-compiled shared library that exposes the CSharpDB embedded database engine as a C-compatible API. This allows **any programming language** to use CSharpDB via FFI (Foreign Function Interface) — no .NET runtime required.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Building](#building)
+  - [Windows](#windows)
+  - [Linux](#linux)
+  - [macOS](#macOS)
+  - [Android](#android)
+  - [iOS](#ios)
+  - [Cross-Compilation](#cross-compilation)
+- [Output](#output)
+- [API Reference](#api-reference)
+  - [Database Lifecycle](#database-lifecycle)
+  - [SQL Execution](#sql-execution)
+  - [Result Navigation](#result-navigation)
+  - [Value Access](#value-access)
+  - [Transactions](#transactions)
+  - [Error Handling](#error-handling)
+- [Type Codes](#type-codes)
+- [Usage Examples](#usage-examples)
+  - [C](#c)
+  - [Python](#python)
+  - [Go](#go)
+  - [Rust](#rust)
+  - [Swift](#swift)
+  - [Kotlin (JNA)](#kotlin-jna)
+  - [Dart / Flutter](#dart--flutter)
+  - [Node.js](#nodejs)
+- [Android Integration](#android-integration)
+  - [Option A: .NET MAUI (No Native Build)](#option-a-net-maui-android-app-no-native-library-needed)
+  - [Option B: Kotlin / Java / Flutter (Native .so)](#option-b-kotlin--java--flutter--react-native-native-so)
+- [Language Client Packages](#language-client-packages)
+- [Thread Safety](#thread-safety)
+- [Memory Management](#memory-management)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Prerequisites
+
+### All Platforms
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later
+
+### Windows
+
+- **Visual Studio** with the **"Desktop development with C++"** workload installed, or
+- **Visual Studio Build Tools** with the **C++ build tools** component
+
+Install via Visual Studio Installer or command line:
+
+```
+vs_buildtools.exe --add Microsoft.VisualStudio.Workload.VCTools
+```
+
+### Linux
+
+```bash
+# Ubuntu / Debian
+sudo apt install clang zlib1g-dev
+
+# Fedora / RHEL
+sudo dnf install clang zlib-devel
+
+# Alpine
+apk add clang build-base zlib-dev
+```
+
+### macOS
+
+```bash
+xcode-select --install
+```
+
+---
+
+## Building
+
+### Windows
+
+```bash
+dotnet publish src/CSharpDB.Native -c Release -r win-x64
+```
+
+Output: `src/CSharpDB.Native/bin/Release/net10.0/win-x64/publish/CSharpDB.Native.dll`
+
+For ARM64 Windows:
+
+```bash
+dotnet publish src/CSharpDB.Native -c Release -r win-arm64
+```
+
+### Linux
+
+```bash
+dotnet publish src/CSharpDB.Native -c Release -r linux-x64
+```
+
+Output: `src/CSharpDB.Native/bin/Release/net10.0/linux-x64/publish/CSharpDB.Native.so`
+
+For ARM64 (e.g., Raspberry Pi, AWS Graviton):
+
+```bash
+dotnet publish src/CSharpDB.Native -c Release -r linux-arm64
+```
+
+### macOS
+
+```bash
+# Apple Silicon
+dotnet publish src/CSharpDB.Native -c Release -r osx-arm64
+
+# Intel
+dotnet publish src/CSharpDB.Native -c Release -r osx-x64
+```
+
+Output: `src/CSharpDB.Native/bin/Release/net10.0/osx-arm64/publish/CSharpDB.Native.dylib`
+
+### Android
+
+```bash
+# ARM64 (most modern Android devices)
+dotnet publish src/CSharpDB.Native -c Release -r linux-bionic-arm64
+
+# x64 (emulators)
+dotnet publish src/CSharpDB.Native -c Release -r linux-bionic-x64
+```
+
+### iOS
+
+iOS requires building on macOS with Xcode installed:
+
+```bash
+dotnet publish src/CSharpDB.Native -c Release -r ios-arm64
+```
+
+> **Note:** iOS apps require static linking. You may need to set
+> `<NativeLib>Static</NativeLib>` in the `.csproj` for iOS targets
+> and link the resulting `.a` file into your Xcode project.
+
+### Cross-Compilation
+
+You can cross-compile from one platform to another if the appropriate toolchain is installed. For example, to build a Linux library from Windows using WSL or a Docker container:
+
+```bash
+docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/dotnet/sdk:10.0 \
+    dotnet publish src/CSharpDB.Native -c Release -r linux-x64
+```
+
+---
+
+## Output
+
+After publishing, the output directory contains:
+
+| File | Description |
+|------|-------------|
+| `CSharpDB.Native.dll` / `.so` / `.dylib` | The native shared library (this is all you need to ship) |
+
+The library is fully self-contained. There is no dependency on the .NET runtime. Copy it alongside your application and load it like any other native library.
+
+Typical sizes (Release, stripped):
+
+| Platform | Approximate Size |
+|----------|-----------------|
+| Windows x64 | ~8-15 MB |
+| Linux x64 | ~8-15 MB |
+| macOS ARM64 | ~8-15 MB |
+
+---
+
+## API Reference
+
+The C header file [`csharpdb.h`](csharpdb.h) defines the full API. All functions use C calling conventions and UTF-8 strings.
+
+### Database Lifecycle
+
+#### `csharpdb_open`
+
+```c
+csharpdb_t csharpdb_open(const char* path);
+```
+
+Open or create a database file at the given path.
+
+- **path** — UTF-8 file path. Creates the file if it does not exist.
+- **Returns** — Opaque database handle, or `NULL` on error.
+
+#### `csharpdb_close`
+
+```c
+void csharpdb_close(csharpdb_t db);
+```
+
+Close the database and free all resources. Safe to call with `NULL`.
+
+---
+
+### SQL Execution
+
+#### `csharpdb_execute`
+
+```c
+csharpdb_result_t csharpdb_execute(csharpdb_t db, const char* sql);
+```
+
+Execute a SQL statement (SELECT, INSERT, UPDATE, DELETE, CREATE TABLE, etc.).
+
+- **db** — Database handle from `csharpdb_open`.
+- **sql** — UTF-8 SQL string.
+- **Returns** — Result handle, or `NULL` on error. **Must** be freed with `csharpdb_result_free`.
+
+---
+
+### Result Navigation
+
+#### `csharpdb_result_is_query`
+
+```c
+int csharpdb_result_is_query(csharpdb_result_t result);
+```
+
+Returns `1` if the result is from a SELECT query, `0` for DML/DDL statements.
+
+#### `csharpdb_result_rows_affected`
+
+```c
+int csharpdb_result_rows_affected(csharpdb_result_t result);
+```
+
+Returns the number of rows affected by INSERT, UPDATE, or DELETE.
+
+#### `csharpdb_result_column_count`
+
+```c
+int csharpdb_result_column_count(csharpdb_result_t result);
+```
+
+Returns the number of columns in the result set.
+
+#### `csharpdb_result_column_name`
+
+```c
+const char* csharpdb_result_column_name(csharpdb_result_t result, int column_index);
+```
+
+Returns the name of a column (UTF-8). The pointer is valid until `csharpdb_result_free`.
+
+#### `csharpdb_result_next`
+
+```c
+int csharpdb_result_next(csharpdb_result_t result);
+```
+
+Advance to the next row.
+
+- Returns `1` if a row is available.
+- Returns `0` at the end of results.
+- Returns `-1` on error.
+
+---
+
+### Value Access
+
+All value-access functions operate on the **current row** (the last row returned by `csharpdb_result_next`).
+
+#### `csharpdb_result_column_type`
+
+```c
+int csharpdb_result_column_type(csharpdb_result_t result, int column_index);
+```
+
+Returns the [type code](#type-codes) of the value at the given column.
+
+#### `csharpdb_result_is_null`
+
+```c
+int csharpdb_result_is_null(csharpdb_result_t result, int column_index);
+```
+
+Returns `1` if the value is NULL, `0` otherwise.
+
+#### `csharpdb_result_get_int64`
+
+```c
+int64_t csharpdb_result_get_int64(csharpdb_result_t result, int column_index);
+```
+
+Read a 64-bit integer from the current row.
+
+#### `csharpdb_result_get_double`
+
+```c
+double csharpdb_result_get_double(csharpdb_result_t result, int column_index);
+```
+
+Read a double-precision float from the current row.
+
+#### `csharpdb_result_get_text`
+
+```c
+const char* csharpdb_result_get_text(csharpdb_result_t result, int column_index);
+```
+
+Read a UTF-8 text value. The pointer is valid until the next `csharpdb_result_next` or `csharpdb_result_free`.
+
+#### `csharpdb_result_get_blob`
+
+```c
+const void* csharpdb_result_get_blob(csharpdb_result_t result, int column_index, int* out_size);
+```
+
+Read a blob. `out_size` receives the byte count (may be `NULL`). The pointer is valid until the next `csharpdb_result_next` or `csharpdb_result_free`.
+
+#### `csharpdb_result_free`
+
+```c
+void csharpdb_result_free(csharpdb_result_t result);
+```
+
+Free a result handle and all associated resources. Safe to call with `NULL`.
+
+---
+
+### Transactions
+
+#### `csharpdb_begin`
+
+```c
+int csharpdb_begin(csharpdb_t db);
+```
+
+Begin an explicit transaction. Returns `0` on success, `-1` on error.
+
+#### `csharpdb_commit`
+
+```c
+int csharpdb_commit(csharpdb_t db);
+```
+
+Commit the current transaction. Returns `0` on success, `-1` on error.
+
+#### `csharpdb_rollback`
+
+```c
+int csharpdb_rollback(csharpdb_t db);
+```
+
+Rollback the current transaction. Returns `0` on success, `-1` on error.
+
+---
+
+### Error Handling
+
+Errors follow the `errno` pattern. After any function returns an error indicator (`NULL`, `-1`), call `csharpdb_last_error` to get the message.
+
+#### `csharpdb_last_error`
+
+```c
+const char* csharpdb_last_error(void);
+```
+
+Returns the last error message (UTF-8), or `NULL` if no error. Valid until the next API call on the same thread.
+
+#### `csharpdb_last_error_code`
+
+```c
+int csharpdb_last_error_code(void);
+```
+
+Returns the last error code. `0` = no error, `-1` = generic error. Positive values map to `CSharpDB.Core.ErrorCode`:
+
+| Code | Name |
+|------|------|
+| 0 | Unknown |
+| 1 | IoError |
+| 2 | CorruptDatabase |
+| 3 | TableNotFound |
+| 4 | TableAlreadyExists |
+| 5 | ColumnNotFound |
+| 6 | TypeMismatch |
+| 7 | SyntaxError |
+| 8 | ConstraintViolation |
+| 9 | JournalError |
+| 10 | DuplicateKey |
+| 11 | TriggerNotFound |
+| 12 | TriggerAlreadyExists |
+| 13 | WalError |
+| 14 | Busy |
+
+#### `csharpdb_clear_error`
+
+```c
+void csharpdb_clear_error(void);
+```
+
+Clear the error state for the current thread.
+
+---
+
+## Type Codes
+
+| Code | Constant | Description |
+|------|----------|-------------|
+| 0 | `CSHARPDB_NULL` | SQL NULL |
+| 1 | `CSHARPDB_INTEGER` | 64-bit signed integer |
+| 2 | `CSHARPDB_REAL` | 64-bit IEEE 754 double |
+| 3 | `CSHARPDB_TEXT` | UTF-8 text string |
+| 4 | `CSHARPDB_BLOB` | Binary data |
+
+---
+
+## Usage Examples
+
+### C
+
+```c
+#include <stdio.h>
+#include "csharpdb.h"
+
+int main() {
+    csharpdb_t db = csharpdb_open("test.db");
+    if (!db) {
+        fprintf(stderr, "Error: %s\n", csharpdb_last_error());
+        return 1;
+    }
+
+    // Create table
+    csharpdb_result_t r = csharpdb_execute(db,
+        "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)");
+    csharpdb_result_free(r);
+
+    // Insert data
+    r = csharpdb_execute(db, "INSERT INTO users VALUES (1, 'Alice', 30)");
+    printf("Rows inserted: %d\n", csharpdb_result_rows_affected(r));
+    csharpdb_result_free(r);
+
+    r = csharpdb_execute(db, "INSERT INTO users VALUES (2, 'Bob', 25)");
+    csharpdb_result_free(r);
+
+    // Query data
+    r = csharpdb_execute(db, "SELECT id, name, age FROM users ORDER BY id");
+    int cols = csharpdb_result_column_count(r);
+
+    // Print column headers
+    for (int i = 0; i < cols; i++) {
+        printf("%-10s", csharpdb_result_column_name(r, i));
+    }
+    printf("\n");
+
+    // Print rows
+    while (csharpdb_result_next(r) == 1) {
+        printf("%-10lld", (long long)csharpdb_result_get_int64(r, 0));
+        printf("%-10s", csharpdb_result_get_text(r, 1));
+        printf("%-10lld", (long long)csharpdb_result_get_int64(r, 2));
+        printf("\n");
+    }
+
+    csharpdb_result_free(r);
+    csharpdb_close(db);
+    return 0;
+}
+```
+
+Compile:
+
+```bash
+# Windows (MSVC)
+cl example.c CSharpDB.Native.lib
+
+# Linux / macOS
+gcc example.c -L. -lcsharpdb -o example
+```
+
+---
+
+### Python
+
+No external packages required — uses the built-in `ctypes` module.
+
+#### Quick start
+
+```bash
+pip install csharpdb  # not needed — ctypes is built into Python
+```
+
+#### Reusable wrapper class
+
+```python
+"""csharpdb.py — Python wrapper for the CSharpDB native library."""
+
+import ctypes
+import os
+import sys
+
+class CSharpDB:
+    """Thin Python wrapper around the CSharpDB NativeAOT shared library."""
+
+    # Map CSharpDB type codes to names
+    NULL, INTEGER, REAL, TEXT, BLOB = 0, 1, 2, 3, 4
+
+    def __init__(self, lib_path=None):
+        if lib_path is None:
+            if sys.platform == "win32":
+                lib_path = "./CSharpDB.Native.dll"
+            elif sys.platform == "darwin":
+                lib_path = "./libCSharpDB.Native.dylib"
+            else:
+                lib_path = "./libCSharpDB.Native.so"
+
+        self._lib = ctypes.CDLL(lib_path)
+        self._setup_signatures()
+        self._db = None
+
+    def _setup_signatures(self):
+        L = self._lib
+        vp = ctypes.c_void_p
+
+        L.csharpdb_open.restype = vp
+        L.csharpdb_open.argtypes = [ctypes.c_char_p]
+        L.csharpdb_close.restype = None
+        L.csharpdb_close.argtypes = [vp]
+        L.csharpdb_execute.restype = vp
+        L.csharpdb_execute.argtypes = [vp, ctypes.c_char_p]
+
+        L.csharpdb_result_is_query.restype = ctypes.c_int
+        L.csharpdb_result_is_query.argtypes = [vp]
+        L.csharpdb_result_next.restype = ctypes.c_int
+        L.csharpdb_result_next.argtypes = [vp]
+        L.csharpdb_result_rows_affected.restype = ctypes.c_int
+        L.csharpdb_result_rows_affected.argtypes = [vp]
+        L.csharpdb_result_column_count.restype = ctypes.c_int
+        L.csharpdb_result_column_count.argtypes = [vp]
+        L.csharpdb_result_column_name.restype = ctypes.c_char_p
+        L.csharpdb_result_column_name.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_column_type.restype = ctypes.c_int
+        L.csharpdb_result_column_type.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_is_null.restype = ctypes.c_int
+        L.csharpdb_result_is_null.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_get_int64.restype = ctypes.c_int64
+        L.csharpdb_result_get_int64.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_get_double.restype = ctypes.c_double
+        L.csharpdb_result_get_double.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_get_text.restype = ctypes.c_char_p
+        L.csharpdb_result_get_text.argtypes = [vp, ctypes.c_int]
+        L.csharpdb_result_get_blob.restype = vp
+        L.csharpdb_result_get_blob.argtypes = [vp, ctypes.c_int, ctypes.POINTER(ctypes.c_int)]
+        L.csharpdb_result_free.restype = None
+        L.csharpdb_result_free.argtypes = [vp]
+
+        L.csharpdb_begin.restype = ctypes.c_int
+        L.csharpdb_begin.argtypes = [vp]
+        L.csharpdb_commit.restype = ctypes.c_int
+        L.csharpdb_commit.argtypes = [vp]
+        L.csharpdb_rollback.restype = ctypes.c_int
+        L.csharpdb_rollback.argtypes = [vp]
+
+        L.csharpdb_last_error.restype = ctypes.c_char_p
+        L.csharpdb_last_error_code.restype = ctypes.c_int
+        L.csharpdb_clear_error.restype = None
+
+    def _check_error(self, context=""):
+        err = self._lib.csharpdb_last_error()
+        if err:
+            raise RuntimeError(f"CSharpDB error{' (' + context + ')' if context else ''}: {err.decode()}")
+
+    def open(self, path):
+        self._db = self._lib.csharpdb_open(path.encode("utf-8"))
+        if not self._db:
+            self._check_error("open")
+
+    def close(self):
+        if self._db:
+            self._lib.csharpdb_close(self._db)
+            self._db = None
+
+    def execute(self, sql):
+        """Execute a non-query statement. Returns rows affected."""
+        r = self._lib.csharpdb_execute(self._db, sql.encode("utf-8"))
+        if not r:
+            self._check_error("execute")
+        affected = self._lib.csharpdb_result_rows_affected(r)
+        self._lib.csharpdb_result_free(r)
+        return affected
+
+    def query(self, sql):
+        """Execute a SELECT and return a list of dicts."""
+        r = self._lib.csharpdb_execute(self._db, sql.encode("utf-8"))
+        if not r:
+            self._check_error("query")
+
+        col_count = self._lib.csharpdb_result_column_count(r)
+        columns = []
+        for i in range(col_count):
+            name = self._lib.csharpdb_result_column_name(r, i)
+            columns.append(name.decode() if name else f"col_{i}")
+
+        rows = []
+        while self._lib.csharpdb_result_next(r) == 1:
+            row = {}
+            for i, col in enumerate(columns):
+                if self._lib.csharpdb_result_is_null(r, i) == 1:
+                    row[col] = None
+                else:
+                    col_type = self._lib.csharpdb_result_column_type(r, i)
+                    if col_type == self.INTEGER:
+                        row[col] = self._lib.csharpdb_result_get_int64(r, i)
+                    elif col_type == self.REAL:
+                        row[col] = self._lib.csharpdb_result_get_double(r, i)
+                    elif col_type == self.TEXT:
+                        val = self._lib.csharpdb_result_get_text(r, i)
+                        row[col] = val.decode() if val else ""
+                    else:
+                        row[col] = None  # BLOB / unknown
+            rows.append(row)
+
+        self._lib.csharpdb_result_free(r)
+        return rows
+
+    def begin(self):
+        if self._lib.csharpdb_begin(self._db) != 0:
+            self._check_error("begin")
+
+    def commit(self):
+        if self._lib.csharpdb_commit(self._db) != 0:
+            self._check_error("commit")
+
+    def rollback(self):
+        if self._lib.csharpdb_rollback(self._db) != 0:
+            self._check_error("rollback")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+```
+
+#### Usage
+
+```python
+from csharpdb import CSharpDB
+
+with CSharpDB() as db:
+    db.open("books.db")
+
+    # Create table
+    db.execute("CREATE TABLE IF NOT EXISTS books (id INTEGER PRIMARY KEY, title TEXT, year INTEGER)")
+
+    # Insert rows inside a transaction
+    db.begin()
+    db.execute("INSERT INTO books VALUES (1, 'Dune', 1965)")
+    db.execute("INSERT INTO books VALUES (2, 'Neuromancer', 1984)")
+    db.execute("INSERT INTO books VALUES (3, 'Snow Crash', 1992)")
+    db.commit()
+
+    # Query — returns list of dicts with typed values
+    for book in db.query("SELECT id, title, year FROM books ORDER BY year"):
+        print(f"  {book['id']}: {book['title']} ({book['year']})")
+
+    # Aggregates work too
+    result = db.query("SELECT COUNT(*) as total, MIN(year) as oldest FROM books")
+    print(f"  {result[0]['total']} books, oldest from {result[0]['oldest']}")
+```
+
+Output:
+
+```
+  1: Dune (1965)
+  2: Neuromancer (1984)
+  3: Snow Crash (1992)
+  3 books, oldest from 1965
+```
+
+---
+
+### Go
+
+```go
+package main
+
+/*
+#cgo LDFLAGS: -L. -lCSharpDB.Native
+#include "csharpdb.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+    "fmt"
+    "unsafe"
+)
+
+func main() {
+    path := C.CString("test.db")
+    defer C.free(unsafe.Pointer(path))
+
+    db := C.csharpdb_open(path)
+    if db == nil {
+        fmt.Printf("Error: %s\n", C.GoString(C.csharpdb_last_error()))
+        return
+    }
+    defer C.csharpdb_close(db)
+
+    // Create table
+    sql := C.CString("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+    r := C.csharpdb_execute(db, sql)
+    C.free(unsafe.Pointer(sql))
+    C.csharpdb_result_free(r)
+
+    // Insert
+    sql = C.CString("INSERT INTO users VALUES (1, 'Alice')")
+    r = C.csharpdb_execute(db, sql)
+    C.free(unsafe.Pointer(sql))
+    fmt.Printf("Inserted: %d row(s)\n", C.csharpdb_result_rows_affected(r))
+    C.csharpdb_result_free(r)
+
+    // Query
+    sql = C.CString("SELECT id, name FROM users")
+    r = C.csharpdb_execute(db, sql)
+    C.free(unsafe.Pointer(sql))
+
+    for C.csharpdb_result_next(r) == 1 {
+        id := int64(C.csharpdb_result_get_int64(r, 0))
+        name := C.GoString(C.csharpdb_result_get_text(r, 1))
+        fmt.Printf("  %d: %s\n", id, name)
+    }
+
+    C.csharpdb_result_free(r)
+}
+```
+
+Build:
+
+```bash
+CGO_ENABLED=1 go build -o example
+```
+
+---
+
+### Rust
+
+```rust
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int, c_void};
+
+// Declare the external functions
+extern "C" {
+    fn csharpdb_open(path: *const c_char) -> *mut c_void;
+    fn csharpdb_close(db: *mut c_void);
+    fn csharpdb_execute(db: *mut c_void, sql: *const c_char) -> *mut c_void;
+    fn csharpdb_result_next(result: *mut c_void) -> c_int;
+    fn csharpdb_result_rows_affected(result: *mut c_void) -> c_int;
+    fn csharpdb_result_get_int64(result: *mut c_void, col: c_int) -> i64;
+    fn csharpdb_result_get_text(result: *mut c_void, col: c_int) -> *const c_char;
+    fn csharpdb_result_free(result: *mut c_void);
+    fn csharpdb_last_error() -> *const c_char;
+}
+
+fn main() {
+    unsafe {
+        let path = CString::new("test.db").unwrap();
+        let db = csharpdb_open(path.as_ptr());
+        if db.is_null() {
+            let err = CStr::from_ptr(csharpdb_last_error());
+            eprintln!("Error: {}", err.to_str().unwrap());
+            return;
+        }
+
+        // Create table
+        let sql = CString::new(
+            "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)"
+        ).unwrap();
+        let r = csharpdb_execute(db, sql.as_ptr());
+        csharpdb_result_free(r);
+
+        // Insert
+        let sql = CString::new("INSERT INTO users VALUES (1, 'Alice')").unwrap();
+        let r = csharpdb_execute(db, sql.as_ptr());
+        println!("Inserted: {} row(s)", csharpdb_result_rows_affected(r));
+        csharpdb_result_free(r);
+
+        // Query
+        let sql = CString::new("SELECT id, name FROM users").unwrap();
+        let r = csharpdb_execute(db, sql.as_ptr());
+
+        while csharpdb_result_next(r) == 1 {
+            let id = csharpdb_result_get_int64(r, 0);
+            let name = CStr::from_ptr(csharpdb_result_get_text(r, 1));
+            println!("  {}: {}", id, name.to_str().unwrap());
+        }
+
+        csharpdb_result_free(r);
+        csharpdb_close(db);
+    }
+}
+```
+
+In `build.rs`:
+
+```rust
+fn main() {
+    println!("cargo:rustc-link-search=native=.");
+    println!("cargo:rustc-link-lib=dylib=CSharpDB.Native");
+}
+```
+
+---
+
+### Swift
+
+```swift
+import Foundation
+
+// Assumes csharpdb.h is added to the bridging header or a module map
+
+let db = csharpdb_open("test.db")
+guard db != nil else {
+    if let err = csharpdb_last_error() {
+        print("Error: \(String(cString: err))")
+    }
+    exit(1)
+}
+
+// Create table
+var r = csharpdb_execute(db,
+    "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+csharpdb_result_free(r)
+
+// Insert
+r = csharpdb_execute(db, "INSERT INTO users VALUES (1, 'Alice')")
+print("Inserted: \(csharpdb_result_rows_affected(r)) row(s)")
+csharpdb_result_free(r)
+
+// Query
+r = csharpdb_execute(db, "SELECT id, name FROM users")
+while csharpdb_result_next(r) == 1 {
+    let id = csharpdb_result_get_int64(r, 0)
+    let name = String(cString: csharpdb_result_get_text(r, 1))
+    print("  \(id): \(name)")
+}
+
+csharpdb_result_free(r)
+csharpdb_close(db)
+```
+
+For iOS/macOS, add the library to your Xcode project and create a module map:
+
+```
+// module.modulemap
+module CSharpDB {
+    header "csharpdb.h"
+    link "CSharpDB.Native"
+    export *
+}
+```
+
+---
+
+### Kotlin (JNA)
+
+```kotlin
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+
+interface CSharpDB : Library {
+    fun csharpdb_open(path: String): Pointer?
+    fun csharpdb_close(db: Pointer)
+    fun csharpdb_execute(db: Pointer, sql: String): Pointer?
+    fun csharpdb_result_next(result: Pointer): Int
+    fun csharpdb_result_rows_affected(result: Pointer): Int
+    fun csharpdb_result_column_count(result: Pointer): Int
+    fun csharpdb_result_get_int64(result: Pointer, col: Int): Long
+    fun csharpdb_result_get_text(result: Pointer, col: Int): String?
+    fun csharpdb_result_free(result: Pointer)
+    fun csharpdb_last_error(): String?
+
+    companion object {
+        val INSTANCE: CSharpDB = Native.load("CSharpDB.Native", CSharpDB::class.java)
+    }
+}
+
+fun main() {
+    val lib = CSharpDB.INSTANCE
+    val db = lib.csharpdb_open("test.db")
+        ?: error("Failed to open: ${lib.csharpdb_last_error()}")
+
+    // Create table
+    lib.csharpdb_result_free(
+        lib.csharpdb_execute(db,
+            "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")!!)
+
+    // Insert
+    val r = lib.csharpdb_execute(db, "INSERT INTO users VALUES (1, 'Alice')")!!
+    println("Inserted: ${lib.csharpdb_result_rows_affected(r)} row(s)")
+    lib.csharpdb_result_free(r)
+
+    // Query
+    val result = lib.csharpdb_execute(db, "SELECT id, name FROM users")!!
+    while (lib.csharpdb_result_next(result) == 1) {
+        val id = lib.csharpdb_result_get_int64(result, 0)
+        val name = lib.csharpdb_result_get_text(result, 1)
+        println("  $id: $name")
+    }
+
+    lib.csharpdb_result_free(result)
+    lib.csharpdb_close(db)
+}
+```
+
+Add JNA dependency:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("net.java.dev.jna:jna:5.14.0")
+}
+```
+
+For **Android**, use JNA or JNI and place the `.so` in `jniLibs/arm64-v8a/`.
+
+---
+
+### Dart / Flutter
+
+```dart
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/package:ffi.dart';
+
+// Type definitions
+typedef CsharpdbOpenNative = Pointer<Void> Function(Pointer<Utf8>);
+typedef CsharpdbOpen = Pointer<Void> Function(Pointer<Utf8>);
+
+typedef CsharpdbExecuteNative = Pointer<Void> Function(Pointer<Void>, Pointer<Utf8>);
+typedef CsharpdbExecute = Pointer<Void> Function(Pointer<Void>, Pointer<Utf8>);
+
+typedef CsharpdbResultNextNative = Int32 Function(Pointer<Void>);
+typedef CsharpdbResultNext = int Function(Pointer<Void>);
+
+typedef CsharpdbResultGetInt64Native = Int64 Function(Pointer<Void>, Int32);
+typedef CsharpdbResultGetInt64 = int Function(Pointer<Void>, int);
+
+typedef CsharpdbResultGetTextNative = Pointer<Utf8> Function(Pointer<Void>, Int32);
+typedef CsharpdbResultGetText = Pointer<Utf8> Function(Pointer<Void>, int);
+
+typedef CsharpdbResultFreeNative = Void Function(Pointer<Void>);
+typedef CsharpdbResultFree = void Function(Pointer<Void>);
+
+typedef CsharpdbCloseNative = Void Function(Pointer<Void>);
+typedef CsharpdbClose = void Function(Pointer<Void>);
+
+void main() {
+  final lib = DynamicLibrary.open(
+    Platform.isWindows ? 'CSharpDB.Native.dll' :
+    Platform.isMacOS   ? 'libCSharpDB.Native.dylib' :
+                         'libCSharpDB.Native.so'
+  );
+
+  final open = lib.lookupFunction<CsharpdbOpenNative, CsharpdbOpen>('csharpdb_open');
+  final execute = lib.lookupFunction<CsharpdbExecuteNative, CsharpdbExecute>('csharpdb_execute');
+  final next = lib.lookupFunction<CsharpdbResultNextNative, CsharpdbResultNext>('csharpdb_result_next');
+  final getInt64 = lib.lookupFunction<CsharpdbResultGetInt64Native, CsharpdbResultGetInt64>('csharpdb_result_get_int64');
+  final getText = lib.lookupFunction<CsharpdbResultGetTextNative, CsharpdbResultGetText>('csharpdb_result_get_text');
+  final resultFree = lib.lookupFunction<CsharpdbResultFreeNative, CsharpdbResultFree>('csharpdb_result_free');
+  final close = lib.lookupFunction<CsharpdbCloseNative, CsharpdbClose>('csharpdb_close');
+
+  final path = 'test.db'.toNativeUtf8();
+  final db = open(path);
+  calloc.free(path);
+
+  // Create table
+  final createSql = 'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)'.toNativeUtf8();
+  var r = execute(db, createSql);
+  calloc.free(createSql);
+  resultFree(r);
+
+  // Insert
+  final insertSql = "INSERT INTO users VALUES (1, 'Alice')".toNativeUtf8();
+  r = execute(db, insertSql);
+  calloc.free(insertSql);
+  resultFree(r);
+
+  // Query
+  final selectSql = 'SELECT id, name FROM users'.toNativeUtf8();
+  r = execute(db, selectSql);
+  calloc.free(selectSql);
+
+  while (next(r) == 1) {
+    final id = getInt64(r, 0);
+    final name = getText(r, 1).toDartString();
+    print('  $id: $name');
+  }
+
+  resultFree(r);
+  close(db);
+}
+```
+
+---
+
+### Node.js
+
+> **Dedicated TypeScript package available:** For a production-ready TypeScript/Node.js client with
+> full type safety, generator-based iteration, and automatic library discovery, see
+> [`clients/node/`](../../clients/node/) (`csharpdb` on npm).
+
+Uses [koffi](https://koffi.dev/), a zero-dependency FFI library for Node.js.
+
+#### Setup
+
+```bash
+npm init -y
+npm install koffi
+```
+
+Copy `CSharpDB.Native.dll` (or `.so` / `.dylib`) into your project directory.
+
+#### Reusable wrapper module
+
+```javascript
+// csharpdb.js — Node.js wrapper for the CSharpDB native library
+
+const koffi = require("koffi");
+const path = require("path");
+
+// Type codes matching CSharpDB.Core.DbType
+const DbType = { NULL: 0, INTEGER: 1, REAL: 2, TEXT: 3, BLOB: 4 };
+
+function loadLibrary(libPath) {
+  if (!libPath) {
+    if (process.platform === "win32") libPath = "./CSharpDB.Native.dll";
+    else if (process.platform === "darwin") libPath = "./libCSharpDB.Native.dylib";
+    else libPath = "./libCSharpDB.Native.so";
+  }
+  return koffi.load(libPath);
+}
+
+class CSharpDB {
+  constructor(libPath) {
+    const lib = loadLibrary(libPath);
+
+    // Bind all exported functions
+    this._open = lib.func("csharpdb_open", "void*", ["str"]);
+    this._close = lib.func("csharpdb_close", "void", ["void*"]);
+    this._execute = lib.func("csharpdb_execute", "void*", ["void*", "str"]);
+
+    this._resultIsQuery = lib.func("csharpdb_result_is_query", "int", ["void*"]);
+    this._resultNext = lib.func("csharpdb_result_next", "int", ["void*"]);
+    this._resultRowsAffected = lib.func("csharpdb_result_rows_affected", "int", ["void*"]);
+    this._resultColumnCount = lib.func("csharpdb_result_column_count", "int", ["void*"]);
+    this._resultColumnName = lib.func("csharpdb_result_column_name", "str", ["void*", "int"]);
+    this._resultColumnType = lib.func("csharpdb_result_column_type", "int", ["void*", "int"]);
+    this._resultIsNull = lib.func("csharpdb_result_is_null", "int", ["void*", "int"]);
+    this._resultGetInt64 = lib.func("csharpdb_result_get_int64", "int64_t", ["void*", "int"]);
+    this._resultGetDouble = lib.func("csharpdb_result_get_double", "double", ["void*", "int"]);
+    this._resultGetText = lib.func("csharpdb_result_get_text", "str", ["void*", "int"]);
+    this._resultFree = lib.func("csharpdb_result_free", "void", ["void*"]);
+
+    this._begin = lib.func("csharpdb_begin", "int", ["void*"]);
+    this._commit = lib.func("csharpdb_commit", "int", ["void*"]);
+    this._rollback = lib.func("csharpdb_rollback", "int", ["void*"]);
+
+    this._lastError = lib.func("csharpdb_last_error", "str", []);
+    this._lastErrorCode = lib.func("csharpdb_last_error_code", "int", []);
+    this._clearError = lib.func("csharpdb_clear_error", "void", []);
+
+    this._db = null;
+  }
+
+  open(dbPath) {
+    this._db = this._open(dbPath);
+    if (!this._db) {
+      throw new Error(`Failed to open database: ${this._lastError()}`);
+    }
+  }
+
+  close() {
+    if (this._db) {
+      this._close(this._db);
+      this._db = null;
+    }
+  }
+
+  /** Execute a non-query statement (INSERT, UPDATE, DELETE, CREATE, etc.). Returns rows affected. */
+  execute(sql) {
+    const r = this._execute(this._db, sql);
+    if (!r) throw new Error(`SQL error: ${this._lastError()}`);
+    const affected = this._resultRowsAffected(r);
+    this._resultFree(r);
+    return affected;
+  }
+
+  /** Execute a SELECT and return an array of objects. */
+  query(sql) {
+    const r = this._execute(this._db, sql);
+    if (!r) throw new Error(`Query error: ${this._lastError()}`);
+
+    const colCount = this._resultColumnCount(r);
+    const columns = [];
+    for (let i = 0; i < colCount; i++) {
+      columns.push(this._resultColumnName(r, i) || `col_${i}`);
+    }
+
+    const rows = [];
+    while (this._resultNext(r) === 1) {
+      const row = {};
+      for (let i = 0; i < colCount; i++) {
+        if (this._resultIsNull(r, i) === 1) {
+          row[columns[i]] = null;
+          continue;
+        }
+        const type = this._resultColumnType(r, i);
+        switch (type) {
+          case DbType.INTEGER:
+            // koffi returns BigInt for int64 — convert to Number if safe
+            const val = this._resultGetInt64(r, i);
+            row[columns[i]] = typeof val === "bigint"
+              ? (val >= -Number.MAX_SAFE_INTEGER && val <= Number.MAX_SAFE_INTEGER ? Number(val) : val)
+              : val;
+            break;
+          case DbType.REAL:
+            row[columns[i]] = this._resultGetDouble(r, i);
+            break;
+          case DbType.TEXT:
+            row[columns[i]] = this._resultGetText(r, i) || "";
+            break;
+          default:
+            row[columns[i]] = null;
+        }
+      }
+      rows.add ? rows.push(row) : rows.push(row);
+    }
+
+    this._resultFree(r);
+    return rows;
+  }
+
+  /** Execute a SELECT and return the first row, or null. */
+  queryOne(sql) {
+    const rows = this.query(sql);
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  begin() {
+    if (this._begin(this._db) !== 0) throw new Error(`Transaction error: ${this._lastError()}`);
+  }
+
+  commit() {
+    if (this._commit(this._db) !== 0) throw new Error(`Commit error: ${this._lastError()}`);
+  }
+
+  rollback() {
+    if (this._rollback(this._db) !== 0) throw new Error(`Rollback error: ${this._lastError()}`);
+  }
+
+  /** Run a function inside a transaction. Auto-commits on success, rolls back on error. */
+  transaction(fn) {
+    this.begin();
+    try {
+      const result = fn(this);
+      this.commit();
+      return result;
+    } catch (err) {
+      this.rollback();
+      throw err;
+    }
+  }
+}
+
+module.exports = { CSharpDB, DbType };
+```
+
+#### Usage
+
+```javascript
+const { CSharpDB } = require("./csharpdb");
+
+const db = new CSharpDB();
+db.open("books.db");
+
+// Create table
+db.execute(`
+  CREATE TABLE IF NOT EXISTS books (
+    id INTEGER PRIMARY KEY,
+    title TEXT,
+    year INTEGER,
+    rating REAL
+  )
+`);
+
+// Insert rows inside a transaction
+db.transaction(() => {
+  db.execute("INSERT INTO books VALUES (1, 'Dune', 1965, 4.8)");
+  db.execute("INSERT INTO books VALUES (2, 'Neuromancer', 1984, 4.5)");
+  db.execute("INSERT INTO books VALUES (3, 'Snow Crash', 1992, 4.3)");
+});
+
+// Query — returns array of objects with typed values
+const books = db.query("SELECT id, title, year, rating FROM books ORDER BY year");
+for (const book of books) {
+  console.log(`  ${book.id}: ${book.title} (${book.year}) — ${book.rating}/5`);
+}
+
+// Aggregates
+const stats = db.queryOne("SELECT COUNT(*) as total, AVG(rating) as avg_rating FROM books");
+console.log(`  ${stats.total} books, avg rating: ${stats.avg_rating.toFixed(1)}`);
+
+db.close();
+```
+
+Output:
+
+```
+  1: Dune (1965) — 4.8/5
+  2: Neuromancer (1984) — 4.5/5
+  3: Snow Crash (1992) — 4.3/5
+  3 books, avg rating: 4.5
+```
+
+#### Express.js REST API example
+
+```javascript
+const express = require("express");
+const { CSharpDB } = require("./csharpdb");
+
+const app = express();
+app.use(express.json());
+
+const db = new CSharpDB();
+db.open("api.db");
+db.execute(`
+  CREATE TABLE IF NOT EXISTS todos (
+    id INTEGER PRIMARY KEY,
+    title TEXT,
+    done INTEGER DEFAULT 0
+  )
+`);
+
+app.get("/todos", (req, res) => {
+  res.json(db.query("SELECT * FROM todos ORDER BY id"));
+});
+
+app.post("/todos", (req, res) => {
+  const { title } = req.body;
+  const count = db.queryOne("SELECT COALESCE(MAX(id), 0) + 1 as next_id FROM todos");
+  db.execute(`INSERT INTO todos VALUES (${count.next_id}, '${title.replace(/'/g, "''")}', 0)`);
+  res.json({ id: count.next_id, title, done: 0 });
+});
+
+app.listen(3000, () => console.log("Listening on :3000"));
+
+process.on("SIGINT", () => { db.close(); process.exit(); });
+```
+
+---
+
+## Android Integration
+
+There are two ways to use CSharpDB on Android, depending on what your app is built with.
+
+### Option A: .NET MAUI Android App (No Native Library Needed)
+
+If your Android app uses .NET MAUI, reference the CSharpDB NuGet package directly — the database runs in-process with no FFI or native builds required:
+
+```xml
+<!-- In your MAUI .csproj -->
+<PackageReference Include="CSharpDB" Version="1.6.0" />
+```
+
+```csharp
+// Runs on-device, fully offline
+var dbPath = Path.Combine(FileSystem.AppDataDirectory, "local.db");
+await using var db = await Database.OpenAsync(dbPath);
+await db.ExecuteAsync("CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, text TEXT)");
+```
+
+### Option B: Kotlin / Java / Flutter / React Native (Native .so)
+
+For non-.NET Android apps, use the NativeAOT-compiled shared library.
+
+#### Step 1: Build the .so for Android
+
+```bash
+# ARM64 — most real devices (Pixel, Samsung, etc.)
+dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r linux-bionic-arm64
+
+# x64 — Android emulators
+dotnet publish src/CSharpDB.Native/CSharpDB.Native.csproj -c Release -r linux-bionic-x64
+```
+
+#### Step 2: Copy the .so into your Android project
+
+Rename the output and place it in the standard `jniLibs` directory:
+
+```
+MyAndroidApp/
+  app/
+    src/main/
+      jniLibs/
+        arm64-v8a/
+          libcsharpdb.so        <- from linux-bionic-arm64 publish
+        x86_64/
+          libcsharpdb.so        <- from linux-bionic-x64 publish
+```
+
+> **Important:** The file must be named `libcsharpdb.so` (with the `lib` prefix).
+> Android's linker requires shared libraries to follow the `lib<name>.so` convention.
+
+#### Step 3a: Kotlin / Java with JNA
+
+Add the JNA dependency:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("net.java.dev.jna:jna:5.14.0@aar")
+}
+```
+
+Define the interface:
+
+```kotlin
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+
+interface CSharpDB : Library {
+    companion object {
+        val INSTANCE: CSharpDB = Native.load("csharpdb", CSharpDB::class.java)
+    }
+
+    fun csharpdb_open(path: String): Pointer?
+    fun csharpdb_close(db: Pointer)
+    fun csharpdb_execute(db: Pointer, sql: String): Pointer?
+    fun csharpdb_result_next(result: Pointer): Int
+    fun csharpdb_result_rows_affected(result: Pointer): Int
+    fun csharpdb_result_column_count(result: Pointer): Int
+    fun csharpdb_result_column_name(result: Pointer, col: Int): String?
+    fun csharpdb_result_column_type(result: Pointer, col: Int): Int
+    fun csharpdb_result_is_null(result: Pointer, col: Int): Int
+    fun csharpdb_result_get_int64(result: Pointer, col: Int): Long
+    fun csharpdb_result_get_double(result: Pointer, col: Int): Double
+    fun csharpdb_result_get_text(result: Pointer, col: Int): String?
+    fun csharpdb_result_free(result: Pointer)
+    fun csharpdb_begin(db: Pointer): Int
+    fun csharpdb_commit(db: Pointer): Int
+    fun csharpdb_rollback(db: Pointer): Int
+    fun csharpdb_last_error(): String?
+    fun csharpdb_last_error_code(): Int
+    fun csharpdb_clear_error()
+}
+```
+
+Use it from an Activity, Fragment, or ViewModel:
+
+```kotlin
+class NotesRepository(private val context: Context) {
+    private val lib = CSharpDB.INSTANCE
+    private val db: Pointer
+
+    init {
+        val dbPath = "${context.filesDir}/notes.db"
+        db = lib.csharpdb_open(dbPath)
+            ?: error("Failed to open database: ${lib.csharpdb_last_error()}")
+
+        val r = lib.csharpdb_execute(db,
+            "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY, title TEXT, body TEXT)")
+            ?: error("Failed to create table: ${lib.csharpdb_last_error()}")
+        lib.csharpdb_result_free(r)
+    }
+
+    fun addNote(title: String, body: String) {
+        // Use single quotes escaped for SQL; in production use parameterized queries
+        val sql = "INSERT INTO notes (title, body) VALUES ('${title}', '${body}')"
+        val r = lib.csharpdb_execute(db, sql)
+            ?: error("Insert failed: ${lib.csharpdb_last_error()}")
+        lib.csharpdb_result_free(r)
+    }
+
+    fun getAllNotes(): List<Triple<Long, String, String>> {
+        val notes = mutableListOf<Triple<Long, String, String>>()
+        val r = lib.csharpdb_execute(db, "SELECT id, title, body FROM notes ORDER BY id DESC")
+            ?: error("Query failed: ${lib.csharpdb_last_error()}")
+
+        while (lib.csharpdb_result_next(r) == 1) {
+            val id = lib.csharpdb_result_get_int64(r, 0)
+            val title = lib.csharpdb_result_get_text(r, 1) ?: ""
+            val body = lib.csharpdb_result_get_text(r, 2) ?: ""
+            notes.add(Triple(id, title, body))
+        }
+
+        lib.csharpdb_result_free(r)
+        return notes
+    }
+
+    fun close() {
+        lib.csharpdb_close(db)
+    }
+}
+```
+
+#### Step 3b: Flutter with dart:ffi
+
+Place the `.so` file in your Flutter project:
+
+```
+my_flutter_app/
+  android/
+    app/
+      src/main/
+        jniLibs/
+          arm64-v8a/
+            libcsharpdb.so
+          x86_64/
+            libcsharpdb.so
+```
+
+Create a Dart wrapper:
+
+```dart
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/ffi.dart';
+
+class CSharpDB {
+  late final DynamicLibrary _lib;
+
+  // Function typedefs
+  late final Pointer<Void> Function(Pointer<Utf8>) _open;
+  late final void Function(Pointer<Void>) _close;
+  late final Pointer<Void> Function(Pointer<Void>, Pointer<Utf8>) _execute;
+  late final int Function(Pointer<Void>) _resultNext;
+  late final int Function(Pointer<Void>) _resultRowsAffected;
+  late final int Function(Pointer<Void>) _resultColumnCount;
+  late final Pointer<Utf8> Function(Pointer<Void>, int) _resultGetText;
+  late final int Function(Pointer<Void>, int) _resultGetInt64;
+  late final double Function(Pointer<Void>, int) _resultGetDouble;
+  late final int Function(Pointer<Void>, int) _resultIsNull;
+  late final void Function(Pointer<Void>) _resultFree;
+  late final Pointer<Utf8> Function() _lastError;
+
+  CSharpDB() {
+    _lib = Platform.isAndroid
+        ? DynamicLibrary.open('libcsharpdb.so')
+        : DynamicLibrary.open('CSharpDB.Native.dll');
+
+    _open = _lib.lookupFunction<Pointer<Void> Function(Pointer<Utf8>),
+        Pointer<Void> Function(Pointer<Utf8>)>('csharpdb_open');
+    _close = _lib.lookupFunction<Void Function(Pointer<Void>),
+        void Function(Pointer<Void>)>('csharpdb_close');
+    _execute = _lib.lookupFunction<
+        Pointer<Void> Function(Pointer<Void>, Pointer<Utf8>),
+        Pointer<Void> Function(Pointer<Void>, Pointer<Utf8>)>('csharpdb_execute');
+    _resultNext = _lib.lookupFunction<Int32 Function(Pointer<Void>),
+        int Function(Pointer<Void>)>('csharpdb_result_next');
+    _resultRowsAffected = _lib.lookupFunction<Int32 Function(Pointer<Void>),
+        int Function(Pointer<Void>)>('csharpdb_result_rows_affected');
+    _resultColumnCount = _lib.lookupFunction<Int32 Function(Pointer<Void>),
+        int Function(Pointer<Void>)>('csharpdb_result_column_count');
+    _resultGetText = _lib.lookupFunction<
+        Pointer<Utf8> Function(Pointer<Void>, Int32),
+        Pointer<Utf8> Function(Pointer<Void>, int)>('csharpdb_result_get_text');
+    _resultGetInt64 = _lib.lookupFunction<Int64 Function(Pointer<Void>, Int32),
+        int Function(Pointer<Void>, int)>('csharpdb_result_get_int64');
+    _resultGetDouble = _lib.lookupFunction<
+        Double Function(Pointer<Void>, Int32),
+        double Function(Pointer<Void>, int)>('csharpdb_result_get_double');
+    _resultIsNull = _lib.lookupFunction<Int32 Function(Pointer<Void>, Int32),
+        int Function(Pointer<Void>, int)>('csharpdb_result_is_null');
+    _resultFree = _lib.lookupFunction<Void Function(Pointer<Void>),
+        void Function(Pointer<Void>)>('csharpdb_result_free');
+    _lastError = _lib.lookupFunction<Pointer<Utf8> Function(),
+        Pointer<Utf8> Function()>('csharpdb_last_error');
+  }
+
+  late Pointer<Void> _db;
+
+  void open(String path) {
+    final pathPtr = path.toNativeUtf8();
+    _db = _open(pathPtr);
+    calloc.free(pathPtr);
+    if (_db == nullptr) {
+      throw Exception('Failed to open database: ${_lastError().toDartString()}');
+    }
+  }
+
+  int execute(String sql) {
+    final sqlPtr = sql.toNativeUtf8();
+    final result = _execute(_db, sqlPtr);
+    calloc.free(sqlPtr);
+    if (result == nullptr) {
+      throw Exception('SQL error: ${_lastError().toDartString()}');
+    }
+    final affected = _resultRowsAffected(result);
+    _resultFree(result);
+    return affected;
+  }
+
+  List<Map<String, dynamic>> query(String sql) {
+    final sqlPtr = sql.toNativeUtf8();
+    final result = _execute(_db, sqlPtr);
+    calloc.free(sqlPtr);
+    if (result == nullptr) {
+      throw Exception('Query error: ${_lastError().toDartString()}');
+    }
+
+    final rows = <Map<String, dynamic>>[];
+    final colCount = _resultColumnCount(result);
+
+    while (_resultNext(result) == 1) {
+      final row = <String, dynamic>{};
+      for (var i = 0; i < colCount; i++) {
+        if (_resultIsNull(result, i) == 1) {
+          row['col_$i'] = null;
+        } else {
+          row['col_$i'] = _resultGetText(result, i).toDartString();
+        }
+      }
+      rows.add(row);
+    }
+
+    _resultFree(result);
+    return rows;
+  }
+
+  void close() => _close(_db);
+}
+```
+
+Usage in Flutter:
+
+```dart
+final db = CSharpDB();
+db.open('${(await getApplicationDocumentsDirectory()).path}/app.db');
+db.execute('CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY, name TEXT)');
+db.execute("INSERT INTO items VALUES (1, 'Widget')");
+final rows = db.query('SELECT * FROM items');
+print(rows); // [{col_0: 1, col_1: Widget}]
+db.close();
+```
+
+#### Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Android Device                           │
+│                                                                 │
+│  ┌──────────────────────┐     ┌──────────────────────────────┐  │
+│  │ Kotlin / Flutter App │     │ jniLibs/arm64-v8a/           │  │
+│  │                      │────►│   libcsharpdb.so             │  │
+│  │ JNA / dart:ffi call  │     │   (NativeAOT, no .NET CLR)   │  │
+│  └──────────────────────┘     └──────────────┬───────────────┘  │
+│                                              │                  │
+│                                              ▼                  │
+│                                   ┌──────────────────┐          │
+│                                   │ /data/data/app/  │          │
+│                                   │   myapp.db       │          │
+│                                   │   myapp.db.wal   │          │
+│                                   └──────────────────┘          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+#### Notes
+
+- The `.so` is self-contained — no .NET runtime is installed on the device.
+- The database file is stored in the app's private data directory (`context.filesDir` or `getApplicationDocumentsDirectory()`).
+- ARM64 covers virtually all modern Android phones (2017+). Add `x86_64` only if you need emulator support.
+- The library size for Android ARM64 is typically 8-15 MB.
+
+---
+
+## Language Client Packages
+
+Pre-built client packages that wrap the native library with idiomatic APIs:
+
+| Language | Location | Features |
+|----------|----------|----------|
+| **Node.js / TypeScript** | [`clients/node/`](../../clients/node/) | Full TypeScript types, generator iteration, auto library discovery, transaction helper |
+
+---
+
+## Thread Safety
+
+- **Different database handles** can be used concurrently from different threads.
+- A **single database handle** must NOT be used from multiple threads simultaneously. The underlying engine uses single-writer semantics.
+- **Error state** is per-thread (`csharpdb_last_error` will not be overwritten by another thread).
+- For concurrent read access, open multiple database handles pointing to the same file. CSharpDB's WAL mode supports concurrent readers.
+
+---
+
+## Memory Management
+
+**Rules:**
+
+1. Every `csharpdb_open` must be paired with `csharpdb_close`.
+2. Every `csharpdb_execute` must be paired with `csharpdb_result_free`.
+3. String pointers from `csharpdb_result_get_text` and `csharpdb_result_column_name` are owned by the library. **Do not free them.**
+4. Blob pointers from `csharpdb_result_get_blob` are owned by the library. **Do not free them.**
+5. Text and blob pointers from row values are valid only until the next `csharpdb_result_next` call or `csharpdb_result_free`. Copy the data if you need it longer.
+6. Column name pointers are valid until `csharpdb_result_free`.
+
+---
+
+## Troubleshooting
+
+### "Platform linker not found" on Windows
+
+Install the "Desktop development with C++" workload in Visual Studio:
+
+```
+vs_buildtools.exe --add Microsoft.VisualStudio.Workload.VCTools
+```
+
+### "clang not found" on Linux
+
+```bash
+sudo apt install clang   # Debian/Ubuntu
+sudo dnf install clang   # Fedora/RHEL
+```
+
+### Library not found at runtime
+
+Make sure the shared library is in one of:
+
+- The same directory as your executable
+- A directory in `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH` (macOS)
+- A system library directory (`/usr/local/lib`, etc.)
+
+On Windows, ensure the DLL is in the same folder as the `.exe` or in `PATH`.
+
+### "Entry point not found"
+
+Verify the library was published with NativeAOT:
+
+```bash
+# Linux/macOS
+nm -D libCSharpDB.Native.so | grep csharpdb_
+
+# Windows (from VS Developer Command Prompt)
+dumpbin /exports CSharpDB.Native.dll
+```
+
+You should see all `csharpdb_*` symbols listed.
+
+### Large binary size
+
+The NativeAOT binary includes the .NET runtime and GC. To reduce size:
+
+```bash
+# Strip debug symbols (default in Release with StripSymbols=true)
+dotnet publish -c Release -r linux-x64 -p:StripSymbols=true
+
+# Aggressive trimming (may break reflection-dependent code)
+dotnet publish -c Release -r linux-x64 -p:OptimizationPreference=Size
+```

--- a/src/CSharpDB.Native/StringCache.cs
+++ b/src/CSharpDB.Native/StringCache.cs
@@ -22,7 +22,7 @@ internal static class StringCache
     public static IntPtr GetOrAdd(IntPtr resultHandle, int columnIndex, string value)
     {
         var key = (resultHandle, columnIndex);
-        return s_columnNames.GetOrAdd(key, _ => Marshal.StringToHGlobalAnsi(value));
+        return s_columnNames.GetOrAdd(key, _ => Utf8StringMemory.Allocate(value));
     }
 
     /// <summary>
@@ -31,7 +31,7 @@ internal static class StringCache
     public static IntPtr SetCurrentRowText(IntPtr resultHandle, int columnIndex, string value)
     {
         var key = (resultHandle, columnIndex);
-        var newPtr = Marshal.StringToHGlobalAnsi(value);
+        var newPtr = Utf8StringMemory.Allocate(value);
 
         if (s_rowTexts.TryGetValue(key, out var oldPtr))
         {

--- a/src/CSharpDB.Native/StringCache.cs
+++ b/src/CSharpDB.Native/StringCache.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+
+namespace CSharpDB.Native;
+
+/// <summary>
+/// Manages unmanaged UTF-8 string pointers returned to foreign callers.
+/// Column name strings live as long as their result handle.
+/// Row text values are overwritten on each row advance.
+/// </summary>
+internal static class StringCache
+{
+    // Column name pointers: keyed by (resultHandle, columnIndex)
+    private static readonly ConcurrentDictionary<(IntPtr, int), IntPtr> s_columnNames = new();
+
+    // Current-row text pointers: keyed by (resultHandle, columnIndex)
+    private static readonly ConcurrentDictionary<(IntPtr, int), IntPtr> s_rowTexts = new();
+
+    /// <summary>
+    /// Get or allocate a UTF-8 pointer for a column name. Lives until Remove() is called.
+    /// </summary>
+    public static IntPtr GetOrAdd(IntPtr resultHandle, int columnIndex, string value)
+    {
+        var key = (resultHandle, columnIndex);
+        return s_columnNames.GetOrAdd(key, _ => Marshal.StringToHGlobalAnsi(value));
+    }
+
+    /// <summary>
+    /// Set the text value for the current row at a given column. Frees the previous value.
+    /// </summary>
+    public static IntPtr SetCurrentRowText(IntPtr resultHandle, int columnIndex, string value)
+    {
+        var key = (resultHandle, columnIndex);
+        var newPtr = Marshal.StringToHGlobalAnsi(value);
+
+        if (s_rowTexts.TryGetValue(key, out var oldPtr))
+        {
+            Marshal.FreeHGlobal(oldPtr);
+            s_rowTexts[key] = newPtr;
+        }
+        else
+        {
+            s_rowTexts[key] = newPtr;
+        }
+
+        return newPtr;
+    }
+
+    /// <summary>
+    /// Free all unmanaged strings associated with a result handle.
+    /// </summary>
+    public static void Remove(IntPtr resultHandle)
+    {
+        // Free column name strings
+        foreach (var key in s_columnNames.Keys)
+        {
+            if (key.Item1 == resultHandle && s_columnNames.TryRemove(key, out var ptr))
+                Marshal.FreeHGlobal(ptr);
+        }
+
+        // Free row text strings
+        foreach (var key in s_rowTexts.Keys)
+        {
+            if (key.Item1 == resultHandle && s_rowTexts.TryRemove(key, out var ptr))
+                Marshal.FreeHGlobal(ptr);
+        }
+    }
+}

--- a/src/CSharpDB.Native/Utf8StringMemory.cs
+++ b/src/CSharpDB.Native/Utf8StringMemory.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace CSharpDB.Native;
+
+internal static class Utf8StringMemory
+{
+    public static IntPtr Allocate(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        byte[] bytes = Encoding.UTF8.GetBytes(value);
+        IntPtr buffer = Marshal.AllocHGlobal(bytes.Length + 1);
+        Marshal.Copy(bytes, 0, buffer, bytes.Length);
+        Marshal.WriteByte(buffer, bytes.Length, 0);
+        return buffer;
+    }
+}

--- a/src/CSharpDB.Native/csharpdb.h
+++ b/src/CSharpDB.Native/csharpdb.h
@@ -1,0 +1,211 @@
+/*
+ * csharpdb.h — C API for the CSharpDB embedded database engine.
+ *
+ * This header describes the public interface of the NativeAOT shared library
+ * (csharpdb.dll / libcsharpdb.so / libcsharpdb.dylib).
+ *
+ * All functions are thread-safe with respect to different database handles.
+ * A single database handle must NOT be used concurrently from multiple threads.
+ *
+ * Error handling follows the errno pattern:
+ *   - Functions returning a pointer return NULL on error.
+ *   - Functions returning int return -1 on error (unless documented otherwise).
+ *   - Call csharpdb_last_error() to get the error message after a failure.
+ *
+ * Usage example:
+ *
+ *   csharpdb_t db = csharpdb_open("mydata.db");
+ *   if (!db) { fprintf(stderr, "%s\n", csharpdb_last_error()); exit(1); }
+ *
+ *   csharpdb_result_t r = csharpdb_execute(db, "SELECT id, name FROM users");
+ *   int cols = csharpdb_result_column_count(r);
+ *   while (csharpdb_result_next(r) == 1) {
+ *       long long id   = csharpdb_result_get_int64(r, 0);
+ *       const char* nm = csharpdb_result_get_text(r, 1);
+ *       printf("%lld %s\n", id, nm);
+ *   }
+ *   csharpdb_result_free(r);
+ *   csharpdb_close(db);
+ */
+
+#ifndef CSHARPDB_H
+#define CSHARPDB_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ------------------------------------------------------------------ */
+/*  Opaque handle types                                                */
+/* ------------------------------------------------------------------ */
+
+/** Opaque database handle. */
+typedef void* csharpdb_t;
+
+/** Opaque query result handle. */
+typedef void* csharpdb_result_t;
+
+/* ------------------------------------------------------------------ */
+/*  Column / value type codes (matches CSharpDB.Core.DbType)           */
+/* ------------------------------------------------------------------ */
+
+#define CSHARPDB_NULL    0
+#define CSHARPDB_INTEGER 1
+#define CSHARPDB_REAL    2
+#define CSHARPDB_TEXT    3
+#define CSHARPDB_BLOB    4
+
+/* ------------------------------------------------------------------ */
+/*  Database lifecycle                                                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Open or create a database file.
+ * @param path  UTF-8 file path.
+ * @return Database handle, or NULL on error.
+ */
+csharpdb_t csharpdb_open(const char* path);
+
+/**
+ * Close a database and release all resources.
+ * Safe to call with NULL.
+ */
+void csharpdb_close(csharpdb_t db);
+
+/* ------------------------------------------------------------------ */
+/*  SQL execution                                                      */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Execute a SQL statement.
+ * @param db   Database handle.
+ * @param sql  UTF-8 SQL string.
+ * @return Result handle, or NULL on error.
+ */
+csharpdb_result_t csharpdb_execute(csharpdb_t db, const char* sql);
+
+/* ------------------------------------------------------------------ */
+/*  Result metadata                                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Returns 1 if the result is from a SELECT query, 0 for DML/DDL.
+ */
+int csharpdb_result_is_query(csharpdb_result_t result);
+
+/**
+ * Returns the number of rows affected by INSERT/UPDATE/DELETE.
+ */
+int csharpdb_result_rows_affected(csharpdb_result_t result);
+
+/**
+ * Returns the number of columns in the result set.
+ */
+int csharpdb_result_column_count(csharpdb_result_t result);
+
+/**
+ * Returns the name of a column (UTF-8).
+ * The pointer is valid until csharpdb_result_free().
+ */
+const char* csharpdb_result_column_name(csharpdb_result_t result, int column_index);
+
+/* ------------------------------------------------------------------ */
+/*  Row iteration                                                      */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Advance to the next row.
+ * @return 1 if a row is available, 0 at end of results, -1 on error.
+ */
+int csharpdb_result_next(csharpdb_result_t result);
+
+/**
+ * Returns the type code of the value at the given column in the current row.
+ * See CSHARPDB_NULL, CSHARPDB_INTEGER, etc.
+ */
+int csharpdb_result_column_type(csharpdb_result_t result, int column_index);
+
+/**
+ * Returns 1 if the column value is NULL, 0 otherwise.
+ */
+int csharpdb_result_is_null(csharpdb_result_t result, int column_index);
+
+/**
+ * Read a 64-bit integer from the current row.
+ */
+int64_t csharpdb_result_get_int64(csharpdb_result_t result, int column_index);
+
+/**
+ * Read a double-precision float from the current row.
+ */
+double csharpdb_result_get_double(csharpdb_result_t result, int column_index);
+
+/**
+ * Read a UTF-8 text value from the current row.
+ * The pointer is valid until the next csharpdb_result_next() or csharpdb_result_free().
+ */
+const char* csharpdb_result_get_text(csharpdb_result_t result, int column_index);
+
+/**
+ * Read a blob from the current row.
+ * @param out_size  Receives the blob size in bytes (may be NULL).
+ * @return Pointer to blob data, valid until next row or result free.
+ */
+const void* csharpdb_result_get_blob(csharpdb_result_t result, int column_index, int* out_size);
+
+/**
+ * Free a result handle and all associated resources.
+ * Safe to call with NULL.
+ */
+void csharpdb_result_free(csharpdb_result_t result);
+
+/* ------------------------------------------------------------------ */
+/*  Transactions                                                       */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Begin an explicit transaction.
+ * @return 0 on success, -1 on error.
+ */
+int csharpdb_begin(csharpdb_t db);
+
+/**
+ * Commit the current transaction.
+ * @return 0 on success, -1 on error.
+ */
+int csharpdb_commit(csharpdb_t db);
+
+/**
+ * Rollback the current transaction.
+ * @return 0 on success, -1 on error.
+ */
+int csharpdb_rollback(csharpdb_t db);
+
+/* ------------------------------------------------------------------ */
+/*  Error handling                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Returns the last error message (UTF-8), or NULL if no error.
+ * The pointer is valid until the next API call on the same thread.
+ */
+const char* csharpdb_last_error(void);
+
+/**
+ * Returns the last error code. 0 = no error, -1 = generic error.
+ * Positive values correspond to CSharpDB.Core.ErrorCode values.
+ */
+int csharpdb_last_error_code(void);
+
+/**
+ * Clear the error state for the current thread.
+ */
+void csharpdb_clear_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CSHARPDB_H */

--- a/src/CSharpDB.Service/CSharpDB.Service.csproj
+++ b/src/CSharpDB.Service/CSharpDB.Service.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CSharpDB.Data\CSharpDB.Data.csproj" />
-    <ProjectReference Include="..\CSharpDB.Storage.Diagnostics\CSharpDB.Storage.Diagnostics.csproj" />
+    <ProjectReference Include="..\CSharpDB.Client\CSharpDB.Client.csproj" />
+    <ProjectReference Include="..\CSharpDB.Sql\CSharpDB.Sql.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CSharpDB.Service/CSharpDbService.cs
+++ b/src/CSharpDB.Service/CSharpDbService.cs
@@ -1,10 +1,7 @@
-using System.Data.Common;
-using System.Diagnostics;
-using System.Globalization;
-using System.Text.Json;
-using CSharpDB.Service.Models;
+using CSharpDB.Client;
+using ClientModels = CSharpDB.Client.Models;
 using CSharpDB.Core;
-using CSharpDB.Data;
+using CSharpDB.Service.Models;
 using CSharpDB.Sql;
 using CSharpDB.Storage.Diagnostics;
 using Microsoft.Extensions.Configuration;
@@ -14,45 +11,226 @@ namespace CSharpDB.Service;
 public sealed class CSharpDbService : IAsyncDisposable
 {
     private const string ProcedureTableName = "__procedures";
-    private const string ProcedureEnabledIndexName = "idx___procedures_is_enabled";
-    private const string SavedQueryTableName = "__saved_queries";
-    private const string SavedQueryNameIndexName = "idx___saved_queries_name";
 
-    private readonly CSharpDbConnection _connection;
+    private readonly ICSharpDbClient _client;
     private readonly SemaphoreSlim _lock = new(1, 1);
-    private static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    };
 
     public CSharpDbService(IConfiguration configuration)
     {
-        string connString = configuration.GetConnectionString("CSharpDB")
+        string connectionString = configuration.GetConnectionString("CSharpDB")
             ?? "Data Source=csharpdb.db";
-        _connection = new CSharpDbConnection(connString);
+
+        _client = CSharpDbClient.Create(new CSharpDbClientOptions
+        {
+            ConnectionString = connectionString,
+        });
     }
 
     public async Task InitializeAsync()
-    {
-        await _connection.OpenAsync();
+        => _ = await _client.GetInfoAsync();
 
-        await _lock.WaitAsync();
-        try
-        {
-            await EnsureProcedureCatalogAsync();
-            await EnsureSavedQueryCatalogAsync();
-        }
-        finally { _lock.Release(); }
+    public string DataSource => _client.DataSource;
+
+    public event Action? TablesChanged;
+    public event Action? SchemaChanged;
+    public event Action? ProceduresChanged;
+
+    public async Task<IReadOnlyCollection<string>> GetTableNamesAsync()
+        => (await WithLockAsync(() => _client.GetTableNamesAsync())).ToArray();
+
+    public async Task<TableSchema?> GetTableSchemaAsync(string tableName)
+    {
+        var schema = await WithLockAsync(() => _client.GetTableSchemaAsync(tableName));
+        return schema is null ? null : MapTableSchema(schema);
     }
 
-    public string DataSource => _connection.DataSource;
+    public async Task<IReadOnlyCollection<IndexSchema>> GetIndexesAsync()
+        => (await WithLockAsync(() => _client.GetIndexesAsync())).Select(MapIndexSchema).ToArray();
 
-    /// <summary>Raised after tables are created or dropped so the sidebar can refresh.</summary>
-    public event Action? TablesChanged;
-    /// <summary>Raised after schema objects (tables, indexes, views, triggers) change.</summary>
-    public event Action? SchemaChanged;
-    /// <summary>Raised after procedure definitions change.</summary>
-    public event Action? ProceduresChanged;
+    public async Task<IReadOnlyCollection<ViewDefinition>> GetViewsAsync()
+        => (await WithLockAsync(() => _client.GetViewsAsync())).Select(MapViewDefinition).ToArray();
+
+    public async Task<IReadOnlyCollection<string>> GetViewNamesAsync()
+        => (await WithLockAsync(() => _client.GetViewNamesAsync())).ToArray();
+
+    public Task<string?> GetViewSqlAsync(string viewName)
+        => WithLockAsync(() => _client.GetViewSqlAsync(viewName));
+
+    public async Task<ViewBrowseResult> BrowseViewAsync(string viewName, int page, int pageSize)
+        => MapViewBrowseResult(await WithLockAsync(() => _client.BrowseViewAsync(viewName, page, pageSize)));
+
+    public async Task<IReadOnlyCollection<TriggerSchema>> GetTriggersAsync()
+        => (await WithLockAsync(() => _client.GetTriggersAsync())).Select(MapTriggerSchema).ToArray();
+
+    public async Task<IReadOnlyList<SavedQueryDefinition>> GetSavedQueriesAsync()
+        => (await WithLockAsync(() => _client.GetSavedQueriesAsync())).Select(MapSavedQueryDefinition).ToList();
+
+    public async Task<SavedQueryDefinition?> GetSavedQueryAsync(string name)
+    {
+        var savedQuery = await WithLockAsync(() => _client.GetSavedQueryAsync(name));
+        return savedQuery is null ? null : MapSavedQueryDefinition(savedQuery);
+    }
+
+    public async Task<SavedQueryDefinition> UpsertSavedQueryAsync(string name, string sqlText)
+        => MapSavedQueryDefinition(await WithLockAsync(() => _client.UpsertSavedQueryAsync(name, sqlText)));
+
+    public Task DeleteSavedQueryAsync(string name)
+        => WithLockAsync(() => _client.DeleteSavedQueryAsync(name));
+
+    public async Task<IReadOnlyList<ProcedureDefinition>> GetProceduresAsync(bool includeDisabled = true)
+        => (await WithLockAsync(() => _client.GetProceduresAsync(includeDisabled))).Select(MapProcedureDefinition).ToList();
+
+    public async Task<ProcedureDefinition?> GetProcedureAsync(string name)
+    {
+        var procedure = await WithLockAsync(() => _client.GetProcedureAsync(name));
+        return procedure is null ? null : MapProcedureDefinition(procedure);
+    }
+
+    public async Task CreateProcedureAsync(ProcedureDefinition definition)
+    {
+        await WithLockAsync(() => _client.CreateProcedureAsync(MapProcedureDefinition(definition)));
+        ProceduresChanged?.Invoke();
+    }
+
+    public async Task UpdateProcedureAsync(string existingName, ProcedureDefinition definition)
+    {
+        await WithLockAsync(() => _client.UpdateProcedureAsync(existingName, MapProcedureDefinition(definition)));
+        ProceduresChanged?.Invoke();
+    }
+
+    public async Task DeleteProcedureAsync(string name)
+    {
+        await WithLockAsync(() => _client.DeleteProcedureAsync(name));
+        ProceduresChanged?.Invoke();
+    }
+
+    public async Task<ProcedureExecutionResult> ExecuteProcedureAsync(string name, IReadOnlyDictionary<string, object?> args)
+        => MapProcedureExecutionResult(await WithLockAsync(() => _client.ExecuteProcedureAsync(name, args)));
+
+    public async Task<TableBrowseResult> BrowseTableAsync(string tableName, int page, int pageSize)
+        => MapTableBrowseResult(await WithLockAsync(() => _client.BrowseTableAsync(tableName, page, pageSize)));
+
+    public Task<Dictionary<string, object?>?> GetRowByPkAsync(string tableName, string pkColumn, object pkValue)
+        => WithLockAsync(() => _client.GetRowByPkAsync(tableName, pkColumn, pkValue));
+
+    public Task<int> InsertRowAsync(string tableName, Dictionary<string, object?> values)
+        => WithLockAsync(() => _client.InsertRowAsync(tableName, values));
+
+    public Task<int> UpdateRowAsync(string tableName, string pkColumn, object pkValue, Dictionary<string, object?> values)
+        => WithLockAsync(() => _client.UpdateRowAsync(tableName, pkColumn, pkValue, values));
+
+    public Task<int> DeleteRowAsync(string tableName, string pkColumn, object pkValue)
+        => WithLockAsync(() => _client.DeleteRowAsync(tableName, pkColumn, pkValue));
+
+    public async Task DropTableAsync(string tableName)
+    {
+        await WithLockAsync(() => _client.DropTableAsync(tableName));
+        NotifySchemaChanged(tablesMayHaveChanged: true);
+    }
+
+    public async Task RenameTableAsync(string tableName, string newTableName)
+    {
+        await WithLockAsync(() => _client.RenameTableAsync(tableName, newTableName));
+        NotifySchemaChanged(tablesMayHaveChanged: true);
+    }
+
+    public async Task AddColumnAsync(string tableName, string columnName, DbType type, bool notNull)
+    {
+        await WithLockAsync(() => _client.AddColumnAsync(tableName, columnName, MapDbType(type), notNull));
+        NotifySchemaChanged(tablesMayHaveChanged: true);
+    }
+
+    public async Task DropColumnAsync(string tableName, string columnName)
+    {
+        await WithLockAsync(() => _client.DropColumnAsync(tableName, columnName));
+        NotifySchemaChanged(tablesMayHaveChanged: true);
+    }
+
+    public async Task RenameColumnAsync(string tableName, string oldColumnName, string newColumnName)
+    {
+        await WithLockAsync(() => _client.RenameColumnAsync(tableName, oldColumnName, newColumnName));
+        NotifySchemaChanged(tablesMayHaveChanged: true);
+    }
+
+    public async Task CreateIndexAsync(string indexName, string tableName, string columnName, bool isUnique)
+    {
+        await WithLockAsync(() => _client.CreateIndexAsync(indexName, tableName, columnName, isUnique));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task UpdateIndexAsync(string existingIndexName, string newIndexName, string tableName, string columnName, bool isUnique)
+    {
+        await WithLockAsync(() => _client.UpdateIndexAsync(existingIndexName, newIndexName, tableName, columnName, isUnique));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task DropIndexAsync(string indexName)
+    {
+        await WithLockAsync(() => _client.DropIndexAsync(indexName));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task CreateViewAsync(string viewName, string selectSql)
+    {
+        await WithLockAsync(() => _client.CreateViewAsync(viewName, selectSql));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task UpdateViewAsync(string existingViewName, string newViewName, string selectSql)
+    {
+        await WithLockAsync(() => _client.UpdateViewAsync(existingViewName, newViewName, selectSql));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task DropViewAsync(string viewName)
+    {
+        await WithLockAsync(() => _client.DropViewAsync(viewName));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task CreateTriggerAsync(string triggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql)
+    {
+        await WithLockAsync(() => _client.CreateTriggerAsync(triggerName, tableName, MapTriggerTiming(timing), MapTriggerEvent(triggerEvent), bodySql));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task UpdateTriggerAsync(string existingTriggerName, string newTriggerName, string tableName, TriggerTiming timing, TriggerEvent triggerEvent, string bodySql)
+    {
+        await WithLockAsync(() => _client.UpdateTriggerAsync(existingTriggerName, newTriggerName, tableName, MapTriggerTiming(timing), MapTriggerEvent(triggerEvent), bodySql));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task DropTriggerAsync(string triggerName)
+    {
+        await WithLockAsync(() => _client.DropTriggerAsync(triggerName));
+        NotifySchemaChanged(tablesMayHaveChanged: false);
+    }
+
+    public async Task<SqlExecutionResult> ExecuteSqlAsync(string sql)
+    {
+        var result = MapSqlExecutionResult(await WithLockAsync(() => _client.ExecuteSqlAsync(sql)));
+        AnalyzeSqlEffects(sql, out bool schemaMutated, out bool tableMutated, out bool proceduresMutated);
+        if (schemaMutated)
+            NotifySchemaChanged(tableMutated);
+        if (proceduresMutated)
+            ProceduresChanged?.Invoke();
+        return result;
+    }
+
+    public Task<DatabaseInspectReport> InspectStorageAsync(string? databasePath = null, bool includePages = false)
+        => WithLockAsync(() => _client.InspectStorageAsync(databasePath, includePages));
+
+    public Task<WalInspectReport> CheckWalAsync(string? databasePath = null)
+        => WithLockAsync(() => _client.CheckWalAsync(databasePath));
+
+    public Task<PageInspectReport> InspectPageAsync(uint pageId, bool includeHex = false, string? databasePath = null)
+        => WithLockAsync(() => _client.InspectPageAsync(pageId, includeHex, databasePath));
+
+    public Task<IndexInspectReport> CheckIndexesAsync(string? databasePath = null, string? indexName = null, int? sampleSize = null)
+        => WithLockAsync(() => _client.CheckIndexesAsync(databasePath, indexName, sampleSize));
+
+    public Task<int> GetRowCountAsync(string tableName)
+        => WithLockAsync(() => _client.GetRowCountAsync(tableName));
 
     private void NotifySchemaChanged(bool tablesMayHaveChanged)
     {
@@ -61,1905 +239,223 @@ public sealed class CSharpDbService : IAsyncDisposable
             TablesChanged?.Invoke();
     }
 
-    private void NotifyProceduresChanged() => ProceduresChanged?.Invoke();
-
-    // ─── Schema ────────────────────────────────────────────────────
-
-    public async Task<IReadOnlyCollection<string>> GetTableNamesAsync()
+    private async Task<T> WithLockAsync<T>(Func<Task<T>> action)
     {
         await _lock.WaitAsync();
-        try
-        {
-            return _connection.GetTableNames()
-                .Where(name => !IsInternalTable(name))
-                .ToArray();
-        }
+        try { return await action(); }
         finally { _lock.Release(); }
     }
 
-    public async Task<TableSchema?> GetTableSchemaAsync(string tableName)
+    private async Task WithLockAsync(Func<Task> action)
     {
         await _lock.WaitAsync();
-        try
-        {
-            if (IsInternalTable(tableName))
-                return null;
-            return _connection.GetTableSchema(tableName);
-        }
+        try { await action(); }
         finally { _lock.Release(); }
     }
 
-    public async Task<IReadOnlyCollection<IndexSchema>> GetIndexesAsync()
+    private static ClientModels.DbType MapDbType(DbType type) => type switch
     {
-        await _lock.WaitAsync();
-        try
-        {
-            return _connection.GetIndexes()
-                .OrderBy(i => i.IndexName, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<IReadOnlyCollection<ViewDefinition>> GetViewsAsync()
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            var views = new List<ViewDefinition>();
-            foreach (var viewName in _connection.GetViewNames().OrderBy(v => v, StringComparer.OrdinalIgnoreCase))
-            {
-                views.Add(new ViewDefinition
-                {
-                    Name = viewName,
-                    Sql = _connection.GetViewSql(viewName) ?? string.Empty,
-                });
-            }
-
-            return views;
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<IReadOnlyCollection<string>> GetViewNamesAsync()
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            return _connection.GetViewNames()
-                .OrderBy(v => v, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<string?> GetViewSqlAsync(string viewName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateViewName(viewName);
-            return _connection.GetViewSql(viewName);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<ViewBrowseResult> BrowseViewAsync(string viewName, int page, int pageSize)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateViewName(viewName);
-
-            int totalRows = await CountRowsInternal(viewName);
-            int offset = (page - 1) * pageSize;
-            var rows = new List<object?[]>();
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"SELECT * FROM {viewName} LIMIT @limit OFFSET @offset;";
-            cmd.Parameters.AddWithValue("@limit", pageSize);
-            cmd.Parameters.AddWithValue("@offset", offset);
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            var columnNames = new string[reader.FieldCount];
-            for (int i = 0; i < reader.FieldCount; i++)
-                columnNames[i] = reader.GetName(i);
-
-            while (await reader.ReadAsync())
-            {
-                var row = new object?[reader.FieldCount];
-                for (int i = 0; i < reader.FieldCount; i++)
-                    row[i] = reader.IsDBNull(i) ? null : reader.GetValue(i);
-                rows.Add(row);
-            }
-
-            return new ViewBrowseResult
-            {
-                ViewName = viewName,
-                ColumnNames = columnNames,
-                Rows = rows,
-                TotalRows = totalRows,
-                Page = page,
-                PageSize = pageSize,
-            };
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<IReadOnlyCollection<TriggerSchema>> GetTriggersAsync()
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            return _connection.GetTriggers()
-                .OrderBy(t => t.TriggerName, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Saved Queries ────────────────────────────────────────────
-
-    public async Task<IReadOnlyList<SavedQueryDefinition>> GetSavedQueriesAsync()
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            var savedQueries = new List<SavedQueryDefinition>();
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"""
-                SELECT id, name, sql_text, created_utc, updated_utc
-                FROM {SavedQueryTableName}
-                ORDER BY name;
-                """;
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-                savedQueries.Add(ReadSavedQueryDefinition(reader));
-
-            return savedQueries;
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<SavedQueryDefinition?> GetSavedQueryAsync(string name)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            string normalizedName = NormalizeSavedQueryName(name);
-            return await GetSavedQueryInternalAsync(normalizedName);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<SavedQueryDefinition> UpsertSavedQueryAsync(string name, string sqlText)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            string normalizedName = NormalizeSavedQueryName(name);
-            string normalizedSql = NormalizeSqlFragment(sqlText, "saved query SQL");
-
-            var existing = await GetSavedQueryInternalAsync(normalizedName);
-            var now = DateTime.UtcNow;
-            string nowText = now.ToString("O", CultureInfo.InvariantCulture);
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            if (existing is null)
-            {
-                cmd.CommandText = $"""
-                    INSERT INTO {SavedQueryTableName} (name, sql_text, created_utc, updated_utc)
-                    VALUES (@name, @sql, @created, @updated);
-                    """;
-                cmd.Parameters.AddWithValue("@name", normalizedName);
-                cmd.Parameters.AddWithValue("@sql", normalizedSql);
-                cmd.Parameters.AddWithValue("@created", nowText);
-                cmd.Parameters.AddWithValue("@updated", nowText);
-            }
-            else
-            {
-                cmd.CommandText = $"""
-                    UPDATE {SavedQueryTableName}
-                    SET sql_text = @sql,
-                        updated_utc = @updated
-                    WHERE name = @name;
-                    """;
-                cmd.Parameters.AddWithValue("@name", normalizedName);
-                cmd.Parameters.AddWithValue("@sql", normalizedSql);
-                cmd.Parameters.AddWithValue("@updated", nowText);
-            }
-
-            await cmd.ExecuteNonQueryAsync();
-
-            return await GetSavedQueryInternalAsync(normalizedName)
-                ?? throw new InvalidOperationException($"Saved query '{normalizedName}' could not be loaded after save.");
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task DeleteSavedQueryAsync(string name)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            string normalizedName = NormalizeSavedQueryName(name);
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"DELETE FROM {SavedQueryTableName} WHERE name = @name;";
-            cmd.Parameters.AddWithValue("@name", normalizedName);
-            int affected = await cmd.ExecuteNonQueryAsync();
-            if (affected == 0)
-                throw new ArgumentException($"Saved query '{normalizedName}' not found.");
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Procedures ────────────────────────────────────────────────
-
-    public async Task<IReadOnlyList<ProcedureDefinition>> GetProceduresAsync(bool includeDisabled = true)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            var procedures = new List<ProcedureDefinition>();
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = includeDisabled
-                ? $"SELECT name, body_sql, params_json, description, is_enabled, created_utc, updated_utc FROM {ProcedureTableName} ORDER BY name;"
-                : $"SELECT name, body_sql, params_json, description, is_enabled, created_utc, updated_utc FROM {ProcedureTableName} WHERE is_enabled = 1 ORDER BY name;";
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-                procedures.Add(ReadProcedureDefinition(reader));
-
-            return procedures;
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<ProcedureDefinition?> GetProcedureAsync(string name)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(name, "procedure name");
-            return await GetProcedureInternalAsync(name);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task CreateProcedureAsync(ProcedureDefinition definition)
-    {
-        ArgumentNullException.ThrowIfNull(definition);
-
-        await _lock.WaitAsync();
-        try
-        {
-            var normalized = NormalizeProcedureDefinition(definition, defaultCreatedUtc: DateTime.UtcNow);
-            if (await GetProcedureInternalAsync(normalized.Name) is not null)
-                throw new ArgumentException($"Procedure '{normalized.Name}' already exists.");
-
-            string paramsJson = SerializeProcedureParameters(normalized.Parameters);
-            string createdUtc = normalized.CreatedUtc.ToString("O", CultureInfo.InvariantCulture);
-            string updatedUtc = normalized.UpdatedUtc.ToString("O", CultureInfo.InvariantCulture);
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"""
-                INSERT INTO {ProcedureTableName}
-                    (name, body_sql, params_json, description, is_enabled, created_utc, updated_utc)
-                VALUES
-                    (@name, @body, @params, @description, @enabled, @created, @updated);
-                """;
-            cmd.Parameters.AddWithValue("@name", normalized.Name);
-            cmd.Parameters.AddWithValue("@body", normalized.BodySql);
-            cmd.Parameters.AddWithValue("@params", paramsJson);
-            cmd.Parameters.AddWithValue("@description", normalized.Description is null ? DBNull.Value : normalized.Description);
-            cmd.Parameters.AddWithValue("@enabled", normalized.IsEnabled ? 1L : 0L);
-            cmd.Parameters.AddWithValue("@created", createdUtc);
-            cmd.Parameters.AddWithValue("@updated", updatedUtc);
-            await cmd.ExecuteNonQueryAsync();
-
-            NotifyProceduresChanged();
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task UpdateProcedureAsync(string existingName, ProcedureDefinition definition)
-    {
-        ArgumentNullException.ThrowIfNull(definition);
-
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(existingName, "existing procedure name");
-            var existing = await GetProcedureInternalAsync(existingName);
-            if (existing is null)
-                throw new ArgumentException($"Procedure '{existingName}' not found.");
-
-            var normalized = NormalizeProcedureDefinition(definition, existing.CreatedUtc);
-            string paramsJson = SerializeProcedureParameters(normalized.Parameters);
-            string createdUtc = normalized.CreatedUtc.ToString("O", CultureInfo.InvariantCulture);
-            string updatedUtc = normalized.UpdatedUtc.ToString("O", CultureInfo.InvariantCulture);
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"""
-                UPDATE {ProcedureTableName}
-                SET name = @newName,
-                    body_sql = @body,
-                    params_json = @params,
-                    description = @description,
-                    is_enabled = @enabled,
-                    created_utc = @created,
-                    updated_utc = @updated
-                WHERE name = @existing;
-                """;
-            cmd.Parameters.AddWithValue("@newName", normalized.Name);
-            cmd.Parameters.AddWithValue("@body", normalized.BodySql);
-            cmd.Parameters.AddWithValue("@params", paramsJson);
-            cmd.Parameters.AddWithValue("@description", normalized.Description is null ? DBNull.Value : normalized.Description);
-            cmd.Parameters.AddWithValue("@enabled", normalized.IsEnabled ? 1L : 0L);
-            cmd.Parameters.AddWithValue("@created", createdUtc);
-            cmd.Parameters.AddWithValue("@updated", updatedUtc);
-            cmd.Parameters.AddWithValue("@existing", existingName);
-            int affected = await cmd.ExecuteNonQueryAsync();
-            if (affected == 0)
-                throw new ArgumentException($"Procedure '{existingName}' not found.");
-
-            NotifyProceduresChanged();
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task DeleteProcedureAsync(string name)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(name, "procedure name");
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"DELETE FROM {ProcedureTableName} WHERE name = @name;";
-            cmd.Parameters.AddWithValue("@name", name);
-            int affected = await cmd.ExecuteNonQueryAsync();
-            if (affected == 0)
-                throw new ArgumentException($"Procedure '{name}' not found.");
-
-            NotifyProceduresChanged();
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<ProcedureExecutionResult> ExecuteProcedureAsync(
-        string name,
-        IReadOnlyDictionary<string, object?> args)
-    {
-        ArgumentNullException.ThrowIfNull(args);
-
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(name, "procedure name");
-
-            var procedure = await GetProcedureInternalAsync(name);
-            if (procedure is null)
-                throw new ArgumentException($"Procedure '{name}' not found.");
-
-            if (!procedure.IsEnabled)
-            {
-                return new ProcedureExecutionResult
-                {
-                    ProcedureName = name,
-                    Succeeded = false,
-                    Error = $"Procedure '{name}' is disabled.",
-                    Elapsed = TimeSpan.Zero,
-                };
-            }
-
-            var totalSw = Stopwatch.StartNew();
-            Dictionary<string, object?> boundArgs;
-            try
-            {
-                boundArgs = BindProcedureArguments(procedure, args);
-            }
-            catch (ArgumentException ex)
-            {
-                totalSw.Stop();
-                return new ProcedureExecutionResult
-                {
-                    ProcedureName = name,
-                    Succeeded = false,
-                    Error = ex.Message,
-                    Elapsed = totalSw.Elapsed,
-                };
-            }
-
-            IReadOnlyList<string> statements;
-            try
-            {
-                statements = SplitSqlStatements(procedure.BodySql);
-            }
-            catch (CSharpDbException ex)
-            {
-                totalSw.Stop();
-                return new ProcedureExecutionResult
-                {
-                    ProcedureName = name,
-                    Succeeded = false,
-                    Error = ex.Message,
-                    Elapsed = totalSw.Elapsed,
-                };
-            }
-
-            var results = new List<ProcedureStatementExecutionResult>(statements.Count);
-            bool schemaMutated = false;
-            bool tableMutated = false;
-            bool proceduresMutated = false;
-
-            await using var tx = await _connection.BeginTransactionAsync();
-            try
-            {
-                for (int i = 0; i < statements.Count; i++)
-                {
-                    string statement = statements[i];
-                    var single = await ExecuteSingleStatementWithArgumentsAsync(i, statement, boundArgs);
-                    results.Add(single);
-
-                    if (LooksLikeSchemaMutation(statement))
-                    {
-                        schemaMutated = true;
-                        tableMutated |= LooksLikeTableMutation(statement);
-                    }
-
-                    proceduresMutated |= LooksLikeProcedureMutation(statement);
-                }
-
-                await tx.CommitAsync();
-            }
-            catch (DbException ex)
-            {
-                await tx.RollbackAsync();
-                totalSw.Stop();
-                return new ProcedureExecutionResult
-                {
-                    ProcedureName = name,
-                    Succeeded = false,
-                    Statements = results,
-                    Error = ex.Message,
-                    FailedStatementIndex = results.Count,
-                    Elapsed = totalSw.Elapsed,
-                };
-            }
-            catch (OperationCanceledException)
-            {
-                await tx.RollbackAsync();
-                throw;
-            }
-            catch (Exception ex)
-            {
-                await tx.RollbackAsync();
-                totalSw.Stop();
-                return new ProcedureExecutionResult
-                {
-                    ProcedureName = name,
-                    Succeeded = false,
-                    Statements = results,
-                    Error = ex.Message,
-                    FailedStatementIndex = results.Count,
-                    Elapsed = totalSw.Elapsed,
-                };
-            }
-
-            totalSw.Stop();
-
-            if (schemaMutated)
-                NotifySchemaChanged(tablesMayHaveChanged: tableMutated);
-            if (proceduresMutated)
-                NotifyProceduresChanged();
-
-            return new ProcedureExecutionResult
-            {
-                ProcedureName = name,
-                Succeeded = true,
-                Statements = results,
-                Elapsed = totalSw.Elapsed,
-            };
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Browse (paginated) ────────────────────────────────────────
-
-    public async Task<TableBrowseResult> BrowseTableAsync(string tableName, int page, int pageSize)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            var schema = _connection.GetTableSchema(tableName)!;
-
-            int totalRows = await CountRowsInternal(tableName);
-
-            int offset = (page - 1) * pageSize;
-            var rows = new List<object?[]>();
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"SELECT * FROM {tableName} LIMIT @limit OFFSET @offset;";
-            cmd.Parameters.AddWithValue("@limit", pageSize);
-            cmd.Parameters.AddWithValue("@offset", offset);
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-            {
-                var row = new object?[reader.FieldCount];
-                for (int i = 0; i < reader.FieldCount; i++)
-                    row[i] = reader.IsDBNull(i) ? null : reader.GetValue(i);
-                rows.Add(row);
-            }
-
-            return new TableBrowseResult
-            {
-                TableName = tableName,
-                Schema = schema,
-                Rows = rows,
-                TotalRows = totalRows,
-                Page = page,
-                PageSize = pageSize,
-            };
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Single row by PK ──────────────────────────────────────────
-
-    public async Task<Dictionary<string, object?>?> GetRowByPkAsync(
-        string tableName, string pkColumn, object pkValue)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            ValidateColumnName(tableName, pkColumn);
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"SELECT * FROM {tableName} WHERE {pkColumn} = @pk;";
-            cmd.Parameters.AddWithValue("@pk", pkValue);
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync())
-                return null;
-
-            var result = new Dictionary<string, object?>();
-            for (int i = 0; i < reader.FieldCount; i++)
-            {
-                string name = reader.GetName(i);
-                result[name] = reader.IsDBNull(i) ? null : reader.GetValue(i);
-            }
-            return result;
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Insert ────────────────────────────────────────────────────
-
-    public async Task<int> InsertRowAsync(string tableName, Dictionary<string, object?> values)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            var schema = _connection.GetTableSchema(tableName)!;
-
-            var cols = new List<string>();
-            var paramNames = new List<string>();
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            int idx = 0;
-            foreach (var (col, val) in values)
-            {
-                ValidateColumnName(tableName, col);
-                cols.Add(col);
-                string pName = $"@p{idx}";
-                paramNames.Add(pName);
-                cmd.Parameters.AddWithValue(pName, val ?? DBNull.Value);
-                idx++;
-            }
-
-            cmd.CommandText = $"INSERT INTO {tableName} ({string.Join(", ", cols)}) VALUES ({string.Join(", ", paramNames)});";
-            return await cmd.ExecuteNonQueryAsync();
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Update ────────────────────────────────────────────────────
-
-    public async Task<int> UpdateRowAsync(
-        string tableName, string pkColumn, object pkValue, Dictionary<string, object?> values)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            ValidateColumnName(tableName, pkColumn);
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            var setClauses = new List<string>();
-            int idx = 0;
-            foreach (var (col, val) in values)
-            {
-                if (col == pkColumn) continue;
-                ValidateColumnName(tableName, col);
-                string pName = $"@p{idx}";
-                setClauses.Add($"{col} = {pName}");
-                cmd.Parameters.AddWithValue(pName, val ?? DBNull.Value);
-                idx++;
-            }
-
-            cmd.Parameters.AddWithValue("@pk", pkValue);
-            cmd.CommandText = $"UPDATE {tableName} SET {string.Join(", ", setClauses)} WHERE {pkColumn} = @pk;";
-            return await cmd.ExecuteNonQueryAsync();
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Delete ────────────────────────────────────────────────────
-
-    public async Task<int> DeleteRowAsync(string tableName, string pkColumn, object pkValue)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            ValidateColumnName(tableName, pkColumn);
-
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"DELETE FROM {tableName} WHERE {pkColumn} = @pk;";
-            cmd.Parameters.AddWithValue("@pk", pkValue);
-            return await cmd.ExecuteNonQueryAsync();
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Drop Table ────────────────────────────────────────────────
-
-    public async Task DropTableAsync(string tableName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"DROP TABLE {tableName};";
-            await cmd.ExecuteNonQueryAsync();
-            NotifySchemaChanged(tablesMayHaveChanged: true);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task RenameTableAsync(string tableName, string newTableName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            ValidateIdentifier(newTableName, "new table name");
-            await ExecuteNonQueryAsync($"ALTER TABLE {tableName} RENAME TO {newTableName};");
-            NotifySchemaChanged(tablesMayHaveChanged: true);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task AddColumnAsync(string tableName, string columnName, DbType type, bool notNull)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            ValidateIdentifier(columnName, "column name");
-            string nullClause = notNull ? " NOT NULL" : string.Empty;
-            await ExecuteNonQueryAsync($"ALTER TABLE {tableName} ADD COLUMN {columnName} {type.ToString().ToUpperInvariant()}{nullClause};");
-            NotifySchemaChanged(tablesMayHaveChanged: true);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task DropColumnAsync(string tableName, string columnName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            ValidateColumnName(tableName, columnName);
-            await ExecuteNonQueryAsync($"ALTER TABLE {tableName} DROP COLUMN {columnName};");
-            NotifySchemaChanged(tablesMayHaveChanged: true);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task RenameColumnAsync(string tableName, string oldColumnName, string newColumnName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            ValidateColumnName(tableName, oldColumnName);
-            ValidateIdentifier(newColumnName, "new column name");
-            await ExecuteNonQueryAsync($"ALTER TABLE {tableName} RENAME COLUMN {oldColumnName} TO {newColumnName};");
-            NotifySchemaChanged(tablesMayHaveChanged: true);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task CreateIndexAsync(string indexName, string tableName, string columnName, bool isUnique)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(indexName, "index name");
-            ValidateTableName(tableName);
-            ValidateColumnName(tableName, columnName);
-
-            string uniqueClause = isUnique ? "UNIQUE " : string.Empty;
-            await ExecuteNonQueryAsync($"CREATE {uniqueClause}INDEX {indexName} ON {tableName} ({columnName});");
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task UpdateIndexAsync(
-        string existingIndexName,
-        string newIndexName,
-        string tableName,
-        string columnName,
-        bool isUnique)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(existingIndexName, "existing index name");
-            ValidateIdentifier(newIndexName, "new index name");
-            ValidateTableName(tableName);
-            ValidateColumnName(tableName, columnName);
-
-            await using var tx = await _connection.BeginTransactionAsync();
-            try
-            {
-                await ExecuteNonQueryAsync($"DROP INDEX {existingIndexName};");
-
-                string uniqueClause = isUnique ? "UNIQUE " : string.Empty;
-                await ExecuteNonQueryAsync($"CREATE {uniqueClause}INDEX {newIndexName} ON {tableName} ({columnName});");
-                await tx.CommitAsync();
-            }
-            catch
-            {
-                await tx.RollbackAsync();
-                throw;
-            }
-
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task DropIndexAsync(string indexName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(indexName, "index name");
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"DROP INDEX {indexName};";
-            await cmd.ExecuteNonQueryAsync();
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task CreateViewAsync(string viewName, string selectSql)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(viewName, "view name");
-            string normalizedSelect = NormalizeSqlFragment(selectSql, "view query");
-            await ExecuteNonQueryAsync($"CREATE VIEW {viewName} AS {normalizedSelect};");
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task UpdateViewAsync(string existingViewName, string newViewName, string selectSql)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(existingViewName, "existing view name");
-            ValidateIdentifier(newViewName, "new view name");
-            string normalizedSelect = NormalizeSqlFragment(selectSql, "view query");
-
-            await using var tx = await _connection.BeginTransactionAsync();
-            try
-            {
-                await ExecuteNonQueryAsync($"DROP VIEW {existingViewName};");
-                await ExecuteNonQueryAsync($"CREATE VIEW {newViewName} AS {normalizedSelect};");
-                await tx.CommitAsync();
-            }
-            catch
-            {
-                await tx.RollbackAsync();
-                throw;
-            }
-
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task DropViewAsync(string viewName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(viewName, "view name");
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"DROP VIEW {viewName};";
-            await cmd.ExecuteNonQueryAsync();
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task CreateTriggerAsync(
-        string triggerName,
-        string tableName,
-        TriggerTiming timing,
-        TriggerEvent triggerEvent,
-        string bodySql)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(triggerName, "trigger name");
-            ValidateTableName(tableName);
-            string normalizedBody = NormalizeSqlFragment(bodySql, "trigger body");
-
-            await ExecuteNonQueryAsync(
-                $"CREATE TRIGGER {triggerName} {timing.ToString().ToUpperInvariant()} {triggerEvent.ToString().ToUpperInvariant()} ON {tableName} BEGIN {normalizedBody}; END;");
-
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task UpdateTriggerAsync(
-        string existingTriggerName,
-        string newTriggerName,
-        string tableName,
-        TriggerTiming timing,
-        TriggerEvent triggerEvent,
-        string bodySql)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(existingTriggerName, "existing trigger name");
-            ValidateIdentifier(newTriggerName, "new trigger name");
-            ValidateTableName(tableName);
-            string normalizedBody = NormalizeSqlFragment(bodySql, "trigger body");
-
-            await using var tx = await _connection.BeginTransactionAsync();
-            try
-            {
-                await ExecuteNonQueryAsync($"DROP TRIGGER {existingTriggerName};");
-                await ExecuteNonQueryAsync(
-                    $"CREATE TRIGGER {newTriggerName} {timing.ToString().ToUpperInvariant()} {triggerEvent.ToString().ToUpperInvariant()} ON {tableName} BEGIN {normalizedBody}; END;");
-                await tx.CommitAsync();
-            }
-            catch
-            {
-                await tx.RollbackAsync();
-                throw;
-            }
-
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task DropTriggerAsync(string triggerName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateIdentifier(triggerName, "trigger name");
-            using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-            cmd.CommandText = $"DROP TRIGGER {triggerName};";
-            await cmd.ExecuteNonQueryAsync();
-            NotifySchemaChanged(tablesMayHaveChanged: false);
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── SQL Console ───────────────────────────────────────────────
-
-    public async Task<SqlExecutionResult> ExecuteSqlAsync(string sql)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            var sw = Stopwatch.StartNew();
-            IReadOnlyList<string> statements;
-            try
-            {
-                statements = SplitSqlStatements(sql);
-            }
-            catch (CSharpDbException ex)
-            {
-                sw.Stop();
-                return new SqlExecutionResult
-                {
-                    Error = ex.Message,
-                    Elapsed = sw.Elapsed,
-                };
-            }
-
-            if (statements.Count == 0)
-            {
-                sw.Stop();
-                return new SqlExecutionResult
-                {
-                    IsQuery = false,
-                    RowsAffected = 0,
-                    Elapsed = sw.Elapsed,
-                };
-            }
-
-            SqlExecutionResult? lastResult = null;
-            int totalRowsAffected = 0;
-            bool schemaMutated = false;
-            bool tableMutated = false;
-            bool proceduresMutated = false;
-
-            for (int i = 0; i < statements.Count; i++)
-            {
-                string statement = statements[i];
-
-                try
-                {
-                    var singleResult = await ExecuteSingleStatementAsync(statement);
-                    lastResult = singleResult;
-
-                    if (!singleResult.IsQuery)
-                        totalRowsAffected += singleResult.RowsAffected;
-
-                    if (LooksLikeSchemaMutation(statement))
-                    {
-                        schemaMutated = true;
-                        tableMutated |= LooksLikeTableMutation(statement);
-                    }
-
-                    proceduresMutated |= LooksLikeProcedureMutation(statement);
-                }
-                catch (DbException ex)
-                {
-                    sw.Stop();
-
-                    if (schemaMutated)
-                        NotifySchemaChanged(tablesMayHaveChanged: tableMutated);
-                    if (proceduresMutated)
-                        NotifyProceduresChanged();
-
-                    string error = statements.Count > 1
-                        ? $"Statement {i + 1} failed: {ex.Message}"
-                        : ex.Message;
-
-                    return new SqlExecutionResult
-                    {
-                        Error = error,
-                        Elapsed = sw.Elapsed,
-                    };
-                }
-            }
-
-            sw.Stop();
-
-            if (schemaMutated)
-                NotifySchemaChanged(tablesMayHaveChanged: tableMutated);
-            if (proceduresMutated)
-                NotifyProceduresChanged();
-
-            if (lastResult is null)
-            {
-                return new SqlExecutionResult
-                {
-                    IsQuery = false,
-                    RowsAffected = 0,
-                    Elapsed = sw.Elapsed,
-                };
-            }
-
-            if (lastResult.IsQuery)
-            {
-                return new SqlExecutionResult
-                {
-                    IsQuery = true,
-                    ColumnNames = lastResult.ColumnNames,
-                    Rows = lastResult.Rows,
-                    RowsAffected = lastResult.RowsAffected,
-                    Elapsed = sw.Elapsed,
-                };
-            }
-
-            return new SqlExecutionResult
-            {
-                IsQuery = false,
-                RowsAffected = totalRowsAffected,
-                Elapsed = sw.Elapsed,
-            };
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Storage Diagnostics (read-only) ───────────────────────────
-
-    public async Task<DatabaseInspectReport> InspectStorageAsync(
-        string? databasePath = null,
-        bool includePages = false)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            string dbPath = ResolveDatabasePath(databasePath);
-            return await DatabaseInspector.InspectAsync(
-                dbPath,
-                new DatabaseInspectOptions { IncludePages = includePages });
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<WalInspectReport> CheckWalAsync(string? databasePath = null)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            string dbPath = ResolveDatabasePath(databasePath);
-            return await WalInspector.InspectAsync(dbPath);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<PageInspectReport> InspectPageAsync(
-        uint pageId,
-        bool includeHex = false,
-        string? databasePath = null)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            string dbPath = ResolveDatabasePath(databasePath);
-            return await DatabaseInspector.InspectPageAsync(dbPath, pageId, includeHex);
-        }
-        finally { _lock.Release(); }
-    }
-
-    public async Task<IndexInspectReport> CheckIndexesAsync(
-        string? databasePath = null,
-        string? indexName = null,
-        int? sampleSize = null)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            string dbPath = ResolveDatabasePath(databasePath);
-            return await IndexInspector.CheckAsync(dbPath, indexName, sampleSize);
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Row count ─────────────────────────────────────────────────
-
-    public async Task<int> GetRowCountAsync(string tableName)
-    {
-        await _lock.WaitAsync();
-        try
-        {
-            ValidateTableName(tableName);
-            return await CountRowsInternal(tableName);
-        }
-        finally { _lock.Release(); }
-    }
-
-    // ─── Helpers ───────────────────────────────────────────────────
-
-    private async Task<int> CountRowsInternal(string tableName)
-    {
-        using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-        cmd.CommandText = $"SELECT COUNT(*) FROM {tableName};";
-        object? scalar = await cmd.ExecuteScalarAsync();
-        if (scalar is null || scalar is DBNull)
-            return 0;
-        return Convert.ToInt32(scalar, CultureInfo.InvariantCulture);
-    }
-
-    private static bool IsInternalTable(string tableName)
-        => string.Equals(tableName, ProcedureTableName, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(tableName, SavedQueryTableName, StringComparison.OrdinalIgnoreCase);
-
-    private async Task EnsureProcedureCatalogAsync()
-    {
-        await ExecuteNonQueryAsync($"""
-            CREATE TABLE IF NOT EXISTS {ProcedureTableName} (
-                name TEXT PRIMARY KEY,
-                body_sql TEXT NOT NULL,
-                params_json TEXT NOT NULL,
-                description TEXT,
-                is_enabled INTEGER NOT NULL,
-                created_utc TEXT NOT NULL,
-                updated_utc TEXT NOT NULL
-            );
-            """);
-
-        await ExecuteNonQueryAsync($"""
-            CREATE INDEX IF NOT EXISTS {ProcedureEnabledIndexName}
-            ON {ProcedureTableName} (is_enabled);
-            """);
-    }
-
-    private async Task EnsureSavedQueryCatalogAsync()
-    {
-        await ExecuteNonQueryAsync($"""
-            CREATE TABLE IF NOT EXISTS {SavedQueryTableName} (
-                id INTEGER PRIMARY KEY IDENTITY,
-                name TEXT NOT NULL,
-                sql_text TEXT NOT NULL,
-                created_utc TEXT NOT NULL,
-                updated_utc TEXT NOT NULL
-            );
-            """);
-
-        await ExecuteNonQueryAsync($"""
-            CREATE UNIQUE INDEX IF NOT EXISTS {SavedQueryNameIndexName}
-            ON {SavedQueryTableName} (name);
-            """);
-    }
-
-    private async Task<SavedQueryDefinition?> GetSavedQueryInternalAsync(string normalizedName)
-    {
-        using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-        cmd.CommandText = $"""
-            SELECT id, name, sql_text, created_utc, updated_utc
-            FROM {SavedQueryTableName}
-            WHERE name = @name;
-            """;
-        cmd.Parameters.AddWithValue("@name", normalizedName);
-
-        await using var reader = await cmd.ExecuteReaderAsync();
-        if (!await reader.ReadAsync())
-            return null;
-
-        return ReadSavedQueryDefinition(reader);
-    }
-
-    private async Task<ProcedureDefinition?> GetProcedureInternalAsync(string name)
-    {
-        using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-        cmd.CommandText = $"""
-            SELECT name, body_sql, params_json, description, is_enabled, created_utc, updated_utc
-            FROM {ProcedureTableName}
-            WHERE name = @name;
-            """;
-        cmd.Parameters.AddWithValue("@name", name);
-
-        await using var reader = await cmd.ExecuteReaderAsync();
-        if (!await reader.ReadAsync())
-            return null;
-
-        return ReadProcedureDefinition(reader);
-    }
-
-    private static SavedQueryDefinition ReadSavedQueryDefinition(DbDataReader reader)
-    {
-        long id = Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture);
-        string name = reader.GetString(1);
-        string sqlText = reader.GetString(2);
-        string createdRaw = reader.GetString(3);
-        string updatedRaw = reader.GetString(4);
-
-        if (!DateTime.TryParse(
-                createdRaw,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-                out var createdUtc))
-        {
-            createdUtc = DateTime.UtcNow;
-        }
-
-        if (!DateTime.TryParse(
-                updatedRaw,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-                out var updatedUtc))
-        {
-            updatedUtc = createdUtc;
-        }
-
-        return new SavedQueryDefinition
-        {
-            Id = id,
-            Name = name,
-            SqlText = sqlText,
-            CreatedUtc = createdUtc,
-            UpdatedUtc = updatedUtc,
-        };
-    }
-
-    private static ProcedureDefinition ReadProcedureDefinition(DbDataReader reader)
-    {
-        string name = reader.GetString(0);
-        string bodySql = reader.GetString(1);
-        string paramsJson = reader.GetString(2);
-        string? description = reader.IsDBNull(3) ? null : reader.GetString(3);
-        bool isEnabled = !reader.IsDBNull(4) && Convert.ToInt64(reader.GetValue(4), CultureInfo.InvariantCulture) != 0;
-        string createdRaw = reader.GetString(5);
-        string updatedRaw = reader.GetString(6);
-
-        if (!DateTime.TryParse(
-                createdRaw,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-                out var createdUtc))
-        {
-            createdUtc = DateTime.UtcNow;
-        }
-
-        if (!DateTime.TryParse(
-                updatedRaw,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-                out var updatedUtc))
-        {
-            updatedUtc = createdUtc;
-        }
-
-        return new ProcedureDefinition
-        {
-            Name = name,
-            BodySql = bodySql,
-            Parameters = DeserializeProcedureParameters(paramsJson),
-            Description = description,
-            IsEnabled = isEnabled,
-            CreatedUtc = createdUtc,
-            UpdatedUtc = updatedUtc,
-        };
-    }
-
-    private ProcedureDefinition NormalizeProcedureDefinition(
-        ProcedureDefinition definition,
-        DateTime defaultCreatedUtc)
-    {
-        ValidateIdentifier(definition.Name, "procedure name");
-
-        string normalizedBody = NormalizeSqlFragment(definition.BodySql, "procedure body");
-        var normalizedParameters = NormalizeProcedureParameters(definition.Parameters);
-        ValidateProcedureBodyReferences(normalizedBody, normalizedParameters);
-
-        return new ProcedureDefinition
-        {
-            Name = definition.Name.Trim(),
-            BodySql = normalizedBody,
-            Parameters = normalizedParameters,
-            Description = string.IsNullOrWhiteSpace(definition.Description) ? null : definition.Description.Trim(),
-            IsEnabled = definition.IsEnabled,
-            CreatedUtc = defaultCreatedUtc,
-            UpdatedUtc = DateTime.UtcNow,
-        };
-    }
-
-    private static IReadOnlyList<ProcedureParameterDefinition> NormalizeProcedureParameters(
-        IReadOnlyList<ProcedureParameterDefinition> parameters)
-    {
-        ArgumentNullException.ThrowIfNull(parameters);
-
-        var normalized = new List<ProcedureParameterDefinition>(parameters.Count);
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var parameter in parameters)
-        {
-            if (parameter is null)
-                throw new ArgumentException("Procedure parameter entry cannot be null.");
-
-            string name = NormalizeProcedureParameterName(parameter.Name);
-            if (!seen.Add(name))
-                throw new ArgumentException($"Duplicate parameter '{name}' in procedure definition.");
-
-            object? normalizedDefault = parameter.Default is JsonElement je
-                ? ConvertJsonElement(je)
-                : parameter.Default;
-
-            normalized.Add(new ProcedureParameterDefinition
-            {
-                Name = name,
-                Type = parameter.Type,
-                Required = parameter.Required,
-                Default = normalizedDefault,
-                Description = string.IsNullOrWhiteSpace(parameter.Description) ? null : parameter.Description.Trim(),
-            });
-        }
-
-        return normalized;
-    }
-
-    private static void ValidateProcedureBodyReferences(
-        string bodySql,
-        IReadOnlyList<ProcedureParameterDefinition> parameters)
-    {
-        var defined = new HashSet<string>(parameters.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
-        foreach (string bodyParameter in ExtractParameterNamesFromSql(bodySql))
-        {
-            if (!defined.Contains(bodyParameter))
-            {
-                throw new ArgumentException(
-                    $"Procedure SQL references parameter '@{bodyParameter}' but it is missing from params metadata.");
-            }
-        }
-    }
-
-    private static Dictionary<string, object?> BindProcedureArguments(
-        ProcedureDefinition procedure,
-        IReadOnlyDictionary<string, object?> args)
-    {
-        var incoming = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        foreach (var (rawName, rawValue) in args)
-        {
-            string normalized = NormalizeProcedureParameterName(rawName);
-            incoming[normalized] = rawValue is JsonElement je ? ConvertJsonElement(je) : rawValue;
-        }
-
-        var known = new HashSet<string>(procedure.Parameters.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
-        foreach (string provided in incoming.Keys)
-        {
-            if (!known.Contains(provided))
-                throw new ArgumentException($"Unknown argument '{provided}'.");
-        }
-
-        var bound = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        foreach (var parameter in procedure.Parameters)
-        {
-            if (incoming.TryGetValue(parameter.Name, out var providedValue))
-            {
-                if (providedValue is null)
-                {
-                    if (parameter.Default is not null)
-                    {
-                        bound[parameter.Name] = CoerceProcedureParameterValue(parameter.Name, parameter.Type, parameter.Default);
-                        continue;
-                    }
-
-                    if (parameter.Required)
-                        throw new ArgumentException($"Required parameter '{parameter.Name}' cannot be null.");
-
-                    bound[parameter.Name] = null;
-                    continue;
-                }
-
-                bound[parameter.Name] = CoerceProcedureParameterValue(parameter.Name, parameter.Type, providedValue);
-                continue;
-            }
-
-            if (parameter.Default is not null)
-            {
-                bound[parameter.Name] = CoerceProcedureParameterValue(parameter.Name, parameter.Type, parameter.Default);
-                continue;
-            }
-
-            if (parameter.Required)
-                throw new ArgumentException($"Missing required parameter '{parameter.Name}'.");
-
-            bound[parameter.Name] = null;
-        }
-
-        return bound;
-    }
-
-    private async Task<ProcedureStatementExecutionResult> ExecuteSingleStatementWithArgumentsAsync(
-        int statementIndex,
-        string sql,
-        IReadOnlyDictionary<string, object?> args)
-    {
-        var sw = Stopwatch.StartNew();
-        using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-        cmd.CommandText = sql;
-
-        foreach (string parameterName in ExtractParameterNamesFromSql(sql))
-        {
-            if (!args.TryGetValue(parameterName, out object? value))
-                throw new ArgumentException($"Missing argument for SQL parameter '@{parameterName}'.");
-
-            cmd.Parameters.AddWithValue($"@{parameterName}", value ?? DBNull.Value);
-        }
-
-        await using var reader = await cmd.ExecuteReaderAsync();
-
-        if (reader.FieldCount > 0)
-        {
-            var colNames = new string[reader.FieldCount];
-            for (int i = 0; i < reader.FieldCount; i++)
-                colNames[i] = reader.GetName(i);
-
-            var rows = new List<object?[]>();
-            while (await reader.ReadAsync())
-            {
-                var row = new object?[reader.FieldCount];
-                for (int i = 0; i < reader.FieldCount; i++)
-                    row[i] = reader.IsDBNull(i) ? null : reader.GetValue(i);
-                rows.Add(row);
-            }
-
-            sw.Stop();
-            return new ProcedureStatementExecutionResult
-            {
-                StatementIndex = statementIndex,
-                StatementText = sql,
-                IsQuery = true,
-                ColumnNames = colNames,
-                Rows = rows,
-                RowsAffected = rows.Count,
-                Elapsed = sw.Elapsed,
-            };
-        }
-
-        sw.Stop();
-        return new ProcedureStatementExecutionResult
-        {
-            StatementIndex = statementIndex,
-            StatementText = sql,
-            IsQuery = false,
-            RowsAffected = reader.RecordsAffected,
-            Elapsed = sw.Elapsed,
-        };
-    }
-
-    private static string SerializeProcedureParameters(IReadOnlyList<ProcedureParameterDefinition> parameters)
-    {
-        var storage = parameters.Select(p => new ProcedureParameterStorage
-        {
-            Name = p.Name,
-            Type = p.Type.ToString().ToUpperInvariant(),
-            Required = p.Required,
-            Default = p.Type == DbType.Blob && p.Default is byte[] bytes
-                ? Convert.ToBase64String(bytes)
-                : p.Default,
-            Description = p.Description,
-        });
-
-        return JsonSerializer.Serialize(storage, s_jsonOptions);
-    }
-
-    private static IReadOnlyList<ProcedureParameterDefinition> DeserializeProcedureParameters(string json)
-    {
-        if (string.IsNullOrWhiteSpace(json))
-            return [];
-
-        List<ProcedureParameterStorage>? storage;
-        try
-        {
-            storage = JsonSerializer.Deserialize<List<ProcedureParameterStorage>>(json, s_jsonOptions);
-        }
-        catch (JsonException ex)
-        {
-            throw new ArgumentException($"Invalid procedure params_json payload: {ex.Message}");
-        }
-
-        if (storage is null || storage.Count == 0)
-            return [];
-
-        var result = new List<ProcedureParameterDefinition>(storage.Count);
-        foreach (var item in storage)
-        {
-            if (item is null)
-                continue;
-
-            string name = NormalizeProcedureParameterName(item.Name ?? string.Empty);
-            if (!Enum.TryParse<DbType>(item.Type, ignoreCase: true, out var type))
-                throw new ArgumentException($"Unsupported parameter type '{item.Type}' in params_json.");
-
-            object? defaultValue = item.Default is JsonElement je
-                ? ConvertJsonElement(je)
-                : item.Default;
-
-            result.Add(new ProcedureParameterDefinition
-            {
-                Name = name,
-                Type = type,
-                Required = item.Required,
-                Default = defaultValue,
-                Description = string.IsNullOrWhiteSpace(item.Description) ? null : item.Description.Trim(),
-            });
-        }
-
-        return NormalizeProcedureParameters(result);
-    }
-
-    private static string NormalizeProcedureParameterName(string rawName)
-    {
-        if (string.IsNullOrWhiteSpace(rawName))
-            throw new ArgumentException("Procedure parameter name is required.");
-
-        string trimmed = rawName.Trim();
-        if (trimmed.StartsWith('@'))
-            trimmed = trimmed[1..];
-
-        ValidateIdentifier(trimmed, "procedure parameter name");
-        return trimmed;
-    }
-
-    private static HashSet<string> ExtractParameterNamesFromSql(string sql)
-    {
-        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var token in new Tokenizer(sql).Tokenize())
-        {
-            if (token.Type == TokenType.Parameter)
-                names.Add(token.Value);
-        }
-        return names;
-    }
-
-    private static object? ConvertJsonElement(JsonElement element) => element.ValueKind switch
-    {
-        JsonValueKind.Null => null,
-        JsonValueKind.String => element.GetString(),
-        JsonValueKind.Number => element.TryGetInt64(out long l) ? l : element.GetDouble(),
-        JsonValueKind.True => true,
-        JsonValueKind.False => false,
-        _ => element.ToString(),
+        DbType.Integer => ClientModels.DbType.Integer,
+        DbType.Real => ClientModels.DbType.Real,
+        DbType.Text => ClientModels.DbType.Text,
+        DbType.Blob => ClientModels.DbType.Blob,
+        _ => throw new ArgumentOutOfRangeException(nameof(type)),
     };
 
-    private static object? CoerceProcedureParameterValue(string name, DbType type, object? value)
+    private static DbType MapDbType(ClientModels.DbType type) => type switch
     {
-        if (value is null)
-            return null;
+        ClientModels.DbType.Integer => DbType.Integer,
+        ClientModels.DbType.Real => DbType.Real,
+        ClientModels.DbType.Text => DbType.Text,
+        ClientModels.DbType.Blob => DbType.Blob,
+        _ => throw new ArgumentOutOfRangeException(nameof(type)),
+    };
 
-        if (value is JsonElement element)
-            value = ConvertJsonElement(element);
-        if (value is null)
-            return null;
-
-        switch (type)
+    private static TableSchema MapTableSchema(ClientModels.TableSchema schema) => new()
+    {
+        TableName = schema.TableName,
+        Columns = schema.Columns.Select(column => new ColumnDefinition
         {
-            case DbType.Integer:
-                if (TryCoerceInteger(value, out long integerValue))
-                    return integerValue;
-                throw new ArgumentException($"Parameter '{name}' expects INTEGER.");
+            Name = column.Name,
+            Type = MapDbType(column.Type),
+            Nullable = column.Nullable,
+            IsPrimaryKey = column.IsPrimaryKey,
+            IsIdentity = column.IsIdentity,
+        }).ToArray(),
+    };
 
-            case DbType.Real:
-                if (TryCoerceReal(value, out double realValue))
-                    return realValue;
-                throw new ArgumentException($"Parameter '{name}' expects REAL.");
-
-            case DbType.Text:
-                if (value is string textValue)
-                    return textValue;
-                throw new ArgumentException($"Parameter '{name}' expects TEXT.");
-
-            case DbType.Blob:
-                if (value is byte[] blob)
-                    return blob;
-                if (value is string b64)
-                {
-                    try
-                    {
-                        return Convert.FromBase64String(b64);
-                    }
-                    catch (FormatException)
-                    {
-                        throw new ArgumentException($"Parameter '{name}' expects BLOB as base64 string.");
-                    }
-                }
-                throw new ArgumentException($"Parameter '{name}' expects BLOB.");
-
-            default:
-                throw new ArgumentException($"Unsupported parameter type '{type}' for '{name}'.");
-        }
-    }
-
-    private static bool TryCoerceInteger(object value, out long result)
+    private static IndexSchema MapIndexSchema(ClientModels.IndexSchema index) => new()
     {
-        switch (value)
+        IndexName = index.IndexName,
+        TableName = index.TableName,
+        Columns = index.Columns.ToArray(),
+        IsUnique = index.IsUnique,
+    };
+
+    private static ViewDefinition MapViewDefinition(ClientModels.ViewDefinition view) => new()
+    {
+        Name = view.Name,
+        Sql = view.Sql,
+    };
+
+    private static TriggerSchema MapTriggerSchema(ClientModels.TriggerSchema trigger) => new()
+    {
+        TriggerName = trigger.TriggerName,
+        TableName = trigger.TableName,
+        Timing = MapTriggerTiming(trigger.Timing),
+        Event = MapTriggerEvent(trigger.Event),
+        BodySql = trigger.BodySql,
+    };
+
+    private static ProcedureDefinition MapProcedureDefinition(ClientModels.ProcedureDefinition procedure) => new()
+    {
+        Name = procedure.Name,
+        BodySql = procedure.BodySql,
+        Parameters = procedure.Parameters.Select(MapProcedureParameterDefinition).ToList(),
+        Description = procedure.Description,
+        IsEnabled = procedure.IsEnabled,
+        CreatedUtc = procedure.CreatedUtc,
+        UpdatedUtc = procedure.UpdatedUtc,
+    };
+
+    private static ClientModels.ProcedureDefinition MapProcedureDefinition(ProcedureDefinition procedure) => new()
+    {
+        Name = procedure.Name,
+        BodySql = procedure.BodySql,
+        Parameters = procedure.Parameters.Select(MapProcedureParameterDefinition).ToList(),
+        Description = procedure.Description,
+        IsEnabled = procedure.IsEnabled,
+        CreatedUtc = procedure.CreatedUtc,
+        UpdatedUtc = procedure.UpdatedUtc,
+    };
+
+    private static ProcedureParameterDefinition MapProcedureParameterDefinition(ClientModels.ProcedureParameterDefinition parameter) => new()
+    {
+        Name = parameter.Name,
+        Type = MapDbType(parameter.Type),
+        Required = parameter.Required,
+        Default = parameter.Default,
+        Description = parameter.Description,
+    };
+
+    private static ClientModels.ProcedureParameterDefinition MapProcedureParameterDefinition(ProcedureParameterDefinition parameter) => new()
+    {
+        Name = parameter.Name,
+        Type = MapDbType(parameter.Type),
+        Required = parameter.Required,
+        Default = parameter.Default,
+        Description = parameter.Description,
+    };
+
+    private static ProcedureExecutionResult MapProcedureExecutionResult(ClientModels.ProcedureExecutionResult result) => new()
+    {
+        ProcedureName = result.ProcedureName,
+        Succeeded = result.Succeeded,
+        Statements = result.Statements.Select(statement => new ProcedureStatementExecutionResult
         {
-            case long l:
-                result = l;
-                return true;
-            case int i:
-                result = i;
-                return true;
-            case short s:
-                result = s;
-                return true;
-            case byte b:
-                result = b;
-                return true;
-            case sbyte sb:
-                result = sb;
-                return true;
-            case uint ui:
-                result = ui;
-                return true;
-            case ulong ul when ul <= long.MaxValue:
-                result = (long)ul;
-                return true;
-            case double d when IsWholeNumberInRange(d):
-                result = (long)d;
-                return true;
-            case float f when IsWholeNumberInRange(f):
-                result = (long)f;
-                return true;
-            case decimal m when m >= long.MinValue && m <= long.MaxValue && decimal.Truncate(m) == m:
-                result = (long)m;
-                return true;
-            case string text when long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long parsed):
-                result = parsed;
-                return true;
-            default:
-                result = 0;
-                return false;
-        }
-    }
+            StatementIndex = statement.StatementIndex,
+            StatementText = statement.StatementText,
+            IsQuery = statement.IsQuery,
+            ColumnNames = statement.ColumnNames,
+            Rows = statement.Rows is null ? null : statement.Rows.Select(row => row.ToArray()).ToList(),
+            RowsAffected = statement.RowsAffected,
+            Elapsed = statement.Elapsed,
+        }).ToList(),
+        Error = result.Error,
+        FailedStatementIndex = result.FailedStatementIndex,
+        Elapsed = result.Elapsed,
+    };
 
-    private static bool IsWholeNumberInRange(double value)
-        => !double.IsNaN(value)
-           && !double.IsInfinity(value)
-           && value >= long.MinValue
-           && value <= long.MaxValue
-           && Math.Truncate(value) == value;
-
-    private static bool IsWholeNumberInRange(float value)
-        => !float.IsNaN(value)
-           && !float.IsInfinity(value)
-           && value >= long.MinValue
-           && value <= long.MaxValue
-           && MathF.Truncate(value) == value;
-
-    private static bool TryCoerceReal(object value, out double result)
+    private static SavedQueryDefinition MapSavedQueryDefinition(ClientModels.SavedQueryDefinition savedQuery) => new()
     {
-        switch (value)
+        Id = savedQuery.Id,
+        Name = savedQuery.Name,
+        SqlText = savedQuery.SqlText,
+        CreatedUtc = savedQuery.CreatedUtc,
+        UpdatedUtc = savedQuery.UpdatedUtc,
+    };
+
+    private static TableBrowseResult MapTableBrowseResult(ClientModels.TableBrowseResult result) => new()
+    {
+        TableName = result.TableName,
+        Schema = MapTableSchema(result.Schema),
+        Rows = result.Rows.Select(row => row.ToArray()).ToList(),
+        TotalRows = result.TotalRows,
+        Page = result.Page,
+        PageSize = result.PageSize,
+    };
+
+    private static ViewBrowseResult MapViewBrowseResult(ClientModels.ViewBrowseResult result) => new()
+    {
+        ViewName = result.ViewName,
+        ColumnNames = result.ColumnNames.ToArray(),
+        Rows = result.Rows.Select(row => row.ToArray()).ToList(),
+        TotalRows = result.TotalRows,
+        Page = result.Page,
+        PageSize = result.PageSize,
+    };
+
+    private static SqlExecutionResult MapSqlExecutionResult(ClientModels.SqlExecutionResult result) => new()
+    {
+        IsQuery = result.IsQuery,
+        ColumnNames = result.ColumnNames,
+        Rows = result.Rows is null ? null : result.Rows.Select(row => row.ToArray()).ToList(),
+        RowsAffected = result.RowsAffected,
+        Error = result.Error,
+        Elapsed = result.Elapsed,
+    };
+
+    private static TriggerTiming MapTriggerTiming(ClientModels.TriggerTiming timing) => timing switch
+    {
+        ClientModels.TriggerTiming.Before => TriggerTiming.Before,
+        ClientModels.TriggerTiming.After => TriggerTiming.After,
+        _ => throw new ArgumentOutOfRangeException(nameof(timing)),
+    };
+
+    private static ClientModels.TriggerTiming MapTriggerTiming(TriggerTiming timing) => timing switch
+    {
+        TriggerTiming.Before => ClientModels.TriggerTiming.Before,
+        TriggerTiming.After => ClientModels.TriggerTiming.After,
+        _ => throw new ArgumentOutOfRangeException(nameof(timing)),
+    };
+
+    private static TriggerEvent MapTriggerEvent(ClientModels.TriggerEvent triggerEvent) => triggerEvent switch
+    {
+        ClientModels.TriggerEvent.Insert => TriggerEvent.Insert,
+        ClientModels.TriggerEvent.Update => TriggerEvent.Update,
+        ClientModels.TriggerEvent.Delete => TriggerEvent.Delete,
+        _ => throw new ArgumentOutOfRangeException(nameof(triggerEvent)),
+    };
+
+    private static ClientModels.TriggerEvent MapTriggerEvent(TriggerEvent triggerEvent) => triggerEvent switch
+    {
+        TriggerEvent.Insert => ClientModels.TriggerEvent.Insert,
+        TriggerEvent.Update => ClientModels.TriggerEvent.Update,
+        TriggerEvent.Delete => ClientModels.TriggerEvent.Delete,
+        _ => throw new ArgumentOutOfRangeException(nameof(triggerEvent)),
+    };
+
+    private static void AnalyzeSqlEffects(string sql, out bool schemaMutated, out bool tableMutated, out bool proceduresMutated)
+    {
+        schemaMutated = false;
+        tableMutated = false;
+        proceduresMutated = false;
+
+        foreach (string statement in SqlScriptSplitter.SplitExecutableStatements(sql))
         {
-            case double d:
-                result = d;
-                return true;
-            case float f:
-                result = f;
-                return true;
-            case decimal m:
-                result = (double)m;
-                return true;
-            case long l:
-                result = l;
-                return true;
-            case int i:
-                result = i;
-                return true;
-            case short s:
-                result = s;
-                return true;
-            case byte b:
-                result = b;
-                return true;
-            case sbyte sb:
-                result = sb;
-                return true;
-            case uint ui:
-                result = ui;
-                return true;
-            case ulong ul:
-                result = ul;
-                return true;
-            case string text when double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double parsed):
-                result = parsed;
-                return true;
-            default:
-                result = 0;
-                return false;
-        }
-    }
-
-    private void ValidateTableName(string tableName)
-    {
-        if (IsInternalTable(tableName))
-            throw new ArgumentException($"Table '{tableName}' is internal and not available through table endpoints.");
-
-        var known = _connection.GetTableNames();
-        if (!known.Any(t => string.Equals(t, tableName, StringComparison.OrdinalIgnoreCase)))
-            throw new ArgumentException($"Table '{tableName}' does not exist.");
-    }
-
-    private void ValidateColumnName(string tableName, string columnName)
-    {
-        var schema = _connection.GetTableSchema(tableName);
-        if (schema == null || schema.GetColumnIndex(columnName) < 0)
-            throw new ArgumentException($"Column '{columnName}' not found in table '{tableName}'.");
-    }
-
-    private void ValidateViewName(string viewName)
-    {
-        var known = _connection.GetViewNames();
-        if (!known.Any(v => string.Equals(v, viewName, StringComparison.OrdinalIgnoreCase)))
-            throw new ArgumentException($"View '{viewName}' does not exist.");
-    }
-
-    private static void ValidateIdentifier(string value, string label)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            throw new ArgumentException($"{label} is required.");
-
-        string trimmed = value.Trim();
-        if (!IsIdentifierStart(trimmed[0]))
-            throw new ArgumentException($"{label} must start with a letter or underscore.");
-
-        for (int i = 1; i < trimmed.Length; i++)
-        {
-            if (!IsIdentifierPart(trimmed[i]))
-                throw new ArgumentException($"{label} can only contain letters, digits, and underscore.");
-        }
-    }
-
-    private static string NormalizeSavedQueryName(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            throw new ArgumentException("saved query name is required.");
-
-        string trimmed = name.Trim();
-        if (trimmed.Length > 256)
-            throw new ArgumentException("saved query name cannot exceed 256 characters.");
-        if (trimmed.Any(char.IsControl))
-            throw new ArgumentException("saved query name cannot contain control characters.");
-
-        return trimmed;
-    }
-
-    private static string NormalizeSqlFragment(string sql, string label)
-    {
-        if (string.IsNullOrWhiteSpace(sql))
-            throw new ArgumentException($"{label} is required.");
-
-        string trimmed = sql.Trim();
-        if (trimmed.EndsWith(';'))
-            trimmed = trimmed.TrimEnd(';').TrimEnd();
-        if (trimmed.Length == 0)
-            throw new ArgumentException($"{label} is required.");
-        return trimmed;
-    }
-
-    private static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';
-    private static bool IsIdentifierPart(char c) => char.IsLetterOrDigit(c) || c == '_';
-
-    private async Task ExecuteNonQueryAsync(string sql)
-    {
-        using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-        cmd.CommandText = sql;
-        await cmd.ExecuteNonQueryAsync();
-    }
-
-    private async Task<SqlExecutionResult> ExecuteSingleStatementAsync(string sql)
-    {
-        using var cmd = (CSharpDbCommand)_connection.CreateCommand();
-        cmd.CommandText = sql;
-
-        await using var reader = await cmd.ExecuteReaderAsync();
-        if (reader.FieldCount > 0)
-        {
-            var colNames = new string[reader.FieldCount];
-            for (int i = 0; i < reader.FieldCount; i++)
-                colNames[i] = reader.GetName(i);
-
-            var rows = new List<object?[]>();
-            while (await reader.ReadAsync())
+            if (LooksLikeSchemaMutation(statement))
             {
-                var row = new object?[reader.FieldCount];
-                for (int i = 0; i < reader.FieldCount; i++)
-                    row[i] = reader.IsDBNull(i) ? null : reader.GetValue(i);
-                rows.Add(row);
+                schemaMutated = true;
+                tableMutated |= LooksLikeTableMutation(statement);
             }
 
-            return new SqlExecutionResult
-            {
-                IsQuery = true,
-                ColumnNames = colNames,
-                Rows = rows,
-                RowsAffected = rows.Count,
-            };
+            proceduresMutated |= LooksLikeProcedureMutation(statement);
         }
-
-        return new SqlExecutionResult
-        {
-            IsQuery = false,
-            RowsAffected = reader.RecordsAffected,
-        };
-    }
-
-    private static IReadOnlyList<string> SplitSqlStatements(string sql)
-    {
-        if (string.IsNullOrWhiteSpace(sql))
-            return Array.Empty<string>();
-
-        var statements = new List<string>();
-        var tokens = new Tokenizer(sql).Tokenize();
-
-        int statementStart = 0;
-        bool atStatementStart = true;
-        bool createSeen = false;
-        bool createTrigger = false;
-        int triggerBeginDepth = 0;
-
-        foreach (var token in tokens)
-        {
-            if (token.Type == TokenType.Eof)
-                break;
-
-            if (atStatementStart)
-            {
-                if (token.Type == TokenType.Semicolon)
-                {
-                    statementStart = token.Position + 1;
-                    continue;
-                }
-
-                atStatementStart = false;
-                createSeen = token.Type == TokenType.Create;
-                createTrigger = false;
-                triggerBeginDepth = 0;
-            }
-            else if (createSeen && !createTrigger && token.Type == TokenType.Trigger)
-            {
-                createTrigger = true;
-            }
-
-            if (createTrigger)
-            {
-                if (token.Type == TokenType.Begin)
-                    triggerBeginDepth++;
-                else if (token.Type == TokenType.End && triggerBeginDepth > 0)
-                    triggerBeginDepth--;
-            }
-
-            if (token.Type == TokenType.Semicolon)
-            {
-                bool isStatementTerminator = !createTrigger || triggerBeginDepth == 0;
-                if (!isStatementTerminator)
-                    continue;
-
-                int statementEnd = token.Position + 1;
-                if (statementEnd > statementStart)
-                {
-                    string statement = sql[statementStart..statementEnd].Trim();
-                    if (statement.Length > 0)
-                        statements.Add(statement);
-                }
-
-                statementStart = statementEnd;
-                atStatementStart = true;
-                createSeen = false;
-                createTrigger = false;
-                triggerBeginDepth = 0;
-            }
-        }
-
-        if (statementStart < sql.Length)
-        {
-            string remainder = sql[statementStart..];
-            var remainderTokens = new Tokenizer(remainder).Tokenize();
-            bool hasSql = remainderTokens.Any(t => t.Type is not (TokenType.Eof or TokenType.Semicolon));
-            if (hasSql)
-            {
-                string trimmed = remainder.Trim();
-                if (trimmed.Length > 0)
-                    statements.Add(trimmed);
-            }
-        }
-
-        return statements;
     }
 
     private static bool LooksLikeSchemaMutation(string sql)
     {
-        var upper = sql.TrimStart().ToUpperInvariant();
+        string upper = sql.TrimStart().ToUpperInvariant();
         return upper.StartsWith("CREATE ", StringComparison.Ordinal)
             || upper.StartsWith("DROP ", StringComparison.Ordinal)
             || upper.StartsWith("ALTER ", StringComparison.Ordinal);
@@ -1967,7 +463,7 @@ public sealed class CSharpDbService : IAsyncDisposable
 
     private static bool LooksLikeTableMutation(string sql)
     {
-        var upper = sql.TrimStart().ToUpperInvariant();
+        string upper = sql.TrimStart().ToUpperInvariant();
         return upper.StartsWith("CREATE TABLE", StringComparison.Ordinal)
             || upper.StartsWith("DROP TABLE", StringComparison.Ordinal)
             || upper.StartsWith("ALTER TABLE", StringComparison.Ordinal);
@@ -1985,26 +481,9 @@ public sealed class CSharpDbService : IAsyncDisposable
             || upper.StartsWith($"ALTER TABLE {ProcedureTableName.ToUpperInvariant()}", StringComparison.Ordinal);
     }
 
-    private sealed class ProcedureParameterStorage
-    {
-        public string? Name { get; init; }
-        public string? Type { get; init; }
-        public bool Required { get; init; }
-        public object? Default { get; init; }
-        public string? Description { get; init; }
-    }
-
-    private string ResolveDatabasePath(string? databasePath)
-    {
-        string path = string.IsNullOrWhiteSpace(databasePath)
-            ? DataSource
-            : databasePath.Trim();
-        return Path.GetFullPath(path);
-    }
-
     public async ValueTask DisposeAsync()
     {
-        await _connection.DisposeAsync();
+        await _client.DisposeAsync();
         _lock.Dispose();
     }
 }

--- a/src/CSharpDB.Service/CSharpDbService.cs
+++ b/src/CSharpDB.Service/CSharpDbService.cs
@@ -105,7 +105,15 @@ public sealed class CSharpDbService : IAsyncDisposable
     }
 
     public async Task<ProcedureExecutionResult> ExecuteProcedureAsync(string name, IReadOnlyDictionary<string, object?> args)
-        => MapProcedureExecutionResult(await WithLockAsync(() => _client.ExecuteProcedureAsync(name, args)));
+    {
+        var result = MapProcedureExecutionResult(await WithLockAsync(() => _client.ExecuteProcedureAsync(name, args)));
+        AnalyzeProcedureEffects(result, out bool schemaMutated, out bool tableMutated, out bool proceduresMutated);
+        if (schemaMutated)
+            NotifySchemaChanged(tableMutated);
+        if (proceduresMutated)
+            ProceduresChanged?.Invoke();
+        return result;
+    }
 
     public async Task<TableBrowseResult> BrowseTableAsync(string tableName, int page, int pageSize)
         => MapTableBrowseResult(await WithLockAsync(() => _client.BrowseTableAsync(tableName, page, pageSize)));
@@ -450,6 +458,25 @@ public sealed class CSharpDbService : IAsyncDisposable
             }
 
             proceduresMutated |= LooksLikeProcedureMutation(statement);
+        }
+    }
+
+    private static void AnalyzeProcedureEffects(
+        ProcedureExecutionResult result,
+        out bool schemaMutated,
+        out bool tableMutated,
+        out bool proceduresMutated)
+    {
+        schemaMutated = false;
+        tableMutated = false;
+        proceduresMutated = false;
+
+        foreach (var statement in result.Statements)
+        {
+            AnalyzeSqlEffects(statement.StatementText, out bool statementSchemaMutated, out bool statementTableMutated, out bool statementProceduresMutated);
+            schemaMutated |= statementSchemaMutated;
+            tableMutated |= statementTableMutated;
+            proceduresMutated |= statementProceduresMutated;
         }
     }
 

--- a/src/CSharpDB.Service/README.md
+++ b/src/CSharpDB.Service/README.md
@@ -1,6 +1,6 @@
 # CSharpDB.Service
 
-Thread-safe service layer for hosting [CSharpDB](https://github.com/MaxAkbar/CSharpDB) in ASP.NET Core, Blazor, or MCP server applications.
+Compatibility facade for hosting [CSharpDB](https://github.com/MaxAkbar/CSharpDB) in ASP.NET Core, Blazor, or MCP server applications.
 
 [![NuGet](https://img.shields.io/nuget/v/CSharpDB.Service)](https://www.nuget.org/packages/CSharpDB.Service)
 [![.NET 10](https://img.shields.io/badge/.NET-10-512bd4)](https://dotnet.microsoft.com/download/dotnet/10.0)
@@ -9,18 +9,17 @@ Thread-safe service layer for hosting [CSharpDB](https://github.com/MaxAkbar/CSh
 
 ## Overview
 
-`CSharpDB.Service` wraps the CSharpDB ADO.NET provider in a thread-safe service class designed for dependency injection in web applications. It provides a complete API surface for schema operations, CRUD, DDL, SQL console execution, and storage diagnostics. Reads the `CSharpDB` connection string from `IConfiguration`.
+`CSharpDB.Service` now delegates to `CSharpDB.Client`.
+
+Its purpose is transition compatibility for existing in-process hosts that still inject `CSharpDbService`. The authoritative database API lives in `CSharpDB.Client`; this package preserves the old DI shape, events, and model surface while the repo retires direct service usage.
 
 ## Features
 
-- **Thread-safe**: All operations are serialized via `SemaphoreSlim`
-- **DI-ready**: Constructor takes `IConfiguration`, reads the `"CSharpDB"` connection string
-- **Full schema operations**: Tables, indexes, views, triggers (create, update, drop)
-- **CRUD**: Browse (paginated), get by PK, insert, update, delete
-- **Procedure catalog**: Table-backed procedure definitions with strict typed parameter validation and transactional execution
-- **SQL console**: `ExecuteSqlAsync` with multi-statement splitting and timing
-- **Storage diagnostics**: Database inspection, WAL checking, page inspection, index verification
-- **Events**: `TablesChanged`, `SchemaChanged`, and `ProceduresChanged` for UI refresh
+- **Compatibility layer**: Existing hosts can keep injecting `CSharpDbService`
+- **Thread-safe wrapper**: Calls are serialized via `SemaphoreSlim`
+- **DI-ready**: Constructor still reads the `"CSharpDB"` connection string from `IConfiguration`
+- **Event bridge**: Preserves `TablesChanged`, `SchemaChanged`, and `ProceduresChanged`
+- **Delegates to client**: Schema, CRUD, SQL, procedures, saved queries, and diagnostics now flow through `CSharpDB.Client`
 
 ## Usage
 
@@ -153,8 +152,8 @@ dotnet add package CSharpDB
 
 ## Dependencies
 
-- `CSharpDB.Data` - ADO.NET provider
-- `CSharpDB.Storage.Diagnostics` - storage inspection toolkit
+- `CSharpDB.Client` - authoritative database API
+- `CSharpDB.Sql` - SQL splitting for compatibility event notifications
 - `Microsoft.Extensions.Configuration.Abstractions` - configuration binding
 
 ## Related Packages

--- a/src/CSharpDB.Sql/CSharpDB.Sql.csproj
+++ b/src/CSharpDB.Sql/CSharpDB.Sql.csproj
@@ -9,6 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>SQL tokenizer, recursive-descent parser, and AST for the CSharpDB embedded database.</Description>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/CSharpDB.Sql/SqlScriptSplitter.cs
+++ b/src/CSharpDB.Sql/SqlScriptSplitter.cs
@@ -1,9 +1,8 @@
 using CSharpDB.Core;
-using CSharpDB.Sql;
 
-namespace CSharpDB.Cli;
+namespace CSharpDB.Sql;
 
-internal static class SqlScriptParser
+public static class SqlScriptSplitter
 {
     public static bool TrySplitCompleteStatements(
         string sql,
@@ -11,41 +10,48 @@ internal static class SqlScriptParser
         out string remainder,
         out string? error)
     {
+        ArgumentNullException.ThrowIfNull(sql);
+
         statements = new List<string>();
         remainder = sql;
         error = null;
 
         try
         {
-            SplitCore(sql, statements, out remainder);
+            SplitCore(sql, statements, out remainder, includeTrailingStatement: false);
+            ValidateStatements(statements);
             return true;
         }
         catch (CSharpDbException ex)
         {
+            statements = new List<string>();
+            remainder = sql;
             error = ex.Message;
             return false;
         }
     }
 
-    public static IReadOnlyList<string> SplitAllStatements(string sql)
+    public static IReadOnlyList<string> SplitExecutableStatements(string sql)
     {
+        ArgumentNullException.ThrowIfNull(sql);
+
+        if (string.IsNullOrWhiteSpace(sql))
+            return Array.Empty<string>();
+
         var statements = new List<string>();
-        SplitCore(sql, statements, out string remainder);
-
-        if (!string.IsNullOrWhiteSpace(remainder))
-        {
-            throw new CSharpDbException(
-                ErrorCode.SyntaxError,
-                "SQL script ended with an incomplete statement (missing semicolon).");
-        }
-
+        SplitCore(sql, statements, out _, includeTrailingStatement: true);
         return statements;
     }
 
-    private static void SplitCore(string sql, List<string> statements, out string remainder)
+    private static void ValidateStatements(IEnumerable<string> statements)
+    {
+        foreach (var statement in statements)
+            _ = Parser.Parse(statement);
+    }
+
+    private static void SplitCore(string sql, List<string> statements, out string remainder, bool includeTrailingStatement)
     {
         var tokens = new Tokenizer(sql).Tokenize();
-
         int statementStart = 0;
         bool atStatementStart = true;
         bool createSeen = false;
@@ -106,5 +112,14 @@ internal static class SqlScriptParser
         }
 
         remainder = statementStart < sql.Length ? sql[statementStart..] : string.Empty;
+
+        if (!includeTrailingStatement)
+            return;
+
+        string trailingStatement = remainder.Trim();
+        if (trailingStatement.Length > 0)
+            statements.Add(trailingStatement);
+
+        remainder = string.Empty;
     }
 }

--- a/src/CSharpDB.Sql/SqlStatementClassifier.cs
+++ b/src/CSharpDB.Sql/SqlStatementClassifier.cs
@@ -1,0 +1,27 @@
+namespace CSharpDB.Sql;
+
+public readonly record struct SqlStatementClassification(Statement Statement, bool IsReadOnly)
+{
+    public bool IsMutating => !IsReadOnly;
+    public bool IsQuery => IsReadOnly;
+}
+
+public static class SqlStatementClassifier
+{
+    public static SqlStatementClassification Classify(string sql)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+
+        if (Parser.TryParseSimpleSelect(sql, out var fastStatement))
+            return new SqlStatementClassification(fastStatement, IsReadOnly(fastStatement));
+
+        var statement = Parser.Parse(sql);
+        return new SqlStatementClassification(statement, IsReadOnly(statement));
+    }
+
+    public static bool IsReadOnly(Statement statement)
+    {
+        ArgumentNullException.ThrowIfNull(statement);
+        return statement is SelectStatement;
+    }
+}

--- a/src/CSharpDB.Storage/CSharpDB.Storage.csproj
+++ b/src/CSharpDB.Storage/CSharpDB.Storage.csproj
@@ -9,6 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>B+tree storage engine with page cache, write-ahead log (WAL), crash recovery, and concurrent snapshot-isolated readers.</Description>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/CSharpDB/CSharpDB.csproj
+++ b/src/CSharpDB/CSharpDB.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>CSharpDB</PackageId>
-    <Description>All-in-one package for CSharpDB application development. Includes engine, ADO.NET provider, service layer, and diagnostics.</Description>
+    <Description>All-in-one package for CSharpDB application development. Includes the unified client, engine, ADO.NET provider, service layer, and diagnostics.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\CSharpDB.Storage\CSharpDB.Storage.csproj" />
     <ProjectReference Include="..\CSharpDB.Execution\CSharpDB.Execution.csproj" />
     <ProjectReference Include="..\CSharpDB.Engine\CSharpDB.Engine.csproj" />
+    <ProjectReference Include="..\CSharpDB.Client\CSharpDB.Client.csproj" />
     <ProjectReference Include="..\CSharpDB.Data\CSharpDB.Data.csproj" />
     <ProjectReference Include="..\CSharpDB.Storage.Diagnostics\CSharpDB.Storage.Diagnostics.csproj" />
     <ProjectReference Include="..\CSharpDB.Service\CSharpDB.Service.csproj" />

--- a/src/CSharpDB/README.md
+++ b/src/CSharpDB/README.md
@@ -11,6 +11,7 @@ All-in-one package for the [CSharpDB](https://github.com/MaxAkbar/CSharpDB) embe
 
 `CSharpDB` is the recommended entry package for application developers. It pulls in the full CSharpDB library set:
 
+- Unified client (`CSharpDB.Client`)
 - Engine API (`CSharpDB.Engine`)
 - ADO.NET provider (`CSharpDB.Data`)
 - Service layer (`CSharpDB.Service`)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
     <PackageTags>database;embedded;sql;dotnet;btree;wal</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />

--- a/tests/CSharpDB.Cli.Tests/CliIntegrationTests.cs
+++ b/tests/CSharpDB.Cli.Tests/CliIntegrationTests.cs
@@ -1,0 +1,172 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using CSharpDB.Engine;
+
+namespace CSharpDB.Cli.Tests;
+
+[Collection("CliConsole")]
+public sealed class CliIntegrationTests
+{
+    [Fact]
+    public async Task CliProcess_InfoCommand_WorksOnFreshDatabase()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string workDir = NewTempDirectory();
+
+        try
+        {
+            var result = await RunCliAsync(
+                [],
+                ".info" + Environment.NewLine + ".quit" + Environment.NewLine,
+                workDir,
+                ct);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("Database: csharpdb.db", result.StdOut, StringComparison.Ordinal);
+            Assert.Contains("Objects:", result.StdOut, StringComparison.Ordinal);
+            Assert.DoesNotContain("Error:", result.StdOut, StringComparison.Ordinal);
+            Assert.True(string.IsNullOrWhiteSpace(result.StdErr));
+            Assert.True(File.Exists(Path.Combine(workDir, "csharpdb.db")));
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(workDir);
+        }
+    }
+
+    [Fact]
+    public async Task CliProcess_PositionalDatabasePath_ExecutesSqlAndPersistsRows()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string workDir = NewTempDirectory();
+        string dbPath = Path.Combine(workDir, "orders.db");
+
+        try
+        {
+            string input = string.Join(Environment.NewLine, new[]
+            {
+                "CREATE TABLE orders (id INTEGER PRIMARY KEY, qty INTEGER NOT NULL);",
+                "INSERT INTO orders VALUES (1, 5);",
+                "SELECT id, qty FROM orders;",
+                ".quit",
+                "",
+            });
+
+            var result = await RunCliAsync([dbPath], input, workDir, ct);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("1 row affected", result.StdOut, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("1 row", result.StdOut, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("qty", result.StdOut, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("5", result.StdOut, StringComparison.Ordinal);
+            Assert.True(string.IsNullOrWhiteSpace(result.StdErr));
+
+            await using var db = await Database.OpenAsync(dbPath, ct);
+            await using var query = await db.ExecuteAsync("SELECT COUNT(*) FROM orders;", ct);
+            var rows = await query.ToListAsync(ct);
+            Assert.Equal(1L, rows[0][0].AsInteger);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(workDir);
+        }
+    }
+
+    [Fact]
+    public async Task CliProcess_ReadCommand_ExecutesScriptFile()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string workDir = NewTempDirectory();
+        string dbPath = Path.Combine(workDir, "script.db");
+        string scriptPath = Path.Combine(workDir, "seed.sql");
+
+        try
+        {
+            await File.WriteAllTextAsync(scriptPath, """
+                CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT);
+                INSERT INTO items VALUES (1, 'alpha');
+                INSERT INTO items VALUES (2, 'beta');
+                """, ct);
+
+            string input = string.Join(Environment.NewLine, new[]
+            {
+                $".read {scriptPath}",
+                ".quit",
+                "",
+            });
+
+            var result = await RunCliAsync([dbPath], input, workDir, ct);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("Script complete: 3 passed, 0 failed.", result.StdOut, StringComparison.Ordinal);
+            Assert.True(string.IsNullOrWhiteSpace(result.StdErr));
+
+            await using var db = await Database.OpenAsync(dbPath, ct);
+            await using var query = await db.ExecuteAsync("SELECT COUNT(*) FROM items;", ct);
+            var rows = await query.ToListAsync(ct);
+            Assert.Equal(2L, rows[0][0].AsInteger);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(workDir);
+        }
+    }
+
+    private static async Task<CliProcessResult> RunCliAsync(
+        IReadOnlyList<string> args,
+        string input,
+        string workingDirectory,
+        CancellationToken ct)
+    {
+        string cliAssemblyPath = typeof(CliShellOptions).Assembly.Location;
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        startInfo.ArgumentList.Add(cliAssemblyPath);
+        foreach (string arg in args)
+            startInfo.ArgumentList.Add(arg);
+
+        using var process = new Process { StartInfo = startInfo };
+        if (!process.Start())
+            throw new InvalidOperationException("Failed to start the CLI process.");
+
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(ct);
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync(ct);
+
+        if (!string.IsNullOrEmpty(input))
+            await process.StandardInput.WriteAsync(input.AsMemory(), ct);
+
+        process.StandardInput.Close();
+        await process.WaitForExitAsync(ct);
+
+        return new CliProcessResult(
+            process.ExitCode,
+            StripAnsi(await stdoutTask),
+            StripAnsi(await stderrTask));
+    }
+
+    private static string StripAnsi(string value)
+        => Regex.Replace(value, @"\x1B\[[0-9;]*m", string.Empty);
+
+    private static string NewTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"csharpdb_cli_integration_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteDirectoryIfExists(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+
+    private sealed record CliProcessResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/tests/CSharpDB.Cli.Tests/CliShellOptionsTests.cs
+++ b/tests/CSharpDB.Cli.Tests/CliShellOptionsTests.cs
@@ -1,0 +1,46 @@
+using CSharpDB.Client;
+
+namespace CSharpDB.Cli.Tests;
+
+public sealed class CliShellOptionsTests
+{
+    [Fact]
+    public void TryParse_PositionalDatabasePath_UsesDirectDefaults()
+    {
+        bool ok = CliShellOptions.TryParse(["sample.db"], out var options, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.NotNull(options);
+        Assert.Equal("sample.db", options!.DisplayTarget);
+        Assert.True(options.EnableLocalDirectFeatures);
+        Assert.Equal("sample.db", options.ClientOptions.Endpoint);
+        Assert.Null(options.ClientOptions.Transport);
+    }
+
+    [Fact]
+    public void TryParse_GrpcEndpoint_RequiresExplicitTransport()
+    {
+        bool ok = CliShellOptions.TryParse(
+            ["--transport", "grpc", "--endpoint", "https://localhost:5001"],
+            out var options,
+            out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.NotNull(options);
+        Assert.False(options!.EnableLocalDirectFeatures);
+        Assert.Equal(CSharpDbTransport.Grpc, options.ClientOptions.Transport);
+        Assert.Equal("https://localhost:5001", options.ClientOptions.Endpoint);
+    }
+
+    [Fact]
+    public void TryParse_UnknownOption_Fails()
+    {
+        bool ok = CliShellOptions.TryParse(["--unknown"], out var options, out var error);
+
+        Assert.False(ok);
+        Assert.Null(options);
+        Assert.Equal("Unknown option '--unknown'.", error);
+    }
+}

--- a/tests/CSharpDB.Cli.Tests/ReplTests.cs
+++ b/tests/CSharpDB.Cli.Tests/ReplTests.cs
@@ -1,3 +1,5 @@
+using CSharpDB.Client;
+using CSharpDB.Client.Internal;
 using CSharpDB.Engine;
 
 namespace CSharpDB.Cli.Tests;
@@ -5,24 +7,6 @@ namespace CSharpDB.Cli.Tests;
 [Collection("CliConsole")]
 public sealed class ReplTests
 {
-    [Fact]
-    public void SqlScriptParser_SplitAllStatements_KeepsTriggerBodyAsSingleStatement()
-    {
-        string sql = """
-            CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER);
-            CREATE TRIGGER tr AFTER INSERT ON t BEGIN
-                INSERT INTO t VALUES (NEW.id + 100, NEW.n);
-            END;
-            INSERT INTO t VALUES (1, 10);
-            """;
-
-        var statements = SqlScriptParser.SplitAllStatements(sql);
-
-        Assert.Equal(3, statements.Count);
-        Assert.Contains("CREATE TRIGGER tr AFTER INSERT ON t BEGIN", statements[1], StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("END;", statements[1], StringComparison.OrdinalIgnoreCase);
-    }
-
     [Fact]
     public async Task Repl_ReadCommand_ExecutesScriptIncludingTrigger()
     {
@@ -55,6 +39,39 @@ public sealed class ReplTests
         finally
         {
             DeleteIfExists(scriptPath);
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
+    [Fact]
+    public async Task Repl_MultiLineTriggerDefinition_ExecutesWhenStatementCompletes()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string dbPath = NewTempFilePath(".db");
+
+        try
+        {
+            string input = string.Join(Environment.NewLine, new[]
+            {
+                "CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER);",
+                "CREATE TABLE t_audit (n INTEGER);",
+                "CREATE TRIGGER t_tr AFTER INSERT ON t BEGIN",
+                "    INSERT INTO t_audit VALUES (42);",
+                "END;",
+                "INSERT INTO t VALUES (1, 10);",
+                ".quit",
+                "",
+            });
+
+            await RunReplAsync(dbPath, input, ct);
+
+            await using var db = await Database.OpenAsync(dbPath, ct);
+            long auditCount = await QueryCountAsync(db, "SELECT COUNT(*) FROM t_audit;", ct);
+            Assert.Equal(1, auditCount);
+        }
+        finally
+        {
             DeleteIfExists(dbPath);
             DeleteIfExists(dbPath + ".wal");
         }
@@ -180,6 +197,34 @@ public sealed class ReplTests
         }
     }
 
+    [Fact]
+    public async Task Repl_InfoCommand_DoesNotFailWhenLocalDirectFeaturesAreEnabled()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string dbPath = NewTempFilePath(".db");
+
+        try
+        {
+            string input = string.Join(Environment.NewLine, new[]
+            {
+                ".info",
+                ".quit",
+                "",
+            });
+
+            string output = await RunReplAsync(dbPath, input, ct);
+            string plainOutput = System.Text.RegularExpressions.Regex.Replace(output, @"\x1B\[[0-9;]*m", string.Empty);
+
+            Assert.Contains("Objects:", plainOutput, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Error:", plainOutput, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
     private static async Task<long> QueryCountAsync(Database db, string sql, CancellationToken ct)
     {
         await using var result = await db.ExecuteAsync(sql, ct);
@@ -190,11 +235,17 @@ public sealed class ReplTests
 
     private static async Task<string> RunReplAsync(string dbPath, string input, CancellationToken ct)
     {
-        await using var db = await Database.OpenAsync(dbPath, ct);
+        await using var client = CSharpDbClient.Create(new CSharpDbClientOptions
+        {
+            DataSource = dbPath,
+        });
+        Database? db = client is IEngineBackedClient engineBacked
+            ? await engineBacked.TryGetDatabaseAsync(ct)
+            : null;
 
         var commands = BuildCommands();
         var output = new StringWriter();
-        using var repl = new Repl(db, dbPath, output, commands);
+        using var repl = new Repl(client, db, dbPath, output, commands);
 
         var originalIn = Console.In;
         try

--- a/tests/CSharpDB.Tests/CSharpDB.Tests.csproj
+++ b/tests/CSharpDB.Tests/CSharpDB.Tests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\src\CSharpDB.Execution\CSharpDB.Execution.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Engine\CSharpDB.Engine.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Client\CSharpDB.Client.csproj" />
+    <ProjectReference Include="..\..\src\CSharpDB.Native\CSharpDB.Native.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Service\CSharpDB.Service.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Storage.Diagnostics\CSharpDB.Storage.Diagnostics.csproj" />
   </ItemGroup>

--- a/tests/CSharpDB.Tests/CSharpDB.Tests.csproj
+++ b/tests/CSharpDB.Tests/CSharpDB.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\src\CSharpDB.Sql\CSharpDB.Sql.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Execution\CSharpDB.Execution.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Engine\CSharpDB.Engine.csproj" />
+    <ProjectReference Include="..\..\src\CSharpDB.Client\CSharpDB.Client.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Service\CSharpDB.Service.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Storage.Diagnostics\CSharpDB.Storage.Diagnostics.csproj" />
   </ItemGroup>

--- a/tests/CSharpDB.Tests/ClientSqlExecutionTests.cs
+++ b/tests/CSharpDB.Tests/ClientSqlExecutionTests.cs
@@ -74,6 +74,36 @@ public sealed class ClientSqlExecutionTests
         }
     }
 
+    [Fact]
+    public async Task GetInfoAsync_CanceledWarmup_DoesNotPoisonClient()
+    {
+        string dbPath = Path.Combine(Path.GetTempPath(), $"csharpdb_client_test_{Guid.NewGuid():N}.db");
+
+        try
+        {
+            await using var client = CSharpDbClient.Create(new CSharpDbClientOptions
+            {
+                DataSource = dbPath,
+            });
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await client.GetInfoAsync(cts.Token));
+
+            var result = await client.ExecuteSqlAsync("CREATE TABLE warmup_ok (id INTEGER PRIMARY KEY);");
+            Assert.Null(result.Error);
+
+            var info = await client.GetInfoAsync();
+            Assert.Equal(1, info.TableCount);
+        }
+        finally
+        {
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
     private static void DeleteIfExists(string path)
     {
         if (File.Exists(path))

--- a/tests/CSharpDB.Tests/ClientSqlExecutionTests.cs
+++ b/tests/CSharpDB.Tests/ClientSqlExecutionTests.cs
@@ -1,0 +1,82 @@
+using CSharpDB.Client;
+
+namespace CSharpDB.Tests;
+
+public sealed class ClientSqlExecutionTests
+{
+    [Fact]
+    public async Task ExecuteSqlAsync_HandlesTriggerBodyAndFinalStatementWithoutSemicolon()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string dbPath = Path.Combine(Path.GetTempPath(), $"csharpdb_client_test_{Guid.NewGuid():N}.db");
+
+        try
+        {
+            await using var client = CSharpDbClient.Create(new CSharpDbClientOptions
+            {
+                DataSource = dbPath,
+            });
+
+            string sql = """
+                CREATE TABLE orders (id INTEGER PRIMARY KEY, qty INTEGER NOT NULL);
+                CREATE TABLE order_audit (order_id INTEGER NOT NULL);
+                CREATE TRIGGER trg_order_audit AFTER INSERT ON orders
+                BEGIN
+                INSERT INTO order_audit VALUES (NEW.id);
+                END;
+                INSERT INTO orders VALUES (1, 3)
+                """;
+
+            var result = await client.ExecuteSqlAsync(sql, ct);
+
+            Assert.Null(result.Error);
+
+            var auditCount = await client.ExecuteSqlAsync("SELECT COUNT(*) FROM order_audit;", ct);
+            Assert.Null(auditCount.Error);
+            Assert.True(auditCount.IsQuery);
+            Assert.NotNull(auditCount.Rows);
+            var row = Assert.Single(auditCount.Rows);
+            Assert.Equal(1L, Convert.ToInt64(row[0]));
+        }
+        finally
+        {
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
+    [Fact]
+    public async Task GetInfoAsync_UsesSingleDirectClientHandle()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string dbPath = Path.Combine(Path.GetTempPath(), $"csharpdb_client_test_{Guid.NewGuid():N}.db");
+
+        try
+        {
+            await using var client = CSharpDbClient.Create(new CSharpDbClientOptions
+            {
+                DataSource = dbPath,
+            });
+
+            var createResult = await client.ExecuteSqlAsync("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT);", ct);
+            Assert.Null(createResult.Error);
+
+            var info = await client.GetInfoAsync(ct);
+
+            Assert.Equal(dbPath, info.DataSource);
+            Assert.Equal(1, info.TableCount);
+            Assert.Equal(0, info.IndexCount);
+        }
+        finally
+        {
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}

--- a/tests/CSharpDB.Tests/NativeStringEncodingTests.cs
+++ b/tests/CSharpDB.Tests/NativeStringEncodingTests.cs
@@ -1,0 +1,44 @@
+using System.Runtime.InteropServices;
+using CSharpDB.Native;
+
+namespace CSharpDB.Tests;
+
+public sealed class NativeStringEncodingTests
+{
+    [Fact]
+    public void StringCache_ReturnsUtf8Pointers()
+    {
+        IntPtr resultHandle = new(1234);
+        const string value = "naïve café";
+
+        try
+        {
+            IntPtr ptr = StringCache.GetOrAdd(resultHandle, 0, value);
+            Assert.Equal(value, Marshal.PtrToStringUTF8(ptr));
+        }
+        finally
+        {
+            StringCache.Remove(resultHandle);
+        }
+    }
+
+    [Fact]
+    public void ErrorState_ReturnsUtf8Pointers()
+    {
+        const string message = "naïve café";
+
+        try
+        {
+            ErrorState.Set(new InvalidOperationException(message));
+
+            IntPtr ptr = ErrorState.GetMessagePtr();
+
+            Assert.NotEqual(IntPtr.Zero, ptr);
+            Assert.Equal(message, Marshal.PtrToStringUTF8(ptr));
+        }
+        finally
+        {
+            ErrorState.Clear();
+        }
+    }
+}

--- a/tests/CSharpDB.Tests/ServiceProcedureTests.cs
+++ b/tests/CSharpDB.Tests/ServiceProcedureTests.cs
@@ -361,6 +361,72 @@ public sealed class ServiceProcedureTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExecuteProcedure_SchemaMutation_RaisesSchemaAndTableEvents()
+    {
+        await _service.CreateProcedureAsync(new ProcedureDefinition
+        {
+            Name = "CreateProcTable",
+            BodySql = "CREATE TABLE proc_created (id INTEGER PRIMARY KEY);",
+            Parameters = [],
+            IsEnabled = true,
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow,
+        });
+
+        int schemaChanged = 0;
+        int tablesChanged = 0;
+        int proceduresChanged = 0;
+        _service.SchemaChanged += () => schemaChanged++;
+        _service.TablesChanged += () => tablesChanged++;
+        _service.ProceduresChanged += () => proceduresChanged++;
+
+        var result = await _service.ExecuteProcedureAsync("CreateProcTable", new Dictionary<string, object?>());
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Equal(1, schemaChanged);
+        Assert.Equal(1, tablesChanged);
+        Assert.Equal(0, proceduresChanged);
+        Assert.Contains("proc_created", await _service.GetTableNamesAsync(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteProcedure_ProcedureCatalogMutation_RaisesProceduresChanged()
+    {
+        await _service.CreateProcedureAsync(new ProcedureDefinition
+        {
+            Name = "ManagedProc",
+            BodySql = "SELECT 1;",
+            Parameters = [],
+            Description = "before",
+            IsEnabled = true,
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow,
+        });
+
+        await _service.CreateProcedureAsync(new ProcedureDefinition
+        {
+            Name = "MutateProcedures",
+            BodySql = "UPDATE __procedures SET description = 'after' WHERE name = 'ManagedProc';",
+            Parameters = [],
+            IsEnabled = true,
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow,
+        });
+
+        int proceduresChanged = 0;
+        int schemaChanged = 0;
+        _service.ProceduresChanged += () => proceduresChanged++;
+        _service.SchemaChanged += () => schemaChanged++;
+
+        var result = await _service.ExecuteProcedureAsync("MutateProcedures", new Dictionary<string, object?>());
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Equal(1, proceduresChanged);
+        Assert.Equal(0, schemaChanged);
+        Assert.Equal("after", (await _service.GetProcedureAsync("ManagedProc"))?.Description);
+    }
+
+    [Fact]
     public async Task ExecuteProcedure_Disabled_RejectsExecution()
     {
         await _service.CreateProcedureAsync(new ProcedureDefinition

--- a/tests/CSharpDB.Tests/SqlScriptSplitterTests.cs
+++ b/tests/CSharpDB.Tests/SqlScriptSplitterTests.cs
@@ -1,0 +1,97 @@
+using CSharpDB.Sql;
+
+namespace CSharpDB.Tests;
+
+public sealed class SqlScriptSplitterTests
+{
+    [Fact]
+    public void TrySplitCompleteStatements_KeepsTriggerBodyAsSingleStatement()
+    {
+        string sql = """
+            CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER);
+            CREATE TRIGGER tr AFTER INSERT ON t BEGIN
+                INSERT INTO t VALUES (NEW.id + 100, NEW.n);
+            END;
+            INSERT INTO t VALUES (1, 10);
+            """;
+
+        bool ok = SqlScriptSplitter.TrySplitCompleteStatements(sql, out var statements, out var remainder, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal(string.Empty, remainder);
+        Assert.Equal(3, statements.Count);
+        Assert.Contains("CREATE TRIGGER tr AFTER INSERT ON t BEGIN", statements[1], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("END;", statements[1], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TrySplitCompleteStatements_IgnoresEmptyStatements()
+    {
+        string sql = ";;CREATE TABLE t (id INTEGER PRIMARY KEY);;;;INSERT INTO t VALUES (1);;";
+
+        bool ok = SqlScriptSplitter.TrySplitCompleteStatements(sql, out var statements, out var remainder, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal(string.Empty, remainder);
+        Assert.Equal(2, statements.Count);
+    }
+
+    [Fact]
+    public void TrySplitCompleteStatements_ReturnsIncompleteTrailingRemainder()
+    {
+        string sql = """
+            CREATE TABLE t (id INTEGER PRIMARY KEY);
+            INSERT INTO t VALUES (1
+            """;
+
+        bool ok = SqlScriptSplitter.TrySplitCompleteStatements(sql, out var statements, out var remainder, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Single(statements);
+        Assert.Contains("INSERT INTO t VALUES (1", remainder, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TrySplitCompleteStatements_ReturnsParserErrorForInvalidCompleteStatement()
+    {
+        string sql = "SELECT FROM t;";
+
+        bool ok = SqlScriptSplitter.TrySplitCompleteStatements(sql, out var statements, out var remainder, out var error);
+
+        Assert.False(ok);
+        Assert.Empty(statements);
+        Assert.Equal(sql, remainder);
+        Assert.NotNull(error);
+        Assert.Contains("Syntax error", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SplitExecutableStatements_AllowsFinalStatementWithoutSemicolon()
+    {
+        string sql = "CREATE TABLE t (id INTEGER PRIMARY KEY); INSERT INTO t VALUES (1)";
+
+        var statements = SqlScriptSplitter.SplitExecutableStatements(sql);
+
+        Assert.Equal(2, statements.Count);
+        Assert.Equal("INSERT INTO t VALUES (1)", statements[1]);
+    }
+
+    [Theory]
+    [InlineData("SELECT * FROM t;", true)]
+    [InlineData("INSERT INTO t VALUES (1);", false)]
+    [InlineData("UPDATE t SET n = 1;", false)]
+    [InlineData("DELETE FROM t WHERE id = 1;", false)]
+    [InlineData("CREATE TABLE t (id INTEGER PRIMARY KEY);", false)]
+    [InlineData("CREATE TRIGGER trg AFTER INSERT ON t BEGIN INSERT INTO log VALUES (1); END;", false)]
+    public void Classify_ReturnsExpectedReadOnlyState(string sql, bool expectedReadOnly)
+    {
+        var classification = SqlStatementClassifier.Classify(sql);
+
+        Assert.Equal(expectedReadOnly, classification.IsReadOnly);
+        Assert.Equal(!expectedReadOnly, classification.IsMutating);
+        Assert.Equal(expectedReadOnly, classification.IsQuery);
+    }
+}


### PR DESCRIPTION
# Summary

Release-prep for the `v1.7.0` client unification pass focused on making `CSharpDB.Client` the single authoritative API for database consumers, moving host applications onto that surface, and adding the first native/Node integration scaffolding.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [x] Tests only

## Related Issues

- Client unification and host migration effort for CLI, API, Admin, and MCP.
- SQL parsing ownership cleanup so REPL and direct client execution share the same statement handling rules.

## Testing

- [x] `dotnet build CSharpDB.slnx /p:UseSharedCompilation=false`
- [x] `dotnet test tests/CSharpDB.Cli.Tests/CSharpDB.Cli.Tests.csproj /p:UseSharedCompilation=false`
- [x] `dotnet test tests/CSharpDB.Api.Tests/CSharpDB.Api.Tests.csproj /p:UseSharedCompilation=false`
- [x] `dotnet test tests/CSharpDB.Tests/CSharpDB.Tests.csproj /p:UseSharedCompilation=false`
- [x] Manual CLI verification for `.info` and direct database startup

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- `CSharpDB.Client` is now the authoritative public API; `CSharpDB.Service` remains only as a compatibility facade.
- The CLI, Web API, Admin app, and MCP host now resolve database access through the client, with `Direct` as the default transport.
- `Grpc`, `Tcp`, and named-pipe transport selection are part of the client options model, but only direct execution is implemented end-to-end in this pass.
- SQL script splitting and read/write classification moved into `CSharpDB.Sql`, which removes the CLI-local parser copy and keeps REPL/client behavior aligned.
- The branch also adds `CSharpDB.Native`, a Node client package, and native FFI tutorial/docs scaffolding; reviewers should treat those as additive SDK work alongside the client migration.
