### PR TITLE
Version 3.5.0 collection payload release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,173 +1,127 @@
 # What's New
 
-## v3.4.0
+## v3.5.0
 
-v3.4.0 focuses on daemon packaging, cross-platform deployment, and remote host
-consolidation without changing SQL, storage, WAL, query planning, or the gRPC
-client contract.
+v3.5.0 focuses on the collection binary payload fast path, generated
+collection codec performance, targeted UTF-8 span plumbing, and refreshed
+release benchmark publishing. It also includes the confirmed CSharpDB Studio
+admin UI access-parity notes and static mockups that are part of this branch.
 
-### Remote Host Consolidation
+### Collection Binary Payload Fast Path
 
-- `CSharpDB.Daemon` now hosts both the existing REST `/api` surface and gRPC
-  from one long-running process.
-- REST and gRPC requests share the same warm daemon-hosted database client, so
-  remote users no longer need separate REST and gRPC host processes for the
-  same database.
-- Plain `http://` daemon endpoints support `Transport = Grpc` through
-  gRPC-Web compatibility so gRPC and REST can share the default service URL.
-  HTTPS and custom test clients can continue using native gRPC.
-- REST is enabled in the daemon by default and can be disabled with
-  `CSharpDB__Daemon__EnableRestApi=false`.
-- The standalone `CSharpDB.Api` REST host remains supported for REST-only
-  deployments.
-- Release archive smoke validation now calls the daemon REST `/api/info`
-  endpoint and a gRPC `GetInfoAsync` client after extracting and starting each
-  daemon binary.
+- Added the opt-in source-generated collection fast path for fixed generated
+  field order, compact type/null metadata, and raw value payloads.
+- Existing non-generated collection paths continue to use their current JSON
+  and binary document behavior.
+- Generated collection models can now use direct binary record encode/decode
+  instead of routing through the slower document-shaped path.
+- `CollectionDocumentCodec<T>` now parses direct binary payload headers once
+  and decodes the key/document from that parsed header.
+- `CollectionBinaryDocumentCodec` now has single-segment
+  `ReadOnlySpan<byte>` lookup overloads for top-level binary document fields.
+- `CollectionPayloadCodec` fast header parsing now favors the common binary
+  payload marker path.
+- Collection field and index bindings now expose generated accessors to faster
+  direct field-reader paths where available.
 
-### Admin Warm Local Database Hosting
+### UTF-8 Text Index And Compare Paths
 
-- `CSharpDB.Admin` direct local mode keeps a warm in-process database instance
-  and now opens it through hybrid incremental-durable database options by
-  default.
-- Admin startup and database switching both use the same host database option
-  builder, so opening a different database from the UI keeps the same warm
-  local database behavior.
-- Admin remote mode still uses `CSharpDB:Transport` plus `CSharpDB:Endpoint`
-  without attaching local direct/hybrid options.
-- Set `CSharpDB__HostDatabase__OpenMode=Direct` to opt back into the older
-  plain direct open path for local Admin runs.
-- Admin table data filters now support contains, starts-with, and ends-with
-  `LIKE` placement plus exact `=` match mode per column.
-- The Admin SQL query editor now has homegrown guided completions for SQL
-  keywords, table/view selection, select-list columns, qualified alias columns,
-  and stored procedure names without adding a third-party editor dependency.
-- The Admin SQL query tab now exposes a visible vertical splitter so the SQL
-  editor and results pane can be resized when longer queries need more working
-  space.
-- The visual query designer now exposes its own splitter so the generated SQL
-  preview can be expanded against the results section instead of staying pinned
-  to a fixed preview height.
-- The form designer property inspector now renders the selected control ID with
-  theme-aware display styling instead of inheriting browser-native readonly
-  input colors that were hard to read in the dark theme.
+- Added targeted UTF-8 span plumbing for collection text index/read/compare
+  paths.
+- Reduced transient allocations in top-level string property reads by avoiding
+  per-call `byte[]` and `byte[][]` path materialization where the
+  single-segment path applies.
+- Updated ordered text index key comparison coverage.
 
-### Daemon Service Packaging
+### Tests And Benchmarks
 
-- Added Windows Service and systemd host integration to `CSharpDB.Daemon`.
-  These hooks are no-ops for normal console and `dotnet run` execution.
-- Added Windows service install/uninstall scripts with defaults for
-  `CSharpDBDaemon`, `C:\Program Files\CSharpDB\Daemon`,
-  `C:\ProgramData\CSharpDB`, and `http://127.0.0.1:5820`.
-- Added Linux systemd service template plus install/uninstall scripts with
-  defaults for `/opt/csharpdb-daemon`, `/var/lib/csharpdb`, service user
-  `csharpdb`, and `http://127.0.0.1:5820`.
-- Added macOS launchd plist template plus install/uninstall scripts with
-  defaults for `/usr/local/lib/csharpdb-daemon`,
-  `/usr/local/var/csharpdb`, and `http://127.0.0.1:5820`.
+- Added `GeneratedCollectionCodecBenchmarks`.
+- Expanded generated collection model tests around binary payload support.
+- Expanded binary document codec tests for direct field access.
+- Added ordered text index key codec coverage.
+- Refreshed `tests/CSharpDB.Benchmarks/README.md` and
+  `release-core-manifest.json` from the April 26, 2026 release-core artifacts.
+- Recorded the collection binary payload investigation, noisy initial guardrail
+  compare, focused retry, and final passing release guardrail in
+  `tests/CSharpDB.Benchmarks/HISTORY.md`.
 
-### Release Archives
+Focused collection investigation:
 
-- Added `scripts/Publish-CSharpDbDaemonRelease.ps1` for self-contained,
-  single-file, non-trimmed daemon release archives.
-- Added release archive coverage for `win-x64`, `linux-x64`, and `osx-arm64`.
-- Added checksum generation through `SHA256SUMS.txt`.
-- Updated the GitHub Release workflow to build daemon archives on native
-  Windows, Linux, and macOS runners, verify each archive, smoke-start the
-  extracted daemon, and attach the archives plus combined checksums to the
-  GitHub Release.
+| Metric | Result |
+|--------|-------:|
+| Matched rows vs same-machine HEAD baseline | `60` |
+| Faster matched rows | `50` |
+| Slower matched rows | `10` |
+| Median matched speedup | `+4.1%` |
+| Mean matched speedup | `+4.8%` |
 
-### Docs
+Focused recovery highlights:
 
-- Updated the daemon README with archive installation, service installation,
-  upgrade, uninstall, and configuration override guidance.
-- Updated the Admin README with warm in-process local database behavior, hybrid
-  local hosting defaults, and the direct open-mode opt-out.
-- Updated the scripts README with daemon packaging and service installer
-  references.
-- Updated the roadmap to mark daemon service packaging done and scoped
-  cross-platform daemon archive deployment in progress.
-- Added a new blog post covering the C# launcher pattern for
-  `CSharpDB.Admin`, including syntax-highlighted examples for the launcher
-  executable flow.
-- Migrated the remaining source-heavy markdown docs into companion reference
-  pages under `www` for architecture, getting started, performance, SQL query
-  execution pipeline, SQL reference, storage engine, roadmap, and the
-  CSharpDB-versus-SQLite benchmarking article so the full original content now
-  stays published on the website.
-- Updated the curated docs/blog pages and sitemap to point at the new source
-  reference routes when users need the full original long-form content.
-- Removed the duplicated markdown copies of the CLI, REST API, MCP server,
-  internals, and storage inspector guides after their website versions were
-  audited and verified.
+| Benchmark | Before | After | Change |
+|-----------|-------:|------:|-------:|
+| Collection field read, missing field | `223.22 ns` | `136.73 ns` | `+38.7%` |
+| Collection decode, direct payload | `333.80 ns` | `155.20 ns` | `+53.5%` |
+| Collection field read, early field | `108.60 ns` | `49.77 ns` | `+54.2%` |
+| Collection field compare, late text field | `159.55 ns` | `97.60 ns` | `+38.8%` |
+| Collection field compare, bound accessor | `128.03 ns` | `92.83 ns` | `+27.5%` |
 
-### Samples And Forms Runtime
+Path-index follow-up highlights:
 
-- Added `samples/fulfillment-hub`, a runnable end-to-end warehouse and order
-  fulfillment sample that seeds tables, indexes, views, triggers, procedures,
-  saved queries, Admin forms, Admin reports, stored pipelines, typed
-  collections, and a full-text index into one database.
-- The Fulfillment Hub sample includes an operational workbook plus a narrative
-  README walkthrough that teaches the platform through receiving, allocation,
-  shipment, returns, audit, pipeline, collection, and full-text flows instead
-  of a flat feature list.
-- Added a forms-only runtime host at `src/CSharpDB.Admin.Forms.Web` that lists
-  stored forms and runs them without exposing the form designer.
-- The forms runtime host points at any target CSharpDB database through
-  `CSharpDB:DataSource`, `ConnectionStrings:CSharpDB`, or `CSharpDB:Endpoint`
-  and reuses the existing `DataEntry` runtime component from
-  `CSharpDB.Admin.Forms`.
-- `CSharpDB.Admin.Forms` now supports runtime-only hosting through optional
-  `ShowDesignerButton`, `BackHref`, and `BackLabel` parameters on
-  `DataEntry.razor`, while keeping the existing Admin studio behavior unchanged
-  by default.
+| Benchmark | Final vs same-machine HEAD baseline |
+|-----------|------------------------------------:|
+| Nested path equality via `FindByIndex` | `+53.6%` |
+| Nested path equality via `FindByPath` | `+55.9%` |
+| Array path equality via `FindByIndex` | `+52.1%` |
+| Text range path lookup | `+42.7%` |
+| Guid equality path lookup | `+59.4%` |
+
+Published scorecard examples from the refreshed benchmark README:
+
+| Area | Result |
+|------|-------:|
+| SQL file-backed single insert | `450.4 ops/sec` |
+| SQL file-backed batch x100 | `41.88K rows/sec` |
+| Collection file-backed put | `447.3 ops/sec` |
+| Collection file-backed batch x100 | `42.28K docs/sec` |
+| Collection hot point get | `1.60M ops/sec` |
+| CSharpDB InsertBatch B1000 | `233.06K rows/sec` |
+
+### CSharpDB Studio Admin UI Notes
+
+- Added admin forms access-parity notes.
+- Added admin reports access-parity notes.
+- Added static CSharpDB Studio admin UI mockups under `www/admin-ui-mockups`.
+- Included dashboard, data, query, heavy operations, reports designer, mobile
+  forms/reports, command palette, sidebar, and shared styling mockups.
 
 ### Validation
 
-- PowerShell parser validation passed for the daemon release publisher and
-  Windows install/uninstall scripts.
-- `bash -n` passed for Linux and macOS service install/uninstall scripts.
-- `dotnet restore CSharpDB.slnx` completed successfully.
-- `dotnet build CSharpDB.slnx -c Release` completed successfully.
-- `dotnet build CSharpDB.slnx -c Release --no-restore` completed successfully.
-- `dotnet test tests\CSharpDB.Api.Tests\CSharpDB.Api.Tests.csproj -c Release --no-build`
-  passed with `15` tests.
-- `dotnet test tests\CSharpDB.Daemon.Tests\CSharpDB.Daemon.Tests.csproj -c Release --no-build`
-  passed with `18` tests.
-- `dotnet test tests\CSharpDB.Admin.Forms.Tests\CSharpDB.Admin.Forms.Tests.csproj -c Release --no-build`
-  passed with `211` tests.
-- Content audit confirmed the new source-reference pages preserve the migrated
-  markdown coverage (100% heading coverage and 99.7-100% token overlap across
-  the migrated set).
-- `python -c "import xml.etree.ElementTree as ET; ET.parse('www/sitemap.xml')"`
-  passed for the updated site map.
-- Repo scan found no remaining references to the deleted duplicated markdown
-  docs.
-- `dotnet run --project samples\fulfillment-hub\FulfillmentHubSample.csproj`
-  completed successfully and seeded `3` forms, `3` reports, `5` procedures,
-  `5` saved queries, `3` stored pipelines, `2` collections, and the
-  `fts_ops_playbooks` full-text index into the sample database.
-- `dotnet build src\CSharpDB.Admin.Forms.Web\CSharpDB.Admin.Forms.Web.csproj`
-  completed successfully.
-- `dotnet run --project src\CSharpDB.Admin.Forms.Web\CSharpDB.Admin.Forms.Web.csproj -- --urls http://127.0.0.1:5095 --CSharpDB:DataSource=<fulfillment-hub-demo.db>`
-  started successfully, listed the seeded sample forms at `/`, and served the
-  runtime-only `orders-workbench` form route at `/forms/orders-workbench`
-  without the designer action.
-- `.\scripts\Publish-CSharpDbDaemonRelease.ps1 -Version 3.4.0 -Runtime win-x64 -OutputRoot artifacts\daemon-release-local`
-  created `csharpdb-daemon-v3.4.0-win-x64.zip` and `SHA256SUMS.txt`.
-- The extracted `win-x64` daemon archive smoke-started successfully, served
-  `/api/info`, and accepted a gRPC `GetInfoAsync` client call on the same base
-  URL with a temporary database.
-- `dotnet run --project src\CSharpDB.Api\CSharpDB.Api.csproj --configuration Release --no-build --no-launch-profile`
-  smoke-started successfully and served `/api/info` with a temporary database.
-- `dotnet run --project src\CSharpDB.Daemon\CSharpDB.Daemon.csproj --configuration Release --no-build --no-launch-profile`
-  smoke-started successfully, served `/api/info`, and accepted a gRPC
-  `GetInfoAsync` client call on the same base URL with a temporary database.
-- `dotnet run --project src\CSharpDB.Admin\CSharpDB.Admin.csproj --configuration Release --no-build --no-launch-profile`
-  smoke-started successfully in direct hybrid incremental-durable mode with a
-  temporary database.
-- `dotnet build src\CSharpDB.Admin.Forms\CSharpDB.Admin.Forms.csproj`
-  completed successfully after the form designer property inspector styling
-  changes.
-- `dotnet build src\CSharpDB.Admin\CSharpDB.Admin.csproj -p:BaseOutputPath=artifacts\verify\`
-  completed successfully after the query tab and visual designer splitter
-  changes.
+- `dotnet build CSharpDB.slnx -c Release --no-restore`
+- `dotnet test CSharpDB.slnx -c Release --no-build -m:1 -- RunConfiguration.DisableParallelization=true`
+- Non-parallel unit test run passed with `1,652` tests.
+- `dotnet run -c Release --project .\tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --release-core --repeat 3 --repro`
+- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Run-Perf-Guardrails.ps1 -Mode release`
+- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Compare-Baseline.ps1 -ThresholdsPath .\tests\CSharpDB.Benchmarks\perf-thresholds.json -CurrentMicroResultsDir .\tests\CSharpDB.Benchmarks\results\.tmp-current-micro-run -ReportPath .\tests\CSharpDB.Benchmarks\results\perf-guardrails-last.md`
+- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Update-BenchmarkReadme.ps1 -RunManifest .\tests\CSharpDB.Benchmarks\release-core-manifest.json`
+- `Get-Content -Raw .\tests\CSharpDB.Benchmarks\release-core-manifest.json | ConvertFrom-Json`
+- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Update-BenchmarkReadme.ps1 -RunManifest .\tests\CSharpDB.Benchmarks\release-core-manifest.json -DryRun`
+- `git diff --check -- tests\CSharpDB.Benchmarks\README.md tests\CSharpDB.Benchmarks\HISTORY.md tests\CSharpDB.Benchmarks\release-core-manifest.json`
+
+Release benchmark guardrail result:
+
+```text
+Compared 185 rows against baseline. PASS=185, WARN=0, SKIP=0, FAIL=0
+```
+
+### Review Notes
+
+- The highest-risk runtime changes are in the generated collection model and
+  collection payload codec paths: `CollectionModelGenerator`,
+  `CollectionPayloadCodec`, `CollectionBinaryDocumentCodec`,
+  `CollectionDocumentCodec<T>`, `CollectionIndexedFieldReader`, and collection
+  index binding.
+- The generator diff is intentionally large because generated code now owns the
+  binary record encode/decode shape for opt-in generated models.
+- The benchmark README generated region should be edited through
+  `release-core-manifest.json` plus `scripts/Update-BenchmarkReadme.ps1`, not
+  manually.

--- a/docs/admin-forms-access-parity/README.md
+++ b/docs/admin-forms-access-parity/README.md
@@ -1,0 +1,126 @@
+# Admin Forms Access Parity Plan
+
+This document captures the current Admin Forms review against Microsoft Access-style
+form design and data-entry expectations. It focuses on gaps that affect whether
+CSharpDB forms can compete with Access for database-backed line-of-business apps.
+
+## Current Baseline
+
+The current forms surface already includes:
+
+- drag/drop absolute-layout designer
+- generated forms from table and view schema
+- database-backed form metadata
+- runtime data entry with create, update, delete, paging, and navigation
+- record search and go-to-primary-key navigation
+- labels, text, textarea, number, date, checkbox, radio, select, lookup,
+  computed, data grid, and child-tabs controls
+- lookup lists loaded from tables
+- computed fields with simple formulas and child-table aggregates
+- one-to-many child grids and nested child tabs
+- print support
+- schema-change warnings
+- designer undo/redo, copy/paste, duplicate, layers, alignment, tab order, and
+  mobile/tablet/desktop breakpoint editing
+
+## Added Review Findings
+
+### P1: Runtime ignores responsive form layouts
+
+The designer stores mobile and tablet overrides in `RendererHints`, but the
+runtime renderer always uses `ControlDefinition.Rect`. Any breakpoint layout work
+saved in the designer will not affect actual data-entry rendering.
+
+Primary code path:
+
+- `src/CSharpDB.Admin.Forms/Components/Designer/FormRenderer.razor`
+- `src/CSharpDB.Admin.Forms/Components/Designer/DesignerState.cs`
+
+Expected fix:
+
+- Add a runtime breakpoint/layout resolver shared with the designer.
+- Render controls from the effective breakpoint rectangle, not only the desktop
+  rectangle.
+- Honor breakpoint visibility at runtime.
+- Add renderer tests for desktop, tablet, and mobile overrides.
+
+### P1: Inferred validation is not enforced
+
+`InferRules` creates required, range, regex, and one-of rules, but `Evaluate`
+currently checks only `maxLength` and manually added `required` rules. Default
+generated forms can save invalid required, range, regex, or enum data unless the
+database rejects it later.
+
+Primary code path:
+
+- `src/CSharpDB.Admin.Forms/Services/DefaultValidationInferenceService.cs`
+- `src/CSharpDB.Admin.Forms/Services/DefaultFormGenerator.cs`
+
+Expected fix:
+
+- Evaluate inferred `required`, `maxLength`, `range`, `regex`, and `oneOf`
+  rules for generated controls.
+- Keep validation override behavior intact.
+- Normalize numeric and choice values before comparing.
+- Add tests for generated forms and override combinations.
+
+## Access-Parity Roadmap
+
+### Phase 1: Correctness Before Expansion
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Runtime breakpoint rendering | Planned | Make mobile/tablet designer work visible in data entry. |
+| Complete inferred validation | Planned | Enforce generated required/range/regex/choice rules before save. |
+| Form runtime regression tests | Planned | Cover renderer layout, validation, lookup, computed, and child grid behavior. |
+
+### Phase 2: Record Source, Filtering, and Sorting
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| First-class record source model | Planned | Move beyond a single `TableName`; support table, view, and saved SQL/query sources with editability metadata. |
+| Default filter and default sort | Planned | Store form-level defaults and apply them in the runtime record service. |
+| User sorting | Planned | Let operators sort by visible/searchable fields at runtime. |
+| Advanced filtering | Planned | Add filter-by-field, filter-by-selection, multi-condition filters, saved filters, and clear-filter flows. |
+
+### Phase 3: Access-Style Form Experiences
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Layout View | Planned | Let designers adjust a form while real data is visible. |
+| Multiple form modes | Planned | Add Single Form, Multiple Items, Datasheet, and Split Form equivalents. |
+| Form sections | Planned | Add header, detail, footer, and optional print sections. |
+| Embedded subforms | Planned | Support arbitrary embedded form definitions, not only child grids/tabs. |
+
+### Phase 4: Actions, Events, and App Behavior
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Command button control | Planned | Add buttons that can run form actions. |
+| Action model | Planned | Support actions such as open form, save, delete, navigate, apply filter, clear filter, run SQL/procedure, and show message. |
+| Event hooks | Planned | Add form/control events such as on load, before save, after save, before field change, after field change, and button click. |
+| Conditional UI rules | Planned | Add visible/enabled/read-only expressions for controls. |
+
+### Phase 5: Broader Control and Property Coverage
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Control palette expansion | Planned | Add list box, option group, toggle button, image, attachment/blob, chart, navigation, line, rectangle, page break, and subreport-like controls. |
+| Formatting properties | Planned | Add font, color, border, alignment, numeric/date format, input mask, default value, and required indicators. |
+| Lookup improvements | Planned | Add searchable combo behavior, display/value column configuration, row limits, and dependent lookups. |
+| Child grid improvements | Planned | Add typed editors, validation, sort/filter, column sizing, and batch edit behavior. |
+
+## Product Positioning
+
+The current implementation is a strong database-backed generated-form system.
+To credibly compete with Microsoft Access as an app builder, the next work should
+move from "render fields over records" toward "design complete data-entry
+workflows." The highest leverage model changes are:
+
+- runtime layout resolver
+- full validation engine
+- richer record-source/filter/sort model
+- action/event model
+- form-mode model
+
+Those foundations should be added before expanding the control palette too far.

--- a/docs/admin-reports-access-parity/README.md
+++ b/docs/admin-reports-access-parity/README.md
@@ -1,0 +1,151 @@
+# Admin Reports Access Parity Plan
+
+This document captures the current Admin Reports review against Microsoft
+Access-style report design, preview, print, and distribution expectations. It
+focuses on gaps that affect whether CSharpDB reports can compete with Access for
+database-backed operational reporting.
+
+## Current Baseline
+
+The current reports surface already includes:
+
+- visual band-based report designer
+- database-backed report metadata
+- report sources from tables, views, and supported saved queries
+- default report generation from source schema
+- page settings for Letter/A4, portrait/landscape, and margins
+- report header, page header, detail, page footer, report footer, group header,
+  and group footer bands
+- grouping and sorting definitions
+- labels, bound text, calculated text, lines, and boxes
+- calculated expressions for page number, print date, field references, numeric
+  arithmetic, and `SUM`/`COUNT`/`AVG`/`MIN`/`MAX` aggregates
+- preview pagination with page headers and footers
+- print support through the browser
+- schema-drift warnings
+
+## Added Review Findings
+
+### P1: Saved-query previews are unbounded before trimming
+
+Saved-query reports execute `source.BaseSql` directly and only trim rows after
+the full result has been materialized in memory. Large saved queries can make
+preview slow, memory-heavy, or effectively unusable. Table and view reports use
+the preview query builder with a row limit, but saved-query reports bypass that
+path.
+
+Primary code path:
+
+- `src/CSharpDB.Admin.Reports/Services/DefaultReportPreviewService.cs`
+- `src/CSharpDB.Admin.Reports/Services/ReportPreviewQueryBuilder.cs`
+
+Expected fix:
+
+- Apply the preview row cap before materializing saved-query results.
+- Preserve report group/sort ordering by wrapping the saved query or using an
+  equivalent safe query-builder path.
+- Keep saved-query SQL validation parameterless unless parameter support is
+  added in the same work.
+- Add tests that prove large saved-query previews fetch only the capped row
+  window.
+
+### P2: Preview and print are capped, with no full output/export pipeline
+
+The preview service intentionally caps output at `10,000` rows and `250` pages.
+That is reasonable for an interactive preview, but Access-style reports also
+need a full render/export path for print-ready output and distribution.
+
+Primary code path:
+
+- `src/CSharpDB.Admin.Reports/Services/DefaultReportPreviewService.cs`
+- `src/CSharpDB.Admin.Reports/Pages/Preview.razor`
+
+Expected fix:
+
+- Separate preview rendering from full report rendering.
+- Add export targets such as PDF, HTML, CSV, and spreadsheet-friendly output.
+- Keep preview caps for the UI, but make full export explicit and cancellable.
+- Show clear warnings when printing a capped preview rather than the full report.
+
+## Access-Parity Roadmap
+
+### Phase 1: Runtime Safety and Output Foundations
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Bounded saved-query previews | Planned | Apply preview row limits before materializing saved-query results. |
+| Full report render pipeline | Planned | Separate capped preview from full print/export rendering. |
+| Export support | Planned | Add PDF first, then HTML, CSV, and spreadsheet-friendly exports. |
+| Print warnings | Planned | Make truncated preview printing explicit in the UI. |
+
+### Phase 2: Record Sources, Parameters, and Filters
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Parameterized report sources | Planned | Support saved query/report parameters with prompt UI and typed values. |
+| Runtime filters | Planned | Let users run a report with ad hoc filters without editing the design. |
+| Saved report filter definitions | Planned | Store default filters with the report definition. |
+| Source query builder integration | Planned | Let reports be based on query-designer definitions, not only raw tables/views/saved queries. |
+
+### Phase 3: Grouping, Totals, and Pagination Semantics
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Grouping options | Planned | Add group intervals, header/footer toggles, keep together, repeat section, and force-new-page behavior. |
+| Running totals | Planned | Add per-group and whole-report running sums. |
+| Total placement helpers | Planned | Add guided totals in group headers, group footers, report header, and report footer. |
+| Page header/footer options | Planned | Support Access-style choices such as suppressing page headers on report-header/report-footer pages. |
+| Overflow behavior | Planned | Add text growth/shrink, clipping rules, and band overflow tests. |
+
+### Phase 4: Design Productivity
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Layout View | Planned | Let users adjust a report while seeing real data. |
+| Report Wizard | Planned | Guide source, fields, grouping, sorting, layout, and totals selection. |
+| Label Wizard | Planned | Generate printable mailing/product labels from source fields. |
+| Style themes | Planned | Add reusable report styles for fonts, spacing, borders, and colors. |
+
+### Phase 5: Broader Report Controls and Formatting
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Control palette expansion | Planned | Add image/logo, rich text, barcode, chart, page break, subreport, and attachment/blob controls. |
+| Conditional formatting | Planned | Add value/expression-based formatting rules for report controls. |
+| Data bars and highlights | Planned | Add visual summaries for numeric ranges and thresholds. |
+| Advanced formatting | Planned | Add borders, fill colors, font styles, text wrapping, alignment, culture-aware formats, and background images. |
+| Subreports | Planned | Embed another report definition with parent/child linking. |
+
+### Phase 6: Distribution and Operations
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Email/report delivery | Planned | Export and attach reports, with host-provided delivery hooks. |
+| Scheduled reports | Research | Run recurring reports and store generated artifacts. |
+| Report artifact history | Research | Store generated report snapshots for auditing and re-download. |
+| Large-report cancellation | Planned | Add cancellation/progress for long render/export jobs. |
+
+## Product Positioning
+
+The current implementation is a useful printable preview engine with a banded
+designer. To compete with Microsoft Access as a report builder, the next work
+should move toward "reliable report production and distribution." The highest
+leverage foundations are:
+
+- bounded source execution
+- separate preview and full-render pipelines
+- parameter/filter model
+- richer grouping and pagination model
+- export/distribution model
+- conditional formatting and expanded controls
+
+Those foundations should come before broadening the designer surface too far.
+
+## References
+
+- [Introduction to reports in Access](https://support.microsoft.com/en-us/office/introduction-to-reports-in-access-e0869f59-7536-4d19-8e05-7158dcd3681c)
+- [Create a simple report](https://support.microsoft.com/en-us/office/create-a-simple-report-408e92a8-11a4-418d-a378-7f1d99c25304)
+- [Create a grouped or summary report](https://support.microsoft.com/en-au/office/create-a-grouped-or-summary-report-f23301a1-3e0a-4243-9002-4a23ac0fdbf3)
+- [Summing in reports](https://support.microsoft.com/en-us/office/summing-in-reports-ad4e310d-64e9-4699-8d33-b8ae9639fbf4)
+- [Highlight data with conditional formatting](https://support.microsoft.com/en-us/office/highlight-data-with-conditional-formatting-7f7c0bd4-7c37-421d-adad-a260125c8129)
+- [Distribute a report](https://support.microsoft.com/en-us/office/distribute-a-report-561a9066-00ab-41ee-8f07-a0734810a778)

--- a/docs/releases/v3.5.0-pr-notes.md
+++ b/docs/releases/v3.5.0-pr-notes.md
@@ -1,0 +1,147 @@
+## Summary
+
+This `v3.5.0` release prepares the collection binary payload fast path, the
+release benchmark refresh, and the confirmed CSharpDB Studio admin UI mockup
+docs that are included on the branch.
+
+The collection work completes the opt-in source-generated collection fast path
+around fixed generated field order, compact type/null metadata, and raw value
+payloads. Existing non-generated collection paths continue to use their current
+JSON and binary document behavior. The runtime path now avoids duplicated direct
+payload header parsing, adds single-segment `ReadOnlySpan<byte>` top-level field
+lookups, and uses targeted UTF-8 span plumbing for text index/read/compare
+paths.
+
+The benchmark work adds generated collection codec coverage, records the
+collection payload investigation, and refreshes the published benchmark README
+from the April 26, 2026 release-core artifacts. The final release guardrail
+compare passed with `PASS=185, WARN=0, SKIP=0, FAIL=0`.
+
+The admin UI work adds forms/reports access-parity notes plus static CSharpDB
+Studio admin UI mockups under `www/admin-ui-mockups`.
+
+## Type of Change
+
+- [ ] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [x] Documentation update
+- [x] Refactor / maintenance
+- [ ] Tests only
+
+## Related Issues
+
+No issue numbers were linked for this branch. Included work in this release:
+
+- Completed the roadmap item for source-generated collection fast path
+  completion.
+- Added generated collection binary payload encode/decode around fixed field
+  order, compact type/null metadata, and raw values.
+- Kept non-generated collection paths unchanged.
+- Added direct binary payload decode improvements and top-level span lookup
+  support.
+- Added targeted UTF-8 span plumbing for collection text index/read/compare
+  paths.
+- Added generated collection codec benchmarks and expanded collection binary
+  codec/generator tests.
+- Refreshed release-core benchmark documentation and history.
+- Added CSharpDB Studio admin UI access-parity docs and static mockups.
+
+## Testing
+
+- [x] `dotnet build CSharpDB.slnx`
+- [x] Relevant tests executed
+- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
+- [x] Manual verification performed (if applicable)
+
+Validation performed:
+
+- `dotnet build CSharpDB.slnx -c Release --no-restore`
+- `dotnet test CSharpDB.slnx -c Release --no-build -m:1 -- RunConfiguration.DisableParallelization=true`
+- Non-parallel unit test run passed with `1,652` tests.
+- `dotnet run -c Release --project .\tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --release-core --repeat 3 --repro`
+- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Run-Perf-Guardrails.ps1 -Mode release`
+- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Compare-Baseline.ps1 -ThresholdsPath .\tests\CSharpDB.Benchmarks\perf-thresholds.json -CurrentMicroResultsDir .\tests\CSharpDB.Benchmarks\results\.tmp-current-micro-run -ReportPath .\tests\CSharpDB.Benchmarks\results\perf-guardrails-last.md`
+- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Update-BenchmarkReadme.ps1 -RunManifest .\tests\CSharpDB.Benchmarks\release-core-manifest.json`
+- `Get-Content -Raw .\tests\CSharpDB.Benchmarks\release-core-manifest.json | ConvertFrom-Json`
+- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Update-BenchmarkReadme.ps1 -RunManifest .\tests\CSharpDB.Benchmarks\release-core-manifest.json -DryRun`
+- `git diff --check -- tests\CSharpDB.Benchmarks\README.md tests\CSharpDB.Benchmarks\HISTORY.md tests\CSharpDB.Benchmarks\release-core-manifest.json`
+
+Benchmark validation details:
+
+- Initial release guardrail wrapper completed benchmark collection but failed
+  compare with volatile samples:
+  `PASS=174, WARN=0, SKIP=0, FAIL=11`.
+- Focused retry refreshed the volatile `CollationIndexBenchmarks`,
+  `CollectionIndexBenchmarks`, and `CompositeIndexBenchmarks` micro CSVs.
+- Final official compare passed:
+  `PASS=185, WARN=0, SKIP=0, FAIL=0`.
+
+Focused collection investigation:
+
+| Metric | Result |
+|--------|-------:|
+| Matched rows vs same-machine HEAD baseline | `60` |
+| Faster matched rows | `50` |
+| Slower matched rows | `10` |
+| Median matched speedup | `+4.1%` |
+| Mean matched speedup | `+4.8%` |
+
+Focused recovery highlights:
+
+| Benchmark | Before | After | Change |
+|-----------|-------:|------:|-------:|
+| Collection field read, missing field | `223.22 ns` | `136.73 ns` | `+38.7%` |
+| Collection decode, direct payload | `333.80 ns` | `155.20 ns` | `+53.5%` |
+| Collection field read, early field | `108.60 ns` | `49.77 ns` | `+54.2%` |
+| Collection field compare, late text field | `159.55 ns` | `97.60 ns` | `+38.8%` |
+| Collection field compare, bound accessor | `128.03 ns` | `92.83 ns` | `+27.5%` |
+
+Path-index follow-up highlights:
+
+| Benchmark | Final vs same-machine HEAD baseline |
+|-----------|------------------------------------:|
+| Nested path equality via `FindByIndex` | `+53.6%` |
+| Nested path equality via `FindByPath` | `+55.9%` |
+| Array path equality via `FindByIndex` | `+52.1%` |
+| Text range path lookup | `+42.7%` |
+| Guid equality path lookup | `+59.4%` |
+
+Published scorecard examples from the refreshed benchmark README:
+
+| Area | Result |
+|------|-------:|
+| SQL file-backed single insert | `450.4 ops/sec` |
+| SQL file-backed batch x100 | `41.88K rows/sec` |
+| Collection file-backed put | `447.3 ops/sec` |
+| Collection file-backed batch x100 | `42.28K docs/sec` |
+| Collection hot point get | `1.60M ops/sec` |
+| CSharpDB InsertBatch B1000 | `233.06K rows/sec` |
+
+## Checklist
+
+- [x] I followed the project style and conventions.
+- [x] I added or updated tests for behavior changes.
+- [x] I covered both success and failure paths for changed behavior.
+- [x] I updated docs for user-facing changes.
+- [x] I verified no sensitive data was added.
+
+## Notes for Reviewers
+
+- The highest-risk runtime changes are in the generated collection model and
+  collection payload codec paths:
+  `CollectionModelGenerator`, `CollectionPayloadCodec`,
+  `CollectionBinaryDocumentCodec`, `CollectionDocumentCodec<T>`,
+  `CollectionIndexedFieldReader`, and collection index binding.
+- The generator diff is intentionally large because generated code now owns the
+  binary record encode/decode shape for opt-in generated models.
+- Existing non-generated collection document behavior should remain on the
+  existing JSON and binary document paths.
+- The benchmark README generated region should be edited through
+  `release-core-manifest.json` plus `scripts/Update-BenchmarkReadme.ps1`, not
+  manually.
+- The release-core source artifacts were not replaced by targeted micro runs.
+  The targeted retry only refreshed volatile guardrail micro CSVs before
+  rerunning the official compare.
+- The admin UI mockup commit is included because the branch owner confirmed it
+  should be part of this PR.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,6 +56,8 @@ SQL feature parity, provider/tooling compatibility, and ecosystem expansion.
 | **NuGet package** | Publish and maintain `CSharpDB.Engine`, `CSharpDB.Data`, `CSharpDB.Client`, and `CSharpDB.Primitives` as the primary NuGet packages | Done |
 | **Connection pooling** | Pool underlying direct embedded sessions behind `CSharpDbConnection` to amortize open/close cost | Done |
 | **Admin dashboard improvements** | Richer SQL editor UX, query history, deeper diagnostics, and integrated Forms/Reports tooling beyond the core schema/procedure/storage surface | Done |
+| **Admin Forms Access parity** | Close the highest-impact Access-style form gaps: runtime responsive layouts, full inferred validation enforcement, richer record-source/filter/sort models, Layout View, form modes, command/action events, and broader control coverage | Planned |
+| **Admin Reports Access parity** | Close the highest-impact Access-style report gaps: bounded saved-query previews, full report rendering/export, parameter/filter prompts, richer grouping/totals options, Layout View, conditional formatting, subreports, and broader report controls | Planned |
 | **Visual query designer** | Classic Admin query builder with source canvas, join editing, design grid, SQL preview, and saved designer layouts | Done |
 | **ETL pipelines** | Built-in package-driven pipeline runtime with validation, dry-run, execute/resume flows, API/CLI/client coverage, run history, and Admin visual designer support | Done |
 | **VS Code extension** | Schema explorer, SQL editor with IntelliSense, data browser, table designer, storage diagnostics | Done |
@@ -104,6 +106,8 @@ These are known simplifications in the current implementation:
 | **Collections** | `FindByIndexAsync` supports declared field-equality lookups; `FindByPathAsync` and `FindByPathRangeAsync` support path-based queries on indexed paths; `FindAsync` remains a full scan for unindexed predicates |
 | **Networking** | `CSharpDB.Daemon` now hosts both REST and gRPC from one process; named pipes remain reserved but are not implemented end to end today |
 | **Security** | Remote HTTP and gRPC deployment still rely on external network controls or front-end TLS termination; built-in authentication, authorization, and TLS/mTLS support are still planned |
+| **Admin Forms** | The Forms designer/runtime supports the core generated-form and data-entry path, but still needs Access-parity work for responsive runtime rendering, complete inferred validation, richer form modes, command/action events, advanced filtering/sorting, and broader controls |
+| **Admin Reports** | The Reports designer/runtime supports the core banded preview path, but still needs Access-parity work for bounded saved-query previews, full report output/export, parameters, richer grouping and totals semantics, conditional formatting, subreports, and broader controls |
 | **Text / Multilingual** | Text is stored as UTF-8 and supports all Unicode languages; default semantics remain ordinal, but opt-in `BINARY`, `NOCASE`, `NOCASE_AI`, and `ICU:<locale>` collation are implemented for SQL and collection indexes. Dedicated ordered SQL text index optimization remains planned |
 | **Concurrency** | The physical WAL commit path is still serialized at the storage boundary. Initial multi-writer support is shipped, but observed gains still depend on conflict shape and whether shared auto-commit `INSERT` is left on the default serialized path |
 | **Storage** | No page-level compression |
@@ -185,4 +189,6 @@ Major features already implemented:
 - [Native FFI Tutorials](tutorials/native-ffi/README.md) — Python and Node.js examples using the NativeAOT shared library
 - [User-Defined Functions Plan](user-defined-functions/README.md) — C# library functions callable by the database, native plugin extensions, and WASM sandboxing
 - [Pub/Sub Change Events Plan](pub-sub-events/README.md) — Engine-level change events with channel-based delivery for real-time data subscriptions
+- [Admin Forms Access Parity Plan](admin-forms-access-parity/README.md) — Microsoft Access parity review findings and forms roadmap
+- [Admin Reports Access Parity Plan](admin-reports-access-parity/README.md) — Microsoft Access parity review findings and reports roadmap
 - [Benchmark Suite](../tests/CSharpDB.Benchmarks/README.md) — Performance data informing optimization priorities

--- a/src/CSharpDB.Engine/CollectionDocumentCodec.cs
+++ b/src/CSharpDB.Engine/CollectionDocumentCodec.cs
@@ -78,6 +78,26 @@ internal sealed class CollectionDocumentCodec<T>
         if (_generatedCodec is not null)
             return _generatedCodec.Decode(payload);
 
+        if (UsesDirectPayloadFormat &&
+            CollectionPayloadCodec.TryReadFastHeader(payload, out var header))
+        {
+            string key = Encoding.UTF8.GetString(CollectionPayloadCodec.GetKeyUtf8(payload, header));
+            ReadOnlySpan<byte> documentPayload = CollectionPayloadCodec.GetDocumentPayload(payload, header);
+
+            try
+            {
+                T document = header.Format == CollectionPayloadCodec.CollectionPayloadFormat.Binary
+                    ? CollectionBinaryDocumentCodec.Decode<T>(documentPayload)
+                    : JsonSerializer.Deserialize<T>(documentPayload, s_jsonOptions)!;
+
+                return (key, document);
+            }
+            catch (Exception ex) when (IsFastHeaderFallbackCandidate(ex))
+            {
+                // Fall through to the existing slower path for marker collisions or corrupt direct payloads.
+            }
+        }
+
         return (DecodeKey(payload), DecodeDocument(payload));
     }
 

--- a/src/CSharpDB.Engine/CollectionFieldAccessor.cs
+++ b/src/CSharpDB.Engine/CollectionFieldAccessor.cs
@@ -112,6 +112,9 @@ internal sealed class CollectionFieldAccessor
     internal bool TryReadString(ReadOnlySpan<byte> payload, out string? value)
         => CollectionIndexedFieldReader.TryReadString(payload, this, out value);
 
+    internal bool TryReadStringUtf8(ReadOnlySpan<byte> payload, out ReadOnlySpan<byte> value)
+        => CollectionIndexedFieldReader.TryReadStringUtf8(payload, this, out value);
+
     internal bool TryReadBoolean(ReadOnlySpan<byte> payload, out bool value)
         => CollectionIndexedFieldReader.TryReadBoolean(payload, this, out value);
 

--- a/src/CSharpDB.Engine/CollectionIndexBinding.cs
+++ b/src/CSharpDB.Engine/CollectionIndexBinding.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
@@ -16,6 +17,7 @@ internal sealed class CollectionIndexBinding<
 {
     private readonly Func<T, object?> _fieldAccessor;
     private readonly CollectionFieldAccessor _payloadAccessor;
+    private readonly CollectionField<T>? _fieldDescriptor;
     private readonly CollectionIndexDataKind _valueKind;
     private readonly string? _collation;
 
@@ -26,13 +28,15 @@ internal sealed class CollectionIndexBinding<
         Func<T, object?> fieldAccessor,
         CollectionFieldAccessor payloadAccessor,
         CollectionIndexDataKind valueKind,
-        string? collation)
+        string? collation,
+        CollectionField<T>? fieldDescriptor = null)
     {
         FieldPath = fieldPath;
         IndexName = indexName;
         IndexStore = indexStore;
         _fieldAccessor = fieldAccessor;
         _payloadAccessor = payloadAccessor;
+        _fieldDescriptor = fieldDescriptor;
         _valueKind = valueKind;
         _collation = ValidateCollationForValueKind(valueKind, collation, fieldPath);
     }
@@ -181,7 +185,8 @@ internal sealed class CollectionIndexBinding<
             field.ReadValue,
             field.PayloadAccessor,
             field.DataKind,
-            collation);
+            collation,
+            field);
     }
 
     internal static Func<T, object?> CreateFieldAccessor(string fieldPath)
@@ -250,14 +255,21 @@ internal sealed class CollectionIndexBinding<
         indexKey = 0;
         if (_valueKind == CollectionIndexDataKind.Integer)
         {
-            if (!_payloadAccessor.TryReadInt64(payload, out long integerValue))
+            if (!TryReadPayloadInt64(payload, out long integerValue))
                 return false;
 
             indexKey = integerValue;
             return true;
         }
 
-        if (!_payloadAccessor.TryReadString(payload, out string? textValue) || textValue == null)
+        if (CollationSupport.IsBinaryOrDefault(_collation) &&
+            TryReadPayloadStringUtf8(payload, out ReadOnlySpan<byte> textUtf8))
+        {
+            indexKey = OrderedTextIndexKeyCodec.ComputeKey(textUtf8);
+            return true;
+        }
+
+        if (!TryReadPayloadString(payload, out string? textValue) || textValue == null)
             return false;
 
         return TryBuildKey(DbValue.FromText(textValue), out indexKey);
@@ -271,7 +283,7 @@ internal sealed class CollectionIndexBinding<
         if (!UsesTextKey || IsMultiValueArray)
             return false;
 
-        if (!_payloadAccessor.TryReadString(payload, out string? rawText) || rawText == null)
+        if (!TryReadPayloadString(payload, out string? rawText) || rawText == null)
             return false;
 
         textValue = NormalizeTextForIndex(rawText);
@@ -317,7 +329,7 @@ internal sealed class CollectionIndexBinding<
 
         if (!IsMultiValueArray)
         {
-            if (_payloadAccessor.TryReadString(payload, out string? textValue) && textValue != null)
+            if (TryReadPayloadString(payload, out string? textValue) && textValue != null)
                 textValues.Add(NormalizeTextForIndex(textValue));
 
             return textValues.Count != startCount;
@@ -340,6 +352,14 @@ internal sealed class CollectionIndexBinding<
     {
         if (!IsMultiValueArray)
         {
+            if (UsesTextKey &&
+                value.Type == DbType.Text &&
+                CollationSupport.IsBinaryOrDefault(_collation) &&
+                TryDirectPayloadTextEqualsBinary(payload, value.AsText, out bool textEquals))
+            {
+                return textEquals;
+            }
+
             if (!TryReadComparableValue(payload, out var actualValue))
                 return false;
 
@@ -475,7 +495,7 @@ internal sealed class CollectionIndexBinding<
         value = DbValue.Null;
 
         if (!IsMultiValueArray)
-            return _payloadAccessor.TryReadValue(payload, out value);
+            return TryReadPayloadValue(payload, out value);
 
         var values = new List<DbValue>();
         if (!_payloadAccessor.TryReadIndexValues(payload, values))
@@ -490,6 +510,50 @@ internal sealed class CollectionIndexBinding<
             }
         }
 
+        return false;
+    }
+
+    private bool TryReadPayloadValue(ReadOnlySpan<byte> payload, out DbValue value)
+    {
+        if (_fieldDescriptor is not null)
+            return _fieldDescriptor.TryReadPayloadValue(payload, out value);
+
+        return _payloadAccessor.TryReadValue(payload, out value);
+    }
+
+    private bool TryReadPayloadInt64(ReadOnlySpan<byte> payload, out long value)
+    {
+        if (_fieldDescriptor is not null)
+            return _fieldDescriptor.TryReadPayloadInt64(payload, out value);
+
+        return _payloadAccessor.TryReadInt64(payload, out value);
+    }
+
+    private bool TryReadPayloadString(ReadOnlySpan<byte> payload, out string? value)
+    {
+        if (_fieldDescriptor is not null)
+            return _fieldDescriptor.TryReadPayloadString(payload, out value);
+
+        return _payloadAccessor.TryReadString(payload, out value);
+    }
+
+    private bool TryReadPayloadStringUtf8(ReadOnlySpan<byte> payload, out ReadOnlySpan<byte> value)
+    {
+        if (_fieldDescriptor is not null)
+            return _fieldDescriptor.TryReadPayloadStringUtf8(payload, out value);
+
+        return _payloadAccessor.TryReadStringUtf8(payload, out value);
+    }
+
+    private bool TryDirectPayloadTextEqualsBinary(ReadOnlySpan<byte> payload, string expectedText, out bool equals)
+    {
+        if (TryReadPayloadStringUtf8(payload, out ReadOnlySpan<byte> textUtf8))
+        {
+            equals = Utf8EqualsString(textUtf8, expectedText);
+            return true;
+        }
+
+        equals = false;
         return false;
     }
 
@@ -520,6 +584,53 @@ internal sealed class CollectionIndexBinding<
 
     private string NormalizeTextForIndex(string text)
         => CollationSupport.NormalizeText(text, _collation);
+
+    private static bool Utf8EqualsString(ReadOnlySpan<byte> utf8, string text)
+    {
+        if (utf8.Length == text.Length)
+        {
+            bool ascii = true;
+            for (int i = 0; i < text.Length; i++)
+            {
+                char ch = text[i];
+                if (ch > 0x7F)
+                {
+                    ascii = false;
+                    break;
+                }
+
+                if (utf8[i] != (byte)ch)
+                    return false;
+            }
+
+            if (ascii)
+                return true;
+        }
+
+        int byteCount = Encoding.UTF8.GetByteCount(text);
+        if (byteCount != utf8.Length)
+            return false;
+
+        const int StackallocTextThreshold = 256;
+        byte[]? rented = null;
+        Span<byte> expected = byteCount <= StackallocTextThreshold
+            ? stackalloc byte[StackallocTextThreshold]
+            : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+        try
+        {
+            int written = Encoding.UTF8.GetBytes(text.AsSpan(), expected);
+            return utf8.SequenceEqual(expected[..written]);
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                expected[..byteCount].Clear();
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
 
     private static MemberInfo[] ResolveMemberPath(string[] segments, bool[] arraySegments, string fieldPath)
     {

--- a/src/CSharpDB.Engine/CollectionIndexedFieldReader.cs
+++ b/src/CSharpDB.Engine/CollectionIndexedFieldReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text.Json;
 using CSharpDB.Primitives;
 using CSharpDB.Storage.Serialization;
@@ -6,6 +7,8 @@ namespace CSharpDB.Engine;
 
 internal static class CollectionIndexedFieldReader
 {
+    private const int StackallocPropertyNameThreshold = 256;
+
     public static bool TryReadInt64(ReadOnlySpan<byte> payload, CollectionFieldAccessor accessor, out long value)
     {
         ArgumentNullException.ThrowIfNull(accessor);
@@ -15,8 +18,70 @@ internal static class CollectionIndexedFieldReader
     public static bool TryReadInt64(ReadOnlySpan<byte> payload, string jsonPropertyName, out long value)
     {
         ArgumentNullException.ThrowIfNull(jsonPropertyName);
-        byte[][] pathSegments = [System.Text.Encoding.UTF8.GetBytes(jsonPropertyName)];
-        return TryReadInt64(payload, pathSegments, out value);
+        if (!CollectionPayloadCodec.TryReadFastHeader(payload, out var header))
+        {
+            if (!CollectionPayloadCodec.TryReadValidatedHeader(payload, out header))
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        try
+        {
+            ReadOnlySpan<byte> documentPayload = CollectionPayloadCodec.GetDocumentPayload(payload, header);
+            if (header.Format == CollectionPayloadCodec.CollectionPayloadFormat.Binary)
+            {
+                int byteCount = System.Text.Encoding.UTF8.GetByteCount(jsonPropertyName);
+                byte[]? rented = null;
+                Span<byte> propertyNameUtf8 = byteCount <= StackallocPropertyNameThreshold
+                    ? stackalloc byte[StackallocPropertyNameThreshold]
+                    : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+                try
+                {
+                    int written = System.Text.Encoding.UTF8.GetBytes(jsonPropertyName.AsSpan(), propertyNameUtf8);
+                    return CollectionBinaryDocumentCodec.TryReadInt64(
+                        documentPayload,
+                        propertyNameUtf8[..written],
+                        out value);
+                }
+                finally
+                {
+                    if (rented is not null)
+                    {
+                        propertyNameUtf8[..byteCount].Clear();
+                        ArrayPool<byte>.Shared.Return(rented);
+                    }
+                }
+            }
+
+            var reader = new Utf8JsonReader(documentPayload, isFinalBlock: true, state: default);
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName || reader.CurrentDepth != 1)
+                    continue;
+
+                if (!reader.ValueTextEquals(jsonPropertyName.AsSpan()))
+                    continue;
+
+                if (!reader.Read())
+                    break;
+
+                if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt64(out value))
+                    return true;
+
+                break;
+            }
+
+            value = default;
+            return false;
+        }
+        catch (Exception ex) when (IsFastHeaderFallbackCandidate(ex))
+        {
+            value = default;
+            return false;
+        }
     }
 
     public static bool TryReadString(ReadOnlySpan<byte> payload, CollectionFieldAccessor accessor, out string? value)
@@ -25,11 +90,82 @@ internal static class CollectionIndexedFieldReader
         return TryReadString(payload, accessor.JsonPathSegmentsUtf8, out value);
     }
 
+    public static bool TryReadStringUtf8(ReadOnlySpan<byte> payload, CollectionFieldAccessor accessor, out ReadOnlySpan<byte> value)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+        return TryReadStringUtf8(payload, accessor.JsonPathSegmentsUtf8, out value);
+    }
+
     public static bool TryReadString(ReadOnlySpan<byte> payload, string jsonPropertyName, out string? value)
     {
         ArgumentNullException.ThrowIfNull(jsonPropertyName);
-        byte[][] pathSegments = [System.Text.Encoding.UTF8.GetBytes(jsonPropertyName)];
-        return TryReadString(payload, pathSegments, out value);
+        if (!CollectionPayloadCodec.TryReadFastHeader(payload, out var header))
+        {
+            if (!CollectionPayloadCodec.TryReadValidatedHeader(payload, out header))
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        try
+        {
+            ReadOnlySpan<byte> documentPayload = CollectionPayloadCodec.GetDocumentPayload(payload, header);
+            if (header.Format == CollectionPayloadCodec.CollectionPayloadFormat.Binary)
+            {
+                int byteCount = System.Text.Encoding.UTF8.GetByteCount(jsonPropertyName);
+                byte[]? rented = null;
+                Span<byte> propertyNameUtf8 = byteCount <= StackallocPropertyNameThreshold
+                    ? stackalloc byte[StackallocPropertyNameThreshold]
+                    : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+                try
+                {
+                    int written = System.Text.Encoding.UTF8.GetBytes(jsonPropertyName.AsSpan(), propertyNameUtf8);
+                    return CollectionBinaryDocumentCodec.TryReadString(
+                        documentPayload,
+                        propertyNameUtf8[..written],
+                        out value);
+                }
+                finally
+                {
+                    if (rented is not null)
+                    {
+                        propertyNameUtf8[..byteCount].Clear();
+                        ArrayPool<byte>.Shared.Return(rented);
+                    }
+                }
+            }
+
+            var reader = new Utf8JsonReader(documentPayload, isFinalBlock: true, state: default);
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName || reader.CurrentDepth != 1)
+                    continue;
+
+                if (!reader.ValueTextEquals(jsonPropertyName.AsSpan()))
+                    continue;
+
+                if (!reader.Read())
+                    break;
+
+                if (reader.TokenType == JsonTokenType.String)
+                {
+                    value = reader.GetString();
+                    return true;
+                }
+
+                break;
+            }
+
+            value = null;
+            return false;
+        }
+        catch (Exception ex) when (IsFastHeaderFallbackCandidate(ex))
+        {
+            value = null;
+            return false;
+        }
     }
 
     public static bool TryReadBoolean(ReadOnlySpan<byte> payload, CollectionFieldAccessor accessor, out bool value)
@@ -77,11 +213,28 @@ internal static class CollectionIndexedFieldReader
             ReadOnlySpan<byte> documentPayload = CollectionPayloadCodec.GetDocumentPayload(payload, header);
             if (header.Format == CollectionPayloadCodec.CollectionPayloadFormat.Binary)
             {
-                byte[][] pathSegments = [System.Text.Encoding.UTF8.GetBytes(jsonPropertyName)];
-                return CollectionBinaryDocumentCodec.TryReadValue(
-                    documentPayload,
-                    pathSegments,
-                    out value);
+                int byteCount = System.Text.Encoding.UTF8.GetByteCount(jsonPropertyName);
+                byte[]? rented = null;
+                Span<byte> propertyNameUtf8 = byteCount <= StackallocPropertyNameThreshold
+                    ? stackalloc byte[StackallocPropertyNameThreshold]
+                    : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+                try
+                {
+                    int written = System.Text.Encoding.UTF8.GetBytes(jsonPropertyName.AsSpan(), propertyNameUtf8);
+                    return CollectionBinaryDocumentCodec.TryReadValue(
+                        documentPayload,
+                        propertyNameUtf8[..written],
+                        out value);
+                }
+                finally
+                {
+                    if (rented is not null)
+                    {
+                        propertyNameUtf8[..byteCount].Clear();
+                        ArrayPool<byte>.Shared.Return(rented);
+                    }
+                }
             }
 
             var reader = new Utf8JsonReader(documentPayload, isFinalBlock: true, state: default);
@@ -138,11 +291,28 @@ internal static class CollectionIndexedFieldReader
             ReadOnlySpan<byte> documentPayload = CollectionPayloadCodec.GetDocumentPayload(payload, header);
             if (header.Format == CollectionPayloadCodec.CollectionPayloadFormat.Binary)
             {
-                byte[][] pathSegments = [System.Text.Encoding.UTF8.GetBytes(jsonPropertyName)];
-                return CollectionBinaryDocumentCodec.TryTextEquals(
-                    documentPayload,
-                    pathSegments,
-                    expectedValue);
+                int byteCount = System.Text.Encoding.UTF8.GetByteCount(jsonPropertyName);
+                byte[]? rented = null;
+                Span<byte> propertyNameUtf8 = byteCount <= StackallocPropertyNameThreshold
+                    ? stackalloc byte[StackallocPropertyNameThreshold]
+                    : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+                try
+                {
+                    int written = System.Text.Encoding.UTF8.GetBytes(jsonPropertyName.AsSpan(), propertyNameUtf8);
+                    return CollectionBinaryDocumentCodec.TryTextEquals(
+                        documentPayload,
+                        propertyNameUtf8[..written],
+                        expectedValue);
+                }
+                finally
+                {
+                    if (rented is not null)
+                    {
+                        propertyNameUtf8[..byteCount].Clear();
+                        ArrayPool<byte>.Shared.Return(rented);
+                    }
+                }
             }
 
             var reader = new Utf8JsonReader(documentPayload, isFinalBlock: true, state: default);
@@ -241,6 +411,33 @@ internal static class CollectionIndexedFieldReader
         catch (Exception ex) when (IsFastHeaderFallbackCandidate(ex))
         {
             value = null;
+            return false;
+        }
+    }
+
+    private static bool TryReadStringUtf8(ReadOnlySpan<byte> payload, byte[][] jsonPathSegmentsUtf8, out ReadOnlySpan<byte> value)
+    {
+        if (!CollectionPayloadCodec.TryReadFastHeader(payload, out var header))
+        {
+            if (!CollectionPayloadCodec.TryReadValidatedHeader(payload, out header))
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        try
+        {
+            ReadOnlySpan<byte> documentPayload = CollectionPayloadCodec.GetDocumentPayload(payload, header);
+            if (header.Format == CollectionPayloadCodec.CollectionPayloadFormat.Binary)
+                return CollectionBinaryDocumentCodec.TryReadStringUtf8(documentPayload, jsonPathSegmentsUtf8, out value);
+
+            value = default;
+            return false;
+        }
+        catch (Exception ex) when (IsFastHeaderFallbackCandidate(ex))
+        {
+            value = default;
             return false;
         }
     }

--- a/src/CSharpDB.Engine/CollectionModels.cs
+++ b/src/CSharpDB.Engine/CollectionModels.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using CSharpDB.Primitives;
 using CSharpDB.Storage.Serialization;
 
 namespace CSharpDB.Engine;
@@ -152,6 +153,18 @@ public abstract class CollectionField<TDocument>
 
     internal object? ReadValue(TDocument document) => ReadValueCore(document);
 
+    public virtual bool TryReadPayloadValue(ReadOnlySpan<byte> payload, out DbValue value)
+        => _payloadAccessor.TryReadValue(payload, out value);
+
+    public virtual bool TryReadPayloadInt64(ReadOnlySpan<byte> payload, out long value)
+        => _payloadAccessor.TryReadInt64(payload, out value);
+
+    public virtual bool TryReadPayloadString(ReadOnlySpan<byte> payload, out string? value)
+        => _payloadAccessor.TryReadString(payload, out value);
+
+    public virtual bool TryReadPayloadStringUtf8(ReadOnlySpan<byte> payload, out ReadOnlySpan<byte> value)
+        => _payloadAccessor.TryReadStringUtf8(payload, out value);
+
     protected abstract object? ReadValueCore(TDocument document);
 
     private static string NormalizeFieldPath(string fieldPath, out bool targetsArrayElements)
@@ -208,7 +221,7 @@ public abstract class CollectionField<TDocument>
 /// <summary>
 /// Strongly typed collection field descriptor for generated collection APIs.
 /// </summary>
-public sealed class CollectionField<TDocument, TField> : CollectionField<TDocument>
+public class CollectionField<TDocument, TField> : CollectionField<TDocument>
 {
     private readonly Func<TDocument, object?> _accessor;
 

--- a/src/CSharpDB.Engine/README.md
+++ b/src/CSharpDB.Engine/README.md
@@ -309,6 +309,9 @@ through `JsonPropertyName` without changing the public descriptor names.
 `GetGeneratedCollectionAsync<T>(...)` requires a generated or manually
 registered collection model and exposes only the descriptor-based collection
 surface. That keeps the call path off the reflection-based collection APIs.
+For supported document graphs, generated codecs write the binary direct-payload
+format; generated models with unsupported binary member shapes continue to use
+the source-generated JSON payload path.
 
 Generated collections also require existing collection indexes on that
 collection to resolve through registered generated descriptors. If a collection

--- a/src/CSharpDB.Generators/CollectionModelGenerator.cs
+++ b/src/CSharpDB.Generators/CollectionModelGenerator.cs
@@ -181,7 +181,8 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
                 jsonContextType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 GetPartialTypeKeyword(typeSymbol),
                 MakeSafeIdentifier(typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
-                fields.ToImmutable()),
+                fields.ToImmutable(),
+                TryCreateBinaryTypeSpec(typeSymbol, ImmutableArray<INamedTypeSymbol>.Empty)),
             diagnostics.ToImmutable());
     }
 
@@ -501,11 +502,324 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         return false;
     }
 
+    private static BinaryTypeSpec? TryCreateBinaryTypeSpec(
+        INamedTypeSymbol type,
+        ImmutableArray<INamedTypeSymbol> recursionStack)
+    {
+        if (ContainsType(recursionStack, type))
+            return null;
+
+        var memberCandidates = ImmutableArray.CreateBuilder<BinaryMemberCandidate>();
+        ImmutableArray<INamedTypeSymbol> nextStack = recursionStack.Add(type);
+        foreach (ISymbol member in type.GetMembers().OrderBy(static member => member.Name, StringComparer.Ordinal))
+        {
+            if (!TryGetCollectionMember(member, out ITypeSymbol? memberType) || memberType is null)
+                continue;
+
+            if (!TryCreateBinaryValueSpec(memberType, nextStack, out BinaryValueSpec valueSpec))
+                return null;
+
+            memberCandidates.Add(new BinaryMemberCandidate(
+                member,
+                memberType,
+                valueSpec));
+        }
+
+        ImmutableArray<BinaryMemberCandidate> candidateMembers = memberCandidates.ToImmutable();
+        if (!TryCreateBinaryConstructorSpec(type, candidateMembers, out BinaryConstructorSpec constructor))
+            return null;
+
+        candidateMembers = OrderBinaryMembersByConstructor(candidateMembers, constructor, out constructor);
+
+        var members = ImmutableArray.CreateBuilder<BinaryMemberSpec>(candidateMembers.Length);
+        for (int i = 0; i < candidateMembers.Length; i++)
+        {
+            BinaryMemberCandidate candidate = candidateMembers[i];
+            ISymbol member = candidate.Member;
+            members.Add(new BinaryMemberSpec(
+                member.Name,
+                EscapeIdentifier(member.Name),
+                GetJsonPropertyName(member) ?? JsonNamingPolicy.CamelCase.ConvertName(member.Name),
+                candidate.Value));
+        }
+
+        return new BinaryTypeSpec(
+            type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            MakeSafeIdentifier(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
+            members.ToImmutable(),
+            constructor);
+    }
+
+    private static bool TryCreateBinaryConstructorSpec(
+        INamedTypeSymbol type,
+        ImmutableArray<BinaryMemberCandidate> members,
+        out BinaryConstructorSpec constructor)
+    {
+        foreach (IMethodSymbol candidate in type.InstanceConstructors)
+        {
+            if (!CanGeneratedCodeCall(candidate) ||
+                candidate.Parameters.Length != members.Length)
+            {
+                continue;
+            }
+
+            var memberIndexes = ImmutableArray.CreateBuilder<int>(candidate.Parameters.Length);
+            var usedMemberIndexes = new HashSet<int>();
+            bool matches = true;
+            foreach (IParameterSymbol parameter in candidate.Parameters)
+            {
+                int memberIndex = FindConstructorMemberIndex(parameter, members, usedMemberIndexes);
+                if (memberIndex < 0)
+                {
+                    matches = false;
+                    break;
+                }
+
+                usedMemberIndexes.Add(memberIndex);
+                memberIndexes.Add(memberIndex);
+            }
+
+            if (!matches)
+                continue;
+
+            constructor = new BinaryConstructorSpec(memberIndexes.ToImmutable());
+            return true;
+        }
+
+        constructor = default;
+        return false;
+    }
+
+    private static ImmutableArray<BinaryMemberCandidate> OrderBinaryMembersByConstructor(
+        ImmutableArray<BinaryMemberCandidate> members,
+        BinaryConstructorSpec constructor,
+        out BinaryConstructorSpec remappedConstructor)
+    {
+        var orderedMembers = ImmutableArray.CreateBuilder<BinaryMemberCandidate>(members.Length);
+        var remappedParameterMemberIndexes = ImmutableArray.CreateBuilder<int>(constructor.ParameterMemberIndexes.Length);
+        var usedMemberIndexes = new HashSet<int>();
+
+        for (int i = 0; i < constructor.ParameterMemberIndexes.Length; i++)
+        {
+            int memberIndex = constructor.ParameterMemberIndexes[i];
+            if ((uint)memberIndex >= (uint)members.Length || !usedMemberIndexes.Add(memberIndex))
+                throw new InvalidOperationException("Generated binary constructor member indexes are invalid.");
+
+            remappedParameterMemberIndexes.Add(orderedMembers.Count);
+            orderedMembers.Add(members[memberIndex]);
+        }
+
+        for (int i = 0; i < members.Length; i++)
+        {
+            if (usedMemberIndexes.Add(i))
+                orderedMembers.Add(members[i]);
+        }
+
+        remappedConstructor = new BinaryConstructorSpec(remappedParameterMemberIndexes.ToImmutable());
+        return orderedMembers.ToImmutable();
+    }
+
+    private static bool CanGeneratedCodeCall(IMethodSymbol constructor)
+        => constructor.DeclaredAccessibility is
+            Accessibility.Public or
+            Accessibility.Internal or
+            Accessibility.ProtectedOrInternal;
+
+    private static int FindConstructorMemberIndex(
+        IParameterSymbol parameter,
+        ImmutableArray<BinaryMemberCandidate> members,
+        HashSet<int> usedMemberIndexes)
+    {
+        for (int i = 0; i < members.Length; i++)
+        {
+            if (usedMemberIndexes.Contains(i))
+                continue;
+
+            BinaryMemberCandidate member = members[i];
+            if (!string.Equals(parameter.Name, member.Member.Name, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!SymbolEqualityComparer.Default.Equals(parameter.Type, member.Type))
+                continue;
+
+            return i;
+        }
+
+        return -1;
+    }
+
+    private static bool TryCreateBinaryValueSpec(
+        ITypeSymbol type,
+        ImmutableArray<INamedTypeSymbol> recursionStack,
+        out BinaryValueSpec valueSpec)
+    {
+        if (TryGetBinaryCollectionElementType(type, out ITypeSymbol? elementType) && elementType is not null)
+        {
+            if (TryGetCollectionElementType(elementType, out _))
+            {
+                valueSpec = null!;
+                return false;
+            }
+
+            if (!TryCreateBinaryElementValueSpec(elementType, recursionStack, out BinaryValueSpec elementSpec))
+            {
+                valueSpec = null!;
+                return false;
+            }
+
+            valueSpec = BinaryValueSpec.ForArray(
+                type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                type is IArrayTypeSymbol,
+                CanBeNull(type),
+                elementSpec);
+            return true;
+        }
+
+        return TryCreateBinaryElementValueSpec(type, recursionStack, out valueSpec);
+    }
+
+    private static bool TryCreateBinaryElementValueSpec(
+        ITypeSymbol type,
+        ImmutableArray<INamedTypeSymbol> recursionStack,
+        out BinaryValueSpec valueSpec)
+    {
+        ITypeSymbol effectiveType = UnwrapNullable(type);
+        if (TryGetBinaryScalarKind(effectiveType, out string valueKindName))
+        {
+            valueSpec = BinaryValueSpec.ForScalar(
+                type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                effectiveType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                valueKindName,
+                CanBeNull(type),
+                IsNullableValueType(type));
+            return true;
+        }
+
+        if (TryGetNavigableComplexType(type, out INamedTypeSymbol? nestedType) &&
+            nestedType is not null &&
+            !ContainsType(recursionStack, nestedType))
+        {
+            BinaryTypeSpec? nestedSpec = TryCreateBinaryTypeSpec(nestedType, recursionStack);
+            if (nestedSpec is not null)
+            {
+                valueSpec = BinaryValueSpec.ForObject(
+                    type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    effectiveType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    CanBeNull(type),
+                    IsNullableValueType(type),
+                    nestedSpec);
+                return true;
+            }
+        }
+
+        valueSpec = null!;
+        return false;
+    }
+
+    private static bool TryGetBinaryScalarKind(ITypeSymbol type, out string valueKindName)
+    {
+        if (type.SpecialType == SpecialType.System_String)
+        {
+            valueKindName = "String";
+            return true;
+        }
+
+        if (IsWellKnownType(type, "System.Guid"))
+        {
+            valueKindName = "Guid";
+            return true;
+        }
+
+        if (IsWellKnownType(type, "System.DateOnly"))
+        {
+            valueKindName = "DateOnly";
+            return true;
+        }
+
+        if (IsWellKnownType(type, "System.TimeOnly"))
+        {
+            valueKindName = "TimeOnly";
+            return true;
+        }
+
+        if (type.TypeKind == TypeKind.Enum)
+        {
+            valueKindName = "Enum";
+            return true;
+        }
+
+        valueKindName = type.SpecialType switch
+        {
+            SpecialType.System_Boolean => "Boolean",
+            SpecialType.System_Byte => "Byte",
+            SpecialType.System_SByte => "SByte",
+            SpecialType.System_Int16 => "Int16",
+            SpecialType.System_UInt16 => "UInt16",
+            SpecialType.System_Int32 => "Int32",
+            SpecialType.System_UInt32 => "UInt32",
+            SpecialType.System_Int64 => "Int64",
+            SpecialType.System_Single => "Single",
+            SpecialType.System_Double => "Double",
+            SpecialType.System_Decimal => "Decimal",
+            _ => string.Empty,
+        };
+
+        return valueKindName.Length > 0;
+    }
+
     private static bool IsEnumerableLike(INamedTypeSymbol constructedType)
     {
         string displayName = constructedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         return displayName is
             "global::System.Collections.Generic.IEnumerable<T>" or
+            "global::System.Collections.Generic.ICollection<T>" or
+            "global::System.Collections.Generic.IList<T>" or
+            "global::System.Collections.Generic.IReadOnlyCollection<T>" or
+            "global::System.Collections.Generic.IReadOnlyList<T>" or
+            "global::System.Collections.Generic.List<T>";
+    }
+
+    private static bool TryGetBinaryCollectionElementType(ITypeSymbol type, out ITypeSymbol? elementType)
+    {
+        elementType = null;
+        if (type.SpecialType == SpecialType.System_String)
+            return false;
+
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            elementType = arrayType.ElementType;
+            return true;
+        }
+
+        if (type is not INamedTypeSymbol namedType)
+            return false;
+
+        if (namedType.IsGenericType &&
+            namedType.TypeArguments.Length == 1 &&
+            IsCountedEnumerableLike(namedType.ConstructedFrom))
+        {
+            elementType = namedType.TypeArguments[0];
+            return true;
+        }
+
+        foreach (INamedTypeSymbol interfaceType in namedType.AllInterfaces)
+        {
+            if (interfaceType.IsGenericType &&
+                interfaceType.TypeArguments.Length == 1 &&
+                IsCountedEnumerableLike(interfaceType.ConstructedFrom))
+            {
+                elementType = interfaceType.TypeArguments[0];
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCountedEnumerableLike(INamedTypeSymbol constructedType)
+    {
+        string displayName = constructedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return displayName is
             "global::System.Collections.Generic.ICollection<T>" or
             "global::System.Collections.Generic.IList<T>" or
             "global::System.Collections.Generic.IReadOnlyCollection<T>" or
@@ -777,6 +1091,111 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         return builder.ToString();
     }
 
+    private static string CreateBinaryPayloadFieldMethodName(CollectionFieldSpec field)
+        => "TryReadBinaryPayloadField_" + MakeSafeIdentifier(field.GeneratedMemberName);
+
+    private static string CreateBinaryPayloadValueReaderName(CollectionFieldSpec field)
+        => "TryReadPayloadValue_" + MakeSafeIdentifier(field.GeneratedMemberName);
+
+    private static string CreateBinaryPayloadIntegerReaderName(CollectionFieldSpec field)
+        => "TryReadPayloadInteger_" + MakeSafeIdentifier(field.GeneratedMemberName);
+
+    private static string CreateBinaryPayloadTextReaderName(CollectionFieldSpec field)
+        => "TryReadPayloadText_" + MakeSafeIdentifier(field.GeneratedMemberName);
+
+    private static string CreateBinaryPayloadTextUtf8ReaderName(CollectionFieldSpec field)
+        => "TryReadPayloadTextUtf8_" + MakeSafeIdentifier(field.GeneratedMemberName);
+
+    private static bool TryCreateBinaryFieldReaderSpec(
+        BinaryTypeSpec root,
+        CollectionFieldSpec field,
+        out BinaryFieldReaderSpec reader)
+    {
+        reader = default;
+        if (field.PayloadFieldPath.IndexOf('[') >= 0 ||
+            field.PayloadFieldPath.IndexOf(']') >= 0)
+        {
+            return false;
+        }
+
+        string[] pathSegments = field.PayloadFieldPath.Split('.');
+        if (pathSegments.Length == 0)
+            return false;
+
+        var memberIndexes = ImmutableArray.CreateBuilder<int>(pathSegments.Length);
+        BinaryTypeSpec currentType = root;
+        BinaryValueSpec? value = null;
+        for (int i = 0; i < pathSegments.Length; i++)
+        {
+            if (!TryFindBinaryMember(currentType, pathSegments[i], out int memberIndex))
+                return false;
+
+            memberIndexes.Add(memberIndex);
+            value = currentType.Members[memberIndex].Value;
+            if (i == pathSegments.Length - 1)
+                break;
+
+            if (value.ObjectType is null)
+                return false;
+
+            currentType = value.ObjectType;
+        }
+
+        if (value is null || value.IsArray || value.ObjectType is not null)
+            return false;
+
+        if (!IsSupportedBinaryPayloadFieldReader(value, field.DataKindName))
+            return false;
+
+        reader = new BinaryFieldReaderSpec(memberIndexes.ToImmutable(), value, field.DataKindName);
+        return true;
+    }
+
+    private static bool TryFindBinaryMember(BinaryTypeSpec type, string jsonName, out int memberIndex)
+    {
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            if (string.Equals(type.Members[i].JsonName, jsonName, StringComparison.Ordinal))
+            {
+                memberIndex = i;
+                return true;
+            }
+        }
+
+        memberIndex = -1;
+        return false;
+    }
+
+    private static bool IsSupportedBinaryPayloadFieldReader(BinaryValueSpec value, string dataKindName)
+        => dataKindName switch
+        {
+            "Integer" => value.ValueKindName is "Byte" or "SByte" or "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "Enum",
+            "Text" => value.ValueKindName is "String" or "Guid" or "DateOnly" or "TimeOnly",
+            _ => false,
+        };
+
+    private static bool CanUseBinaryRecordFormat(BinaryTypeSpec type)
+    {
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            if (ContainsBinaryArray(type.Members[i].Value))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool ContainsBinaryArray(BinaryValueSpec value)
+    {
+        if (value.IsArray)
+            return true;
+
+        if (value.ObjectType is not null && !CanUseBinaryRecordFormat(value.ObjectType))
+            return true;
+
+        return value.Element is not null && ContainsBinaryArray(value.Element);
+    }
+
     private static void EmitModel(SourceProductionContext context, CollectionModelTarget target)
     {
         var source = new StringBuilder();
@@ -796,6 +1215,17 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
 
         foreach (CollectionFieldSpec field in target.Fields)
         {
+            BinaryFieldReaderSpec binaryFieldReader = default;
+            bool hasBinaryPayloadReader = target.BinaryModel is not null &&
+                                          TryCreateBinaryFieldReaderSpec(target.BinaryModel, field, out binaryFieldReader);
+            string codecTypeName = "__CSharpDB_CollectionCodec_" + target.SafeIdentifier;
+            string? fieldTypeName = hasBinaryPayloadReader
+                ? "__CSharpDB_CollectionField_" + MakeSafeIdentifier(field.GeneratedMemberName)
+                : null;
+
+            if (fieldTypeName is not null)
+                EmitGeneratedCollectionFieldType(source, target, field, binaryFieldReader, codecTypeName, fieldTypeName);
+
             source.Append("        public static global::CSharpDB.Engine.CollectionField<")
                 .Append(target.FullyQualifiedTypeName)
                 .Append(", ")
@@ -803,6 +1233,15 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
                 .Append("> ")
                 .Append(field.EscapedMemberName)
                 .AppendLine(" { get; } =");
+            if (fieldTypeName is not null)
+            {
+                source.Append("            new ")
+                    .Append(fieldTypeName)
+                    .AppendLine("();");
+                source.AppendLine();
+                continue;
+            }
+
             source.Append("            new(")
                 .Append(SymbolDisplay.FormatLiteral(field.FieldPath, quote: true))
                 .Append(", ")
@@ -811,6 +1250,37 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
                 .Append(field.DataKindName)
                 .Append(", ")
                 .Append(SymbolDisplay.FormatLiteral(field.PayloadFieldPath, quote: true));
+            if (hasBinaryPayloadReader)
+            {
+                source.Append(", ")
+                    .Append(codecTypeName)
+                    .Append('.')
+                    .Append(CreateBinaryPayloadValueReaderName(field))
+                    .Append(", ");
+                if (binaryFieldReader.DataKindName == "Integer")
+                {
+                    source.Append(codecTypeName)
+                        .Append('.')
+                        .Append(CreateBinaryPayloadIntegerReaderName(field));
+                }
+                else
+                {
+                    source.Append("null");
+                }
+
+                source.Append(", ");
+                if (binaryFieldReader.DataKindName == "Text")
+                {
+                    source.Append(codecTypeName)
+                        .Append('.')
+                        .Append(CreateBinaryPayloadTextReaderName(field));
+                }
+                else
+                {
+                    source.Append("null");
+                }
+            }
+
             source.AppendLine(");");
             source.AppendLine();
         }
@@ -879,6 +1349,22 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
             .AppendLine(">");
         source.AppendLine("{");
         source.AppendLine("    private const int StackallocKeyThreshold = 256;");
+        if (target.BinaryModel is not null)
+        {
+            source.AppendLine("    private const byte RecordFormatMarker = 0xD0;");
+            source.AppendLine("    private const byte RecordFormatMagic = 0xF0;");
+            source.AppendLine("    private const byte RecordFormatVersion = 0x01;");
+            source.AppendLine("    private const byte NullTag = 0;");
+            source.AppendLine("    private const byte StringTag = 1;");
+            source.AppendLine("    private const byte IntegerTag = 2;");
+            source.AppendLine("    private const byte FalseTag = 3;");
+            source.AppendLine("    private const byte TrueTag = 4;");
+            source.AppendLine("    private const byte DoubleTag = 5;");
+            source.AppendLine("    private const byte DecimalTag = 6;");
+            source.AppendLine("    private const byte ObjectTag = 7;");
+            source.AppendLine("    private const byte ArrayTag = 8;");
+        }
+
         source.AppendLine("    private readonly global::CSharpDB.Storage.Serialization.IRecordSerializer _recordSerializer;");
         source.AppendLine("    private readonly bool _usesDirectPayloadFormat;");
         source.Append("    private static readonly global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<")
@@ -908,8 +1394,19 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         source.AppendLine();
         source.AppendLine("        if (_usesDirectPayloadFormat)");
         source.AppendLine("        {");
-        source.AppendLine("            byte[] jsonUtf8 = global::System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(document, s_typeInfo);");
-        source.AppendLine("            return global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.Encode(key, jsonUtf8);");
+        if (target.BinaryModel is not null)
+        {
+            source.AppendLine("            int documentPayloadLength = GetBinaryDocumentSize(document);");
+            source.AppendLine("            byte[] payload = global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.EncodeBinary(key, documentPayloadLength, out int documentPayloadStart);");
+            source.AppendLine("            WriteBinaryDocument(payload.AsSpan(documentPayloadStart, documentPayloadLength), document);");
+            source.AppendLine("            return payload;");
+        }
+        else
+        {
+            source.AppendLine("            byte[] jsonUtf8 = global::System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(document, s_typeInfo);");
+            source.AppendLine("            return global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.Encode(key, jsonUtf8);");
+        }
+
         source.AppendLine("        }");
         source.AppendLine();
         source.AppendLine("        string json = global::System.Text.Json.JsonSerializer.Serialize(document, s_typeInfo);");
@@ -929,6 +1426,13 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
             .Append(target.FullyQualifiedTypeName)
             .AppendLine(" DecodeDocument(global::System.ReadOnlySpan<byte> payload)");
         source.AppendLine("    {");
+        if (target.BinaryModel is not null)
+        {
+            source.AppendLine("        if (_usesDirectPayloadFormat && global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.TryGetBinaryDocumentPayload(payload, out global::System.ReadOnlySpan<byte> binaryDocument))");
+            source.AppendLine("            return DecodeBinaryDocument(binaryDocument);");
+            source.AppendLine();
+        }
+
         source.AppendLine("        if (_usesDirectPayloadFormat && global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.IsDirectPayload(payload))");
         source.AppendLine("        {");
         source.AppendLine("            if (!global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.IsBinaryPayload(payload))");
@@ -949,8 +1453,8 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         source.AppendLine();
         source.AppendLine("    public string DecodeKey(global::System.ReadOnlySpan<byte> payload)");
         source.AppendLine("    {");
-        source.AppendLine("        if (_usesDirectPayloadFormat && global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.IsDirectPayload(payload))");
-        source.AppendLine("            return global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.DecodeKey(payload);");
+        source.AppendLine("        if (_usesDirectPayloadFormat && global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.TryDecodeDirectPayloadKey(payload, out string key))");
+        source.AppendLine("            return key;");
         source.AppendLine();
         source.AppendLine("        global::CSharpDB.Primitives.DbValue[] values = _recordSerializer.DecodeUpTo(payload, 0);");
         source.AppendLine("        return values[0].AsText;");
@@ -974,6 +1478,9 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         source.AppendLine("    {");
         source.AppendLine("        global::System.ArgumentNullException.ThrowIfNull(expectedKey);");
         source.AppendLine();
+        source.AppendLine("        if (_usesDirectPayloadFormat && global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.TryDirectPayloadKeyEquals(payload, expectedKey, out bool directEquals))");
+        source.AppendLine("            return directEquals;");
+        source.AppendLine();
         source.AppendLine("        int byteCount = global::System.Text.Encoding.UTF8.GetByteCount(expectedKey);");
         source.AppendLine("        byte[]? rented = null;");
         source.AppendLine("        global::System.Span<byte> utf8 = byteCount <= StackallocKeyThreshold");
@@ -984,9 +1491,6 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         source.AppendLine("        {");
         source.AppendLine("            int written = global::System.Text.Encoding.UTF8.GetBytes(expectedKey.AsSpan(), utf8);");
         source.AppendLine("            global::System.ReadOnlySpan<byte> expectedKeyUtf8 = utf8[..written];");
-        source.AppendLine();
-        source.AppendLine("            if (_usesDirectPayloadFormat && global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.IsDirectPayload(payload))");
-        source.AppendLine("                return global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.KeyEquals(payload, expectedKeyUtf8);");
         source.AppendLine();
         source.AppendLine("            if (_recordSerializer.TryColumnTextEquals(payload, 0, expectedKeyUtf8, out bool equals))");
         source.AppendLine("                return equals;");
@@ -1002,6 +1506,12 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         source.AppendLine("            }");
         source.AppendLine("        }");
         source.AppendLine("    }");
+        if (target.BinaryModel is not null)
+        {
+            source.AppendLine();
+            EmitBinaryCodecMembers(source, target.BinaryModel, target.Fields);
+        }
+
         source.AppendLine("}");
         source.AppendLine();
 
@@ -1026,6 +1536,2546 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
             sourceText: SourceText.From(source.ToString(), Encoding.UTF8));
     }
 
+    private static void EmitGeneratedCollectionFieldType(
+        StringBuilder source,
+        CollectionModelTarget target,
+        CollectionFieldSpec field,
+        BinaryFieldReaderSpec binaryFieldReader,
+        string codecTypeName,
+        string fieldTypeName)
+    {
+        source.Append("        private sealed class ")
+            .Append(fieldTypeName)
+            .Append(" : global::CSharpDB.Engine.CollectionField<")
+            .Append(target.FullyQualifiedTypeName)
+            .Append(", ")
+            .Append(field.MemberTypeName)
+            .AppendLine(">");
+        source.AppendLine("        {");
+        source.Append("            public ")
+            .Append(fieldTypeName)
+            .AppendLine("()");
+        source.Append("                : base(")
+            .Append(SymbolDisplay.FormatLiteral(field.FieldPath, quote: true))
+            .Append(", ")
+            .Append(field.AccessorExpression)
+            .Append(", global::CSharpDB.Engine.CollectionIndexDataKind.")
+            .Append(field.DataKindName)
+            .Append(", ")
+            .Append(SymbolDisplay.FormatLiteral(field.PayloadFieldPath, quote: true))
+            .AppendLine(")");
+        source.AppendLine("            {");
+        source.AppendLine("            }");
+        source.AppendLine();
+
+        source.AppendLine("            public override bool TryReadPayloadValue(global::System.ReadOnlySpan<byte> payload, out global::CSharpDB.Primitives.DbValue value)");
+        source.AppendLine("            {");
+        source.Append("                if (")
+            .Append(codecTypeName)
+            .Append('.')
+            .Append(CreateBinaryPayloadValueReaderName(field))
+            .AppendLine("(payload, out value))");
+        source.AppendLine("                    return true;");
+        source.AppendLine();
+        source.AppendLine("                return base.TryReadPayloadValue(payload, out value);");
+        source.AppendLine("            }");
+
+        if (binaryFieldReader.DataKindName == "Integer")
+        {
+            source.AppendLine();
+            source.AppendLine("            public override bool TryReadPayloadInt64(global::System.ReadOnlySpan<byte> payload, out long value)");
+            source.AppendLine("            {");
+            source.Append("                if (")
+                .Append(codecTypeName)
+                .Append('.')
+                .Append(CreateBinaryPayloadIntegerReaderName(field))
+                .AppendLine("(payload, out value))");
+            source.AppendLine("                    return true;");
+            source.AppendLine();
+            source.AppendLine("                return base.TryReadPayloadInt64(payload, out value);");
+            source.AppendLine("            }");
+        }
+        else if (binaryFieldReader.DataKindName == "Text")
+        {
+            source.AppendLine();
+            source.AppendLine("            public override bool TryReadPayloadString(global::System.ReadOnlySpan<byte> payload, out string? value)");
+            source.AppendLine("            {");
+            source.Append("                if (")
+                .Append(codecTypeName)
+                .Append('.')
+                .Append(CreateBinaryPayloadTextReaderName(field))
+                .AppendLine("(payload, out value))");
+            source.AppendLine("                    return true;");
+            source.AppendLine();
+            source.AppendLine("                return base.TryReadPayloadString(payload, out value);");
+            source.AppendLine("            }");
+            source.AppendLine();
+            source.AppendLine("            public override bool TryReadPayloadStringUtf8(global::System.ReadOnlySpan<byte> payload, out global::System.ReadOnlySpan<byte> value)");
+            source.AppendLine("            {");
+            source.Append("                if (")
+                .Append(codecTypeName)
+                .Append('.')
+                .Append(CreateBinaryPayloadTextUtf8ReaderName(field))
+                .AppendLine("(payload, out value))");
+            source.AppendLine("                    return true;");
+            source.AppendLine();
+            source.AppendLine("                return base.TryReadPayloadStringUtf8(payload, out value);");
+            source.AppendLine("            }");
+        }
+
+        source.AppendLine("        }");
+        source.AppendLine();
+    }
+
+    private static void EmitBinaryCodecMembers(
+        StringBuilder source,
+        BinaryTypeSpec root,
+        ImmutableArray<CollectionFieldSpec> fields)
+    {
+        bool useRecordFormat = CanUseBinaryRecordFormat(root);
+
+        source.Append("    private static int GetBinaryDocumentSize(")
+            .Append(root.TypeName)
+            .AppendLine(" document)");
+        source.Append("        => ");
+        if (useRecordFormat)
+            source.Append("3 + GetBinaryRecordSize_");
+        else
+            source.Append("GetBinarySize_");
+
+        source.Append(root.SafeIdentifier).AppendLine("(document);");
+        source.AppendLine();
+
+        source.Append("    private static void WriteBinaryDocument(global::System.Span<byte> destination, ")
+            .Append(root.TypeName)
+            .AppendLine(" document)");
+        source.AppendLine("    {");
+        source.AppendLine("        int position = 0;");
+        if (useRecordFormat)
+        {
+            source.AppendLine("        WriteByte(destination, ref position, RecordFormatMarker);");
+            source.AppendLine("        WriteByte(destination, ref position, RecordFormatMagic);");
+            source.AppendLine("        WriteByte(destination, ref position, RecordFormatVersion);");
+            source.Append("        WriteBinaryRecord_").Append(root.SafeIdentifier).AppendLine("(destination, ref position, document);");
+        }
+        else
+        {
+            source.Append("        WriteBinary_").Append(root.SafeIdentifier).AppendLine("(destination, ref position, document);");
+        }
+
+        source.AppendLine("        if (position != destination.Length)");
+        source.AppendLine("            throw new global::System.InvalidOperationException(\"Generated binary collection payload size mismatch.\");");
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        source.Append("    private static ")
+            .Append(root.TypeName)
+            .AppendLine(" DecodeBinaryDocument(global::System.ReadOnlySpan<byte> payload)");
+        source.AppendLine("    {");
+        source.AppendLine("        int position = 0;");
+        if (useRecordFormat)
+        {
+            source.AppendLine("        if (IsBinaryRecordPayload(payload))");
+            source.AppendLine("        {");
+            source.AppendLine("            position = 3;");
+            source.Append("            ")
+                .Append(root.TypeName)
+                .Append(" recordDocument = ReadBinaryRecord_")
+                .Append(root.SafeIdentifier)
+                .AppendLine("(payload, ref position);");
+            source.AppendLine("            if (position != payload.Length)");
+            source.AppendLine("                throw new global::CSharpDB.Primitives.CSharpDbException(global::CSharpDB.Primitives.ErrorCode.CorruptDatabase, \"Invalid generated binary collection payload length.\");");
+            source.AppendLine();
+            source.AppendLine("            return recordDocument;");
+            source.AppendLine("        }");
+            source.AppendLine();
+        }
+
+        source.Append("        ")
+            .Append(root.TypeName)
+            .Append(" document = ReadBinary_")
+            .Append(root.SafeIdentifier)
+            .AppendLine("(payload, ref position);");
+        source.AppendLine("        if (position != payload.Length)");
+        source.AppendLine("            throw new global::CSharpDB.Primitives.CSharpDbException(global::CSharpDB.Primitives.ErrorCode.CorruptDatabase, \"Invalid generated binary collection payload length.\");");
+        source.AppendLine();
+        source.AppendLine("        return document;");
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        var emittedSizeTypes = new HashSet<string>(StringComparer.Ordinal);
+        EmitBinaryTypeSizer(source, root, emittedSizeTypes);
+        var emittedWriterTypes = new HashSet<string>(StringComparer.Ordinal);
+        EmitBinaryTypeWriter(source, root, emittedWriterTypes);
+        var emittedReaderTypes = new HashSet<string>(StringComparer.Ordinal);
+        EmitBinaryTypeReader(source, root, emittedReaderTypes);
+        if (useRecordFormat)
+        {
+            var emittedRecordSizeTypes = new HashSet<string>(StringComparer.Ordinal);
+            EmitBinaryRecordTypeSizer(source, root, emittedRecordSizeTypes);
+            var emittedRecordWriterTypes = new HashSet<string>(StringComparer.Ordinal);
+            EmitBinaryRecordTypeWriter(source, root, emittedRecordWriterTypes);
+            var emittedRecordReaderTypes = new HashSet<string>(StringComparer.Ordinal);
+            EmitBinaryRecordTypeReader(source, root, emittedRecordReaderTypes);
+            var emittedRecordSkipperTypes = new HashSet<string>(StringComparer.Ordinal);
+            EmitBinaryRecordTypeSkipper(source, root, emittedRecordSkipperTypes);
+        }
+
+        EmitBinaryPayloadFieldReaders(source, root, fields);
+        EmitBinaryPrimitiveHelpers(source);
+    }
+
+    private static void EmitBinaryTypeSizer(
+        StringBuilder source,
+        BinaryTypeSpec type,
+        HashSet<string> emittedTypes)
+    {
+        if (!emittedTypes.Add(type.SafeIdentifier))
+            return;
+
+        source.Append("    private static int GetBinarySize_")
+            .Append(type.SafeIdentifier)
+            .Append('(')
+            .Append(type.TypeName)
+            .AppendLine(" value)");
+        source.AppendLine("    {");
+        source.Append("        int size = GetVarintSize((ulong)")
+            .Append(type.Members.Length.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .AppendLine(");");
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            string valueVariable = "value" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            source.Append("        size += GetLengthPrefixedUtf8Size(")
+                .Append(SymbolDisplay.FormatLiteral(member.JsonName, quote: true))
+                .AppendLine("u8);");
+            source.Append("        var ")
+                .Append(valueVariable)
+                .Append(" = value.")
+                .Append(member.EscapedClrName)
+                .AppendLine(";");
+            EmitGetBinaryValueSize(source, member.Value, valueVariable, "        ", i.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        source.AppendLine("        return size;");
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        for (int i = 0; i < type.Members.Length; i++)
+            EmitNestedBinaryTypeSizers(source, type.Members[i].Value, emittedTypes);
+    }
+
+    private static void EmitNestedBinaryTypeSizers(
+        StringBuilder source,
+        BinaryValueSpec value,
+        HashSet<string> emittedTypes)
+    {
+        if (value.ObjectType is not null)
+            EmitBinaryTypeSizer(source, value.ObjectType, emittedTypes);
+
+        if (value.Element is not null)
+            EmitNestedBinaryTypeSizers(source, value.Element, emittedTypes);
+    }
+
+    private static void EmitBinaryTypeWriter(
+        StringBuilder source,
+        BinaryTypeSpec type,
+        HashSet<string> emittedTypes)
+    {
+        if (!emittedTypes.Add(type.SafeIdentifier))
+            return;
+
+        source.Append("    private static void WriteBinary_")
+            .Append(type.SafeIdentifier)
+            .Append("(global::System.Span<byte> destination, ref int position, ")
+            .Append(type.TypeName)
+            .AppendLine(" value)");
+        source.AppendLine("    {");
+        source.Append("        WriteVarint(destination, ref position, (ulong)")
+            .Append(type.Members.Length.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .AppendLine(");");
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            string valueVariable = "value" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            source.Append("        WriteLengthPrefixedUtf8(destination, ref position, ")
+                .Append(SymbolDisplay.FormatLiteral(member.JsonName, quote: true))
+                .AppendLine("u8);");
+            source.Append("        var ")
+                .Append(valueVariable)
+                .Append(" = value.")
+                .Append(member.EscapedClrName)
+                .AppendLine(";");
+            EmitWriteBinaryValue(source, member.Value, valueVariable, "        ", i.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        for (int i = 0; i < type.Members.Length; i++)
+            EmitNestedBinaryTypeWriters(source, type.Members[i].Value, emittedTypes);
+    }
+
+    private static void EmitNestedBinaryTypeWriters(
+        StringBuilder source,
+        BinaryValueSpec value,
+        HashSet<string> emittedTypes)
+    {
+        if (value.ObjectType is not null)
+            EmitBinaryTypeWriter(source, value.ObjectType, emittedTypes);
+
+        if (value.Element is not null)
+            EmitNestedBinaryTypeWriters(source, value.Element, emittedTypes);
+    }
+
+    private static void EmitBinaryTypeReader(
+        StringBuilder source,
+        BinaryTypeSpec type,
+        HashSet<string> emittedTypes)
+    {
+        if (!emittedTypes.Add(type.SafeIdentifier))
+            return;
+
+        source.Append("    private static ")
+            .Append(type.TypeName)
+            .Append(" ReadBinaryObject_")
+            .Append(type.SafeIdentifier)
+            .AppendLine("(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag == NullTag)");
+        source.AppendLine("            return default!;");
+        source.AppendLine();
+        source.AppendLine("        EnsureTag(tag, ObjectTag);");
+        source.Append("        return ReadBinary_")
+            .Append(type.SafeIdentifier)
+            .AppendLine("(payload, ref position);");
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        source.Append("    private static ")
+            .Append(type.TypeName)
+            .Append(" ReadBinary_")
+            .Append(type.SafeIdentifier)
+            .AppendLine("(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        ulong fieldCount = ReadVarint(payload, ref position);");
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            source.Append("        ")
+                .Append(member.Value.TypeName)
+                .Append(" value")
+                .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine(" = default!;");
+        }
+
+        if (type.Members.Length > 0)
+            source.AppendLine();
+
+        source.AppendLine("        for (ulong i = 0; i < fieldCount; i++)");
+        source.AppendLine("        {");
+        source.AppendLine("            global::System.ReadOnlySpan<byte> fieldName = ReadLengthPrefixedBytes(payload, ref position);");
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            source.Append("            ")
+                .Append(i == 0 ? "if" : "else if")
+                .Append(" (fieldName.SequenceEqual(")
+                .Append(SymbolDisplay.FormatLiteral(member.JsonName, quote: true))
+                .AppendLine("u8))");
+            source.AppendLine("            {");
+            source.Append("                value")
+                .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .Append(" = ");
+            AppendReadBinaryValueExpression(
+                source,
+                member.Value,
+                "payload",
+                "position",
+                CreateBinaryReaderMethodName(type, i));
+            source.AppendLine(";");
+            source.AppendLine("                continue;");
+            source.AppendLine("            }");
+        }
+
+        source.AppendLine();
+        source.AppendLine("            SkipBinaryValue(payload, ref position);");
+        source.AppendLine("        }");
+        source.AppendLine();
+        source.Append("        return new ")
+            .Append(type.TypeName)
+            .Append('(');
+        for (int i = 0; i < type.Constructor.ParameterMemberIndexes.Length; i++)
+        {
+            if (i > 0)
+                source.Append(", ");
+
+            source.Append("value")
+                .Append(type.Constructor.ParameterMemberIndexes[i].ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        source.AppendLine(");");
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            if (member.Value.IsArray)
+                EmitBinaryArrayReader(source, member.Value, CreateBinaryReaderMethodName(type, i));
+        }
+
+        for (int i = 0; i < type.Members.Length; i++)
+            EmitNestedBinaryTypeReaders(source, type.Members[i].Value, emittedTypes);
+    }
+
+    private static void EmitNestedBinaryTypeReaders(
+        StringBuilder source,
+        BinaryValueSpec value,
+        HashSet<string> emittedTypes)
+    {
+        if (value.ObjectType is not null)
+            EmitBinaryTypeReader(source, value.ObjectType, emittedTypes);
+
+        if (value.Element is not null)
+            EmitNestedBinaryTypeReaders(source, value.Element, emittedTypes);
+    }
+
+    private static void EmitBinaryRecordTypeSizer(
+        StringBuilder source,
+        BinaryTypeSpec type,
+        HashSet<string> emittedTypes)
+    {
+        if (!emittedTypes.Add(type.SafeIdentifier))
+            return;
+
+        source.Append("    private static int GetBinaryRecordSize_")
+            .Append(type.SafeIdentifier)
+            .Append('(')
+            .Append(type.TypeName)
+            .AppendLine(" value)");
+        source.AppendLine("    {");
+        source.Append("        int size = ")
+            .Append(GetNullBitmapSize(type).ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .AppendLine(";");
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            string valueVariable = "value" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            source.Append("        var ")
+                .Append(valueVariable)
+                .Append(" = value.")
+                .Append(member.EscapedClrName)
+                .AppendLine(";");
+            EmitGetBinaryRecordValueSize(source, member.Value, valueVariable, "        ");
+        }
+
+        source.AppendLine("        return size;");
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        for (int i = 0; i < type.Members.Length; i++)
+            EmitNestedBinaryRecordTypeSizers(source, type.Members[i].Value, emittedTypes);
+    }
+
+    private static void EmitNestedBinaryRecordTypeSizers(
+        StringBuilder source,
+        BinaryValueSpec value,
+        HashSet<string> emittedTypes)
+    {
+        if (value.ObjectType is not null)
+            EmitBinaryRecordTypeSizer(source, value.ObjectType, emittedTypes);
+    }
+
+    private static void EmitBinaryRecordTypeWriter(
+        StringBuilder source,
+        BinaryTypeSpec type,
+        HashSet<string> emittedTypes)
+    {
+        if (!emittedTypes.Add(type.SafeIdentifier))
+            return;
+
+        int nullBitmapSize = GetNullBitmapSize(type);
+        source.Append("    private static void WriteBinaryRecord_")
+            .Append(type.SafeIdentifier)
+            .Append("(global::System.Span<byte> destination, ref int position, ")
+            .Append(type.TypeName)
+            .AppendLine(" value)");
+        source.AppendLine("    {");
+        source.AppendLine("        int nullBitmapStart = position;");
+        if (nullBitmapSize > 0)
+        {
+            source.Append("        destination.Slice(position, ")
+                .Append(nullBitmapSize.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine(").Clear();");
+            source.Append("        position += ")
+                .Append(nullBitmapSize.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine(";");
+        }
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            string valueVariable = "value" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            source.Append("        var ")
+                .Append(valueVariable)
+                .Append(" = value.")
+                .Append(member.EscapedClrName)
+                .AppendLine(";");
+            EmitWriteBinaryRecordValue(source, member.Value, valueVariable, i, "        ");
+        }
+
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        for (int i = 0; i < type.Members.Length; i++)
+            EmitNestedBinaryRecordTypeWriters(source, type.Members[i].Value, emittedTypes);
+    }
+
+    private static void EmitNestedBinaryRecordTypeWriters(
+        StringBuilder source,
+        BinaryValueSpec value,
+        HashSet<string> emittedTypes)
+    {
+        if (value.ObjectType is not null)
+            EmitBinaryRecordTypeWriter(source, value.ObjectType, emittedTypes);
+    }
+
+    private static void EmitBinaryRecordTypeReader(
+        StringBuilder source,
+        BinaryTypeSpec type,
+        HashSet<string> emittedTypes)
+    {
+        if (!emittedTypes.Add(type.SafeIdentifier))
+            return;
+
+        source.Append("    private static ")
+            .Append(type.TypeName)
+            .Append(" ReadBinaryRecord_")
+            .Append(type.SafeIdentifier)
+            .AppendLine("(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.Append("        int nullBitmapStart = ReadBinaryRecordNullBitmap(payload, ref position, ")
+            .Append(GetNullBitmapSize(type).ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .AppendLine(");");
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            source.Append("        ")
+                .Append(member.Value.TypeName)
+                .Append(" value")
+                .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine(" = default!;");
+        }
+
+        if (type.Members.Length > 0)
+            source.AppendLine();
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            source.Append("        if (!IsBinaryRecordNull(payload, nullBitmapStart, ")
+                .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine("))");
+            source.AppendLine("        {");
+            source.Append("            value")
+                .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .Append(" = ");
+            AppendReadBinaryRecordValueExpression(source, member.Value, "payload", "position");
+            source.AppendLine(";");
+            source.AppendLine("        }");
+        }
+
+        source.AppendLine();
+        source.Append("        return new ")
+            .Append(type.TypeName)
+            .Append('(');
+        for (int i = 0; i < type.Constructor.ParameterMemberIndexes.Length; i++)
+        {
+            if (i > 0)
+                source.Append(", ");
+
+            source.Append("value")
+                .Append(type.Constructor.ParameterMemberIndexes[i].ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        source.AppendLine(");");
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        for (int i = 0; i < type.Members.Length; i++)
+            EmitNestedBinaryRecordTypeReaders(source, type.Members[i].Value, emittedTypes);
+    }
+
+    private static void EmitNestedBinaryRecordTypeReaders(
+        StringBuilder source,
+        BinaryValueSpec value,
+        HashSet<string> emittedTypes)
+    {
+        if (value.ObjectType is not null)
+            EmitBinaryRecordTypeReader(source, value.ObjectType, emittedTypes);
+    }
+
+    private static void EmitBinaryRecordTypeSkipper(
+        StringBuilder source,
+        BinaryTypeSpec type,
+        HashSet<string> emittedTypes)
+    {
+        if (!emittedTypes.Add(type.SafeIdentifier))
+            return;
+
+        source.Append("    private static void SkipBinaryRecord_")
+            .Append(type.SafeIdentifier)
+            .AppendLine("(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.Append("        int nullBitmapStart = ReadBinaryRecordNullBitmap(payload, ref position, ")
+            .Append(GetNullBitmapSize(type).ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .AppendLine(");");
+
+        for (int i = 0; i < type.Members.Length; i++)
+        {
+            BinaryMemberSpec member = type.Members[i];
+            source.Append("        if (!IsBinaryRecordNull(payload, nullBitmapStart, ")
+                .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine("))");
+            source.AppendLine("        {");
+            EmitSkipBinaryRecordValue(source, member.Value, "payload", "position", "            ");
+            source.AppendLine("        }");
+        }
+
+        source.AppendLine("    }");
+        source.AppendLine();
+
+        for (int i = 0; i < type.Members.Length; i++)
+            EmitNestedBinaryRecordTypeSkippers(source, type.Members[i].Value, emittedTypes);
+    }
+
+    private static void EmitNestedBinaryRecordTypeSkippers(
+        StringBuilder source,
+        BinaryValueSpec value,
+        HashSet<string> emittedTypes)
+    {
+        if (value.ObjectType is not null)
+            EmitBinaryRecordTypeSkipper(source, value.ObjectType, emittedTypes);
+    }
+
+    private static int GetNullBitmapSize(BinaryTypeSpec type)
+        => (type.Members.Length + 7) / 8;
+
+    private static void EmitGetBinaryRecordValueSize(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent)
+    {
+        if (value.IsArray)
+            throw new InvalidOperationException("Generated binary record format does not support array payloads.");
+
+        if (value.CanBeNull)
+        {
+            source.Append(indent)
+                .Append("if (")
+                .Append(GetNullCheckExpression(value, expression))
+                .AppendLine(")");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("}");
+            source.Append(indent).AppendLine("else");
+            source.Append(indent).AppendLine("{");
+            EmitGetBinaryRecordNonNullValueSize(source, value, GetNonNullExpression(value, expression), indent + "    ");
+            source.Append(indent).AppendLine("}");
+            return;
+        }
+
+        EmitGetBinaryRecordNonNullValueSize(source, value, expression, indent);
+    }
+
+    private static void EmitGetBinaryRecordNonNullValueSize(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent)
+    {
+        if (value.ValueKindName == "Object")
+        {
+            BinaryTypeSpec objectType = value.ObjectType ?? throw new InvalidOperationException("Object binary value is missing its type spec.");
+            source.Append(indent)
+                .Append("size += GetBinaryRecordSize_")
+                .Append(objectType.SafeIdentifier)
+                .Append('(')
+                .Append(expression)
+                .AppendLine(");");
+            return;
+        }
+
+        switch (value.ValueKindName)
+        {
+            case "String":
+                source.Append(indent)
+                    .Append("size += GetLengthPrefixedStringSize(")
+                    .Append(expression)
+                    .AppendLine(");");
+                return;
+            case "Guid":
+                source.Append(indent).AppendLine("size += 16;");
+                return;
+            case "DateOnly":
+            case "Int32":
+            case "UInt32":
+            case "Single":
+                source.Append(indent).AppendLine("size += sizeof(int);");
+                return;
+            case "TimeOnly":
+            case "Enum":
+            case "Int64":
+            case "Double":
+                source.Append(indent).AppendLine("size += sizeof(long);");
+                return;
+            case "Boolean":
+            case "Byte":
+            case "SByte":
+                source.Append(indent).AppendLine("size += 1;");
+                return;
+            case "Int16":
+            case "UInt16":
+                source.Append(indent).AppendLine("size += sizeof(short);");
+                return;
+            case "Decimal":
+                source.Append(indent).AppendLine("size += sizeof(int) * 4;");
+                return;
+            default:
+                throw new InvalidOperationException($"Unsupported generated binary record value kind '{value.ValueKindName}'.");
+        }
+    }
+
+    private static void EmitWriteBinaryRecordValue(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        int memberIndex,
+        string indent)
+    {
+        if (value.IsArray)
+            throw new InvalidOperationException("Generated binary record format does not support array payloads.");
+
+        if (value.CanBeNull)
+        {
+            source.Append(indent)
+                .Append("if (")
+                .Append(GetNullCheckExpression(value, expression))
+                .AppendLine(")");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent)
+                .Append("    SetBinaryRecordNull(destination, nullBitmapStart, ")
+                .Append(memberIndex.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine(");");
+            source.Append(indent).AppendLine("}");
+            source.Append(indent).AppendLine("else");
+            source.Append(indent).AppendLine("{");
+            EmitWriteBinaryRecordNonNullValue(source, value, GetNonNullExpression(value, expression), indent + "    ");
+            source.Append(indent).AppendLine("}");
+            return;
+        }
+
+        EmitWriteBinaryRecordNonNullValue(source, value, expression, indent);
+    }
+
+    private static void EmitWriteBinaryRecordNonNullValue(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent)
+    {
+        if (value.ValueKindName == "Object")
+        {
+            BinaryTypeSpec objectType = value.ObjectType ?? throw new InvalidOperationException("Object binary value is missing its type spec.");
+            source.Append(indent)
+                .Append("WriteBinaryRecord_")
+                .Append(objectType.SafeIdentifier)
+                .Append("(destination, ref position, ")
+                .Append(expression)
+                .AppendLine(");");
+            return;
+        }
+
+        string methodName = value.ValueKindName switch
+        {
+            "String" => "WriteLengthPrefixedString",
+            "Guid" => "WriteBinaryRecordGuid",
+            "DateOnly" => "WriteBinaryRecordDateOnly",
+            "TimeOnly" => "WriteBinaryRecordTimeOnly",
+            "Enum" => "WriteBinaryRecordEnum",
+            "Boolean" => "WriteBinaryRecordBoolean",
+            "Byte" => "WriteBinaryRecordByte",
+            "SByte" => "WriteBinaryRecordSByte",
+            "Int16" => "WriteBinaryRecordInt16",
+            "UInt16" => "WriteBinaryRecordUInt16",
+            "Int32" => "WriteBinaryRecordInt32",
+            "UInt32" => "WriteBinaryRecordUInt32",
+            "Int64" => "WriteInt64",
+            "Single" => "WriteBinaryRecordSingle",
+            "Double" => "WriteBinaryRecordDouble",
+            "Decimal" => "WriteBinaryRecordDecimal",
+            _ => throw new InvalidOperationException($"Unsupported generated binary record value kind '{value.ValueKindName}'."),
+        };
+
+        source.Append(indent)
+            .Append(methodName)
+            .Append("(destination, ref position, ")
+            .Append(expression)
+            .AppendLine(");");
+    }
+
+    private static void AppendReadBinaryRecordValueExpression(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string payloadExpression,
+        string positionVariable)
+    {
+        if (value.IsArray)
+            throw new InvalidOperationException("Generated binary record format does not support array payloads.");
+
+        if (value.ValueKindName == "Object")
+        {
+            BinaryTypeSpec objectType = value.ObjectType ?? throw new InvalidOperationException("Object binary value is missing its type spec.");
+            source.Append("ReadBinaryRecord_")
+                .Append(objectType.SafeIdentifier)
+                .Append('(')
+                .Append(payloadExpression)
+                .Append(", ref ")
+                .Append(positionVariable)
+                .Append(')');
+            return;
+        }
+
+        string methodName = value.ValueKindName switch
+        {
+            "String" => "ReadBinaryRecordString",
+            "Guid" => "ReadBinaryRecordGuid",
+            "DateOnly" => "ReadBinaryRecordDateOnly",
+            "TimeOnly" => "ReadBinaryRecordTimeOnly",
+            "Enum" => "ReadBinaryRecordEnum<" + value.EffectiveTypeName + ">",
+            "Boolean" => "ReadBinaryRecordBoolean",
+            "Byte" => "ReadBinaryRecordByte",
+            "SByte" => "ReadBinaryRecordSByte",
+            "Int16" => "ReadBinaryRecordInt16",
+            "UInt16" => "ReadBinaryRecordUInt16",
+            "Int32" => "ReadBinaryRecordInt32",
+            "UInt32" => "ReadBinaryRecordUInt32",
+            "Int64" => "ReadInt64",
+            "Single" => "ReadBinaryRecordSingle",
+            "Double" => "ReadBinaryRecordDouble",
+            "Decimal" => "ReadBinaryRecordDecimal",
+            _ => throw new InvalidOperationException($"Unsupported generated binary record value kind '{value.ValueKindName}'."),
+        };
+
+        source.Append(methodName)
+            .Append('(')
+            .Append(payloadExpression)
+            .Append(", ref ")
+            .Append(positionVariable)
+            .Append(')');
+        if (value.ValueKindName == "String")
+            source.Append('!');
+    }
+
+    private static void EmitSkipBinaryRecordValue(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string payloadExpression,
+        string positionVariable,
+        string indent)
+    {
+        if (value.IsArray)
+            throw new InvalidOperationException("Generated binary record format does not support array payloads.");
+
+        if (value.ValueKindName == "Object")
+        {
+            BinaryTypeSpec objectType = value.ObjectType ?? throw new InvalidOperationException("Object binary value is missing its type spec.");
+            source.Append(indent)
+                .Append("SkipBinaryRecord_")
+                .Append(objectType.SafeIdentifier)
+                .Append('(')
+                .Append(payloadExpression)
+                .Append(", ref ")
+                .Append(positionVariable)
+                .AppendLine(");");
+            return;
+        }
+
+        switch (value.ValueKindName)
+        {
+            case "String":
+                source.Append(indent)
+                    .Append("_ = ReadLengthPrefixedBytes(")
+                    .Append(payloadExpression)
+                    .Append(", ref ")
+                    .Append(positionVariable)
+                    .AppendLine(");");
+                return;
+            case "Guid":
+                source.Append(indent)
+                    .Append("EnsureAvailable(")
+                    .Append(payloadExpression)
+                    .Append(", ")
+                    .Append(positionVariable)
+                    .AppendLine(", 16);");
+                source.Append(indent)
+                    .Append(positionVariable)
+                    .AppendLine(" += 16;");
+                return;
+            case "DateOnly":
+            case "Int32":
+            case "UInt32":
+            case "Single":
+                source.Append(indent)
+                    .Append("EnsureAvailable(")
+                    .Append(payloadExpression)
+                    .Append(", ")
+                    .Append(positionVariable)
+                    .AppendLine(", sizeof(int));");
+                source.Append(indent)
+                    .Append(positionVariable)
+                    .AppendLine(" += sizeof(int);");
+                return;
+            case "TimeOnly":
+            case "Enum":
+            case "Int64":
+            case "Double":
+                source.Append(indent)
+                    .Append("EnsureAvailable(")
+                    .Append(payloadExpression)
+                    .Append(", ")
+                    .Append(positionVariable)
+                    .AppendLine(", sizeof(long));");
+                source.Append(indent)
+                    .Append(positionVariable)
+                    .AppendLine(" += sizeof(long);");
+                return;
+            case "Boolean":
+            case "Byte":
+            case "SByte":
+                source.Append(indent)
+                    .Append("EnsureAvailable(")
+                    .Append(payloadExpression)
+                    .Append(", ")
+                    .Append(positionVariable)
+                    .AppendLine(", 1);");
+                source.Append(indent)
+                    .Append(positionVariable)
+                    .AppendLine("++;");
+                return;
+            case "Int16":
+            case "UInt16":
+                source.Append(indent)
+                    .Append("EnsureAvailable(")
+                    .Append(payloadExpression)
+                    .Append(", ")
+                    .Append(positionVariable)
+                    .AppendLine(", sizeof(short));");
+                source.Append(indent)
+                    .Append(positionVariable)
+                    .AppendLine(" += sizeof(short);");
+                return;
+            case "Decimal":
+                source.Append(indent)
+                    .Append("EnsureAvailable(")
+                    .Append(payloadExpression)
+                    .Append(", ")
+                    .Append(positionVariable)
+                    .AppendLine(", sizeof(int) * 4);");
+                source.Append(indent)
+                    .Append(positionVariable)
+                    .AppendLine(" += sizeof(int) * 4;");
+                return;
+            default:
+                throw new InvalidOperationException($"Unsupported generated binary record value kind '{value.ValueKindName}'.");
+        }
+    }
+
+    private static string GetNullCheckExpression(BinaryValueSpec value, string expression)
+        => value.IsNullableValueType
+            ? "!" + expression + ".HasValue"
+            : expression + " is null";
+
+    private static string GetNonNullExpression(BinaryValueSpec value, string expression)
+        => value.IsNullableValueType ? expression + ".Value" : expression;
+
+    private static void EmitBinaryPayloadFieldReaders(
+        StringBuilder source,
+        BinaryTypeSpec root,
+        ImmutableArray<CollectionFieldSpec> fields)
+    {
+        for (int i = 0; i < fields.Length; i++)
+        {
+            CollectionFieldSpec field = fields[i];
+            if (!TryCreateBinaryFieldReaderSpec(root, field, out BinaryFieldReaderSpec reader))
+                continue;
+
+            EmitBinaryPayloadFieldReader(source, root, field, reader);
+        }
+    }
+
+    private static void EmitBinaryPayloadFieldReader(
+        StringBuilder source,
+        BinaryTypeSpec root,
+        CollectionFieldSpec field,
+        BinaryFieldReaderSpec reader)
+    {
+        source.Append("    internal static bool ")
+            .Append(CreateBinaryPayloadValueReaderName(field))
+            .AppendLine("(global::System.ReadOnlySpan<byte> payload, out global::CSharpDB.Primitives.DbValue value)");
+            source.AppendLine("    {");
+            source.AppendLine("        value = default;");
+            EmitBinaryPayloadFieldPathReader(
+                source,
+                root,
+                reader,
+                "Value",
+                "        return TryReadBinaryPayloadFieldValue(currentPayload, ref position, out value);");
+            source.AppendLine("    }");
+            source.AppendLine();
+
+        if (reader.DataKindName == "Integer")
+        {
+            source.Append("    internal static bool ")
+                .Append(CreateBinaryPayloadIntegerReaderName(field))
+                .AppendLine("(global::System.ReadOnlySpan<byte> payload, out long value)");
+            source.AppendLine("    {");
+                source.AppendLine("        value = 0;");
+                EmitBinaryPayloadFieldPathReader(
+                    source,
+                    root,
+                    reader,
+                    "Integer",
+                    "        return TryReadBinaryPayloadFieldInt64(currentPayload, ref position, out value);");
+                source.AppendLine("    }");
+                source.AppendLine();
+        }
+        else if (reader.DataKindName == "Text")
+        {
+            source.Append("    internal static bool ")
+                .Append(CreateBinaryPayloadTextReaderName(field))
+                .AppendLine("(global::System.ReadOnlySpan<byte> payload, out string? value)");
+            source.AppendLine("    {");
+                source.AppendLine("        value = null;");
+                EmitBinaryPayloadFieldPathReader(
+                    source,
+                    root,
+                    reader,
+                    "Text",
+                    "        return TryReadBinaryPayloadFieldText(currentPayload, ref position, out value);");
+                source.AppendLine("    }");
+                source.AppendLine();
+
+            source.Append("    internal static bool ")
+                .Append(CreateBinaryPayloadTextUtf8ReaderName(field))
+                .AppendLine("(global::System.ReadOnlySpan<byte> payload, out global::System.ReadOnlySpan<byte> value)");
+            source.AppendLine("    {");
+                source.AppendLine("        value = default;");
+                EmitBinaryPayloadFieldPathReader(
+                    source,
+                    root,
+                    reader,
+                    "TextUtf8",
+                    "        return TryReadBinaryPayloadFieldTextUtf8(currentPayload, ref position, out value);");
+                source.AppendLine("    }");
+                source.AppendLine();
+        }
+    }
+
+    private static void EmitBinaryPayloadFieldPathReader(
+        StringBuilder source,
+        BinaryTypeSpec root,
+        BinaryFieldReaderSpec reader,
+        string recordReadKindName,
+        string finalReadStatement)
+    {
+        source.AppendLine("        if (!global::CSharpDB.Storage.Serialization.CollectionPayloadCodec.TryGetBinaryDocumentPayload(payload, out global::System.ReadOnlySpan<byte> currentPayload))");
+        source.AppendLine("            return false;");
+        source.AppendLine();
+        source.AppendLine("        int position = 0;");
+
+        if (CanUseBinaryRecordFormat(root))
+        {
+            source.AppendLine("        if (IsBinaryRecordPayload(currentPayload))");
+            source.AppendLine("        {");
+            source.AppendLine("            position = 3;");
+            EmitBinaryRecordPayloadFieldPathReader(source, root, reader, recordReadKindName);
+            source.AppendLine("        }");
+            source.AppendLine();
+            source.AppendLine("        position = 0;");
+        }
+
+        BinaryTypeSpec currentType = root;
+        for (int depth = 0; depth < reader.MemberIndexes.Length; depth++)
+        {
+            int memberIndex = reader.MemberIndexes[depth];
+            BinaryMemberSpec member = currentType.Members[memberIndex];
+
+            source.Append("        if (!TryReadExpectedObjectFieldCount(currentPayload, ref position, ")
+                .Append(currentType.Members.Length.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine("))");
+            source.AppendLine("            return false;");
+
+            for (int i = 0; i < memberIndex; i++)
+            {
+                source.AppendLine("        SkipBinaryField(currentPayload, ref position);");
+            }
+
+            source.Append("        if (!TryReadExpectedFieldName(currentPayload, ref position, ")
+                .Append(SymbolDisplay.FormatLiteral(member.JsonName, quote: true))
+                .AppendLine("u8))");
+            source.AppendLine("            return false;");
+
+            if (depth == reader.MemberIndexes.Length - 1)
+            {
+                source.AppendLine(finalReadStatement);
+            }
+            else
+            {
+                source.Append("        if (!TryReadBinaryObjectPayload(currentPayload, ref position, out int nestedStart")
+                    .Append(depth.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    .Append(", out int nestedLength")
+                    .Append(depth.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    .AppendLine("))");
+                source.AppendLine("            return false;");
+                source.Append("        currentPayload = currentPayload.Slice(nestedStart")
+                    .Append(depth.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    .Append(", nestedLength")
+                    .Append(depth.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    .AppendLine(");");
+                source.AppendLine("        position = 0;");
+                source.AppendLine();
+                currentType = member.Value.ObjectType ?? throw new InvalidOperationException("Binary field reader path entered a non-object member.");
+            }
+        }
+    }
+
+    private static void EmitBinaryRecordPayloadFieldPathReader(
+        StringBuilder source,
+        BinaryTypeSpec root,
+        BinaryFieldReaderSpec reader,
+        string recordReadKindName)
+    {
+        BinaryTypeSpec currentType = root;
+        for (int depth = 0; depth < reader.MemberIndexes.Length; depth++)
+        {
+            int memberIndex = reader.MemberIndexes[depth];
+            BinaryMemberSpec member = currentType.Members[memberIndex];
+            string nullBitmapStart = "nullBitmapStart" + depth.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            source.Append("            int ")
+                .Append(nullBitmapStart)
+                .Append(" = ReadBinaryRecordNullBitmap(currentPayload, ref position, ")
+                .Append(GetNullBitmapSize(currentType).ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine(");");
+            source.Append("            if (IsBinaryRecordNull(currentPayload, ")
+                .Append(nullBitmapStart)
+                .Append(", ")
+                .Append(memberIndex.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine("))");
+            source.AppendLine("                return false;");
+
+            for (int i = 0; i < memberIndex; i++)
+            {
+                source.Append("            if (!IsBinaryRecordNull(currentPayload, ")
+                    .Append(nullBitmapStart)
+                    .Append(", ")
+                    .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    .AppendLine("))");
+                source.AppendLine("            {");
+                EmitSkipBinaryRecordValue(source, currentType.Members[i].Value, "currentPayload", "position", "                ");
+                source.AppendLine("            }");
+            }
+
+            if (depth == reader.MemberIndexes.Length - 1)
+            {
+                EmitBinaryRecordPayloadFinalRead(source, reader, recordReadKindName, "            ");
+            }
+            else
+            {
+                currentType = member.Value.ObjectType ?? throw new InvalidOperationException("Binary field reader path entered a non-object member.");
+            }
+        }
+    }
+
+    private static void EmitBinaryRecordPayloadFinalRead(
+        StringBuilder source,
+        BinaryFieldReaderSpec reader,
+        string recordReadKindName,
+        string indent)
+    {
+        switch (recordReadKindName)
+        {
+            case "Value":
+                if (reader.DataKindName == "Integer")
+                {
+                    source.Append(indent).Append("value = global::CSharpDB.Primitives.DbValue.FromInteger(");
+                    AppendReadBinaryRecordIntegerAsInt64Expression(source, reader.Value, "currentPayload", "position");
+                    source.AppendLine(");");
+                }
+                else if (reader.DataKindName == "Text")
+                {
+                    source.Append(indent).Append("value = global::CSharpDB.Primitives.DbValue.FromText(");
+                    AppendReadBinaryRecordTextExpression(source, reader.Value, "currentPayload", "position");
+                    source.AppendLine(");");
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unsupported generated binary record field data kind '{reader.DataKindName}'.");
+                }
+
+                source.Append(indent).AppendLine("return true;");
+                return;
+
+            case "Integer":
+                source.Append(indent).Append("value = ");
+                AppendReadBinaryRecordIntegerAsInt64Expression(source, reader.Value, "currentPayload", "position");
+                source.AppendLine(";");
+                source.Append(indent).AppendLine("return true;");
+                return;
+
+            case "Text":
+                source.Append(indent).Append("value = ");
+                AppendReadBinaryRecordTextExpression(source, reader.Value, "currentPayload", "position");
+                source.AppendLine(";");
+                source.Append(indent).AppendLine("return true;");
+                return;
+
+            case "TextUtf8":
+                if (reader.Value.ValueKindName == "String")
+                {
+                    source.Append(indent).AppendLine("value = ReadBinaryRecordStringUtf8(currentPayload, ref position);");
+                    source.Append(indent).AppendLine("return true;");
+                }
+                else
+                {
+                    source.Append(indent).AppendLine("return false;");
+                }
+
+                return;
+
+            default:
+                throw new InvalidOperationException($"Unsupported generated binary record read kind '{recordReadKindName}'.");
+        }
+    }
+
+    private static void AppendReadBinaryRecordIntegerAsInt64Expression(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string payloadExpression,
+        string positionVariable)
+    {
+        switch (value.ValueKindName)
+        {
+            case "Byte":
+            case "SByte":
+            case "Int16":
+            case "UInt16":
+            case "Int32":
+            case "UInt32":
+                source.Append("(long)");
+                AppendReadBinaryRecordValueExpression(source, value, payloadExpression, positionVariable);
+                return;
+            case "Int64":
+            case "Enum":
+                source.Append("ReadInt64(")
+                    .Append(payloadExpression)
+                    .Append(", ref ")
+                    .Append(positionVariable)
+                    .Append(')');
+                return;
+            default:
+                throw new InvalidOperationException($"Unsupported generated binary record integer field kind '{value.ValueKindName}'.");
+        }
+    }
+
+    private static void AppendReadBinaryRecordTextExpression(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string payloadExpression,
+        string positionVariable)
+    {
+        switch (value.ValueKindName)
+        {
+            case "String":
+                source.Append("ReadBinaryRecordString(")
+                    .Append(payloadExpression)
+                    .Append(", ref ")
+                    .Append(positionVariable)
+                    .Append(')');
+                return;
+            case "Guid":
+                source.Append("ReadBinaryRecordGuid(")
+                    .Append(payloadExpression)
+                    .Append(", ref ")
+                    .Append(positionVariable)
+                    .Append(").ToString(\"D\")");
+                return;
+            case "DateOnly":
+                source.Append("ReadBinaryRecordDateOnly(")
+                    .Append(payloadExpression)
+                    .Append(", ref ")
+                    .Append(positionVariable)
+                    .Append(").ToString(\"O\", global::System.Globalization.CultureInfo.InvariantCulture)");
+                return;
+            case "TimeOnly":
+                source.Append("ReadBinaryRecordTimeOnly(")
+                    .Append(payloadExpression)
+                    .Append(", ref ")
+                    .Append(positionVariable)
+                    .Append(").ToString(\"O\", global::System.Globalization.CultureInfo.InvariantCulture)");
+                return;
+            default:
+                throw new InvalidOperationException($"Unsupported generated binary record text field kind '{value.ValueKindName}'.");
+        }
+    }
+
+    private static string CreateBinaryReaderMethodName(BinaryTypeSpec type, int memberIndex)
+        => "ReadBinaryArray_" + type.SafeIdentifier + "_" + memberIndex.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    private static void EmitBinaryArrayReader(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string methodName)
+    {
+        BinaryValueSpec element = value.Element ?? throw new InvalidOperationException("Array binary value is missing its element spec.");
+
+        source.Append("    private static ")
+            .Append(value.TypeName)
+            .Append(' ')
+            .Append(methodName)
+            .AppendLine("(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag == NullTag)");
+        source.AppendLine("            return default!;");
+        source.AppendLine();
+        source.AppendLine("        EnsureTag(tag, ArrayTag);");
+        source.AppendLine("        ulong count = ReadVarint(payload, ref position);");
+        source.Append("        var values = new global::System.Collections.Generic.List<")
+            .Append(element.TypeName)
+            .AppendLine(">(checked((int)count));");
+        source.AppendLine("        for (ulong i = 0; i < count; i++)");
+        source.AppendLine("        {");
+        source.Append("            values.Add(");
+        AppendReadBinaryValueExpression(source, element, "payload", "position", methodName + "_Element");
+        source.AppendLine(");");
+        source.AppendLine("        }");
+        source.AppendLine();
+        if (value.IsArrayType)
+            source.AppendLine("        return values.ToArray();");
+        else
+            source.AppendLine("        return values;");
+        source.AppendLine("    }");
+        source.AppendLine();
+    }
+
+    private static void AppendReadBinaryValueExpression(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string payloadExpression,
+        string positionVariable,
+        string arrayReaderMethodName)
+    {
+        if (value.IsArray)
+        {
+            source.Append(arrayReaderMethodName)
+                .Append('(')
+                .Append(payloadExpression)
+                .Append(", ref ")
+                .Append(positionVariable)
+                .Append(')');
+            return;
+        }
+
+        if (value.ValueKindName == "Object")
+        {
+            BinaryTypeSpec objectType = value.ObjectType ?? throw new InvalidOperationException("Object binary value is missing its type spec.");
+            source.Append("ReadBinaryObject_")
+                .Append(objectType.SafeIdentifier)
+                .Append('(')
+                .Append(payloadExpression)
+                .Append(", ref ")
+                .Append(positionVariable)
+                .Append(')');
+            return;
+        }
+
+        string methodName = value.ValueKindName switch
+        {
+            "String" => "ReadBinaryString",
+            "Guid" => value.IsNullableValueType ? "ReadNullableBinaryGuid" : "ReadBinaryGuid",
+            "DateOnly" => value.IsNullableValueType ? "ReadNullableBinaryDateOnly" : "ReadBinaryDateOnly",
+            "TimeOnly" => value.IsNullableValueType ? "ReadNullableBinaryTimeOnly" : "ReadBinaryTimeOnly",
+            "Enum" => value.IsNullableValueType ? "ReadNullableBinaryEnum<" + value.EffectiveTypeName + ">" : "ReadBinaryEnum<" + value.EffectiveTypeName + ">",
+            "Boolean" => value.IsNullableValueType ? "ReadNullableBinaryBoolean" : "ReadBinaryBoolean",
+            "Byte" => value.IsNullableValueType ? "ReadNullableBinaryByte" : "ReadBinaryByte",
+            "SByte" => value.IsNullableValueType ? "ReadNullableBinarySByte" : "ReadBinarySByte",
+            "Int16" => value.IsNullableValueType ? "ReadNullableBinaryInt16" : "ReadBinaryInt16",
+            "UInt16" => value.IsNullableValueType ? "ReadNullableBinaryUInt16" : "ReadBinaryUInt16",
+            "Int32" => value.IsNullableValueType ? "ReadNullableBinaryInt32" : "ReadBinaryInt32",
+            "UInt32" => value.IsNullableValueType ? "ReadNullableBinaryUInt32" : "ReadBinaryUInt32",
+            "Int64" => value.IsNullableValueType ? "ReadNullableBinaryInt64" : "ReadBinaryInt64",
+            "Single" => value.IsNullableValueType ? "ReadNullableBinarySingle" : "ReadBinarySingle",
+            "Double" => value.IsNullableValueType ? "ReadNullableBinaryDouble" : "ReadBinaryDouble",
+            "Decimal" => value.IsNullableValueType ? "ReadNullableBinaryDecimal" : "ReadBinaryDecimal",
+            _ => throw new InvalidOperationException($"Unsupported generated binary value kind '{value.ValueKindName}'."),
+        };
+
+        source.Append(methodName)
+            .Append('(')
+            .Append(payloadExpression)
+            .Append(", ref ")
+            .Append(positionVariable)
+            .Append(')');
+        if (value.ValueKindName == "String")
+            source.Append('!');
+    }
+
+    private static void EmitGetBinaryValueSize(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent,
+        string suffix)
+    {
+        if (value.IsArray)
+        {
+            EmitGetBinaryArrayValueSize(source, value, expression, indent, suffix);
+            return;
+        }
+
+        if (value.ValueKindName == "Object")
+        {
+            EmitGetBinaryObjectValueSize(source, value, expression, indent);
+            return;
+        }
+
+        if (value.IsNullableValueType)
+        {
+            source.Append(indent)
+                .Append("if (!")
+                .Append(expression)
+                .AppendLine(".HasValue)");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("    size += 1;");
+            source.Append(indent).AppendLine("}");
+            source.Append(indent).AppendLine("else");
+            source.Append(indent).AppendLine("{");
+            EmitGetBinaryScalarValueSize(source, value, expression + ".Value", indent + "    ");
+            source.Append(indent).AppendLine("}");
+            return;
+        }
+
+        EmitGetBinaryScalarValueSize(source, value, expression, indent);
+    }
+
+    private static void EmitGetBinaryArrayValueSize(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent,
+        string suffix)
+    {
+        BinaryValueSpec element = value.Element ?? throw new InvalidOperationException("Array binary value is missing its element spec.");
+        string countVariable = "count" + suffix;
+        string bufferVariable = "buffer" + suffix;
+        string itemVariable = "item" + suffix;
+
+        source.Append(indent)
+            .Append("if (")
+            .Append(expression)
+            .AppendLine(" is null)");
+        source.Append(indent).AppendLine("{");
+        source.Append(indent).AppendLine("    size += 1;");
+        source.Append(indent).AppendLine("}");
+        source.Append(indent).AppendLine("else");
+        source.Append(indent).AppendLine("{");
+        source.Append(indent).AppendLine("    size += 1;");
+        source.Append(indent)
+            .Append("    if (!global::System.Linq.Enumerable.TryGetNonEnumeratedCount<")
+            .Append(element.TypeName)
+            .Append(">(")
+            .Append(expression)
+            .Append(", out int ")
+            .Append(countVariable)
+            .AppendLine("))");
+        source.Append(indent).AppendLine("    {");
+        source.Append(indent)
+            .Append("        var ")
+            .Append(bufferVariable)
+            .Append(" = new global::System.Collections.Generic.List<")
+            .Append(element.TypeName)
+            .AppendLine(">();");
+        source.Append(indent)
+            .Append("        foreach (var ")
+            .Append(itemVariable)
+            .Append(" in ")
+            .Append(expression)
+            .AppendLine(")");
+        source.Append(indent)
+            .Append("            ")
+            .Append(bufferVariable)
+            .Append(".Add(")
+            .Append(itemVariable)
+            .AppendLine(");");
+        source.Append(indent)
+            .Append("        size += GetVarintSize((ulong)")
+            .Append(bufferVariable)
+            .AppendLine(".Count);");
+        source.Append(indent)
+            .Append("        foreach (var ")
+            .Append(itemVariable)
+            .Append(" in ")
+            .Append(bufferVariable)
+            .AppendLine(")");
+        source.Append(indent).AppendLine("        {");
+        EmitGetBinaryValueSize(source, element, itemVariable, indent + "            ", suffix + "_item");
+        source.Append(indent).AppendLine("        }");
+        source.Append(indent).AppendLine("    }");
+        source.Append(indent).AppendLine("    else");
+        source.Append(indent).AppendLine("    {");
+        source.Append(indent)
+            .Append("        size += GetVarintSize((ulong)")
+            .Append(countVariable)
+            .AppendLine(");");
+        source.Append(indent)
+            .Append("        foreach (var ")
+            .Append(itemVariable)
+            .Append(" in ")
+            .Append(expression)
+            .AppendLine(")");
+        source.Append(indent).AppendLine("        {");
+        EmitGetBinaryValueSize(source, element, itemVariable, indent + "            ", suffix + "_item");
+        source.Append(indent).AppendLine("        }");
+        source.Append(indent).AppendLine("    }");
+        source.Append(indent).AppendLine("}");
+    }
+
+    private static void EmitGetBinaryObjectValueSize(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent)
+    {
+        BinaryTypeSpec objectType = value.ObjectType ?? throw new InvalidOperationException("Object binary value is missing its type spec.");
+
+        if (value.IsNullableValueType)
+        {
+            source.Append(indent)
+                .Append("if (!")
+                .Append(expression)
+                .AppendLine(".HasValue)");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("    size += 1;");
+            source.Append(indent).AppendLine("}");
+            source.Append(indent).AppendLine("else");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent)
+                .Append("    size += 1 + GetBinarySize_")
+                .Append(objectType.SafeIdentifier)
+                .Append('(')
+                .Append(expression)
+                .AppendLine(".Value);");
+            source.Append(indent).AppendLine("}");
+            return;
+        }
+
+        if (value.CanBeNull)
+        {
+            source.Append(indent)
+                .Append("if (")
+                .Append(expression)
+                .AppendLine(" is null)");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("    size += 1;");
+            source.Append(indent).AppendLine("}");
+            source.Append(indent).AppendLine("else");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent)
+                .Append("    size += 1 + GetBinarySize_")
+                .Append(objectType.SafeIdentifier)
+                .Append('(')
+                .Append(expression)
+                .AppendLine(");");
+            source.Append(indent).AppendLine("}");
+            return;
+        }
+
+        source.Append(indent)
+            .Append("size += 1 + GetBinarySize_")
+            .Append(objectType.SafeIdentifier)
+            .Append('(')
+            .Append(expression)
+            .AppendLine(");");
+    }
+
+    private static void EmitGetBinaryScalarValueSize(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent)
+    {
+        switch (value.ValueKindName)
+        {
+            case "String":
+                source.Append(indent)
+                    .Append("size += GetBinaryStringSize(")
+                    .Append(expression)
+                    .AppendLine(");");
+                return;
+            case "Guid":
+                source.Append(indent)
+                    .Append("size += GetBinaryStringSize(")
+                    .Append(expression)
+                    .AppendLine(".ToString(\"D\"));");
+                return;
+            case "DateOnly":
+            case "TimeOnly":
+                source.Append(indent)
+                    .Append("size += GetBinaryStringSize(")
+                    .Append(expression)
+                    .AppendLine(".ToString(\"O\", global::System.Globalization.CultureInfo.InvariantCulture));");
+                return;
+            case "Boolean":
+                source.Append(indent).AppendLine("size += 1;");
+                return;
+            case "Enum":
+            case "Byte":
+            case "SByte":
+            case "Int16":
+            case "UInt16":
+            case "Int32":
+            case "UInt32":
+            case "Int64":
+            case "Single":
+            case "Double":
+                source.Append(indent).AppendLine("size += 1 + sizeof(long);");
+                return;
+            case "Decimal":
+                source.Append(indent).AppendLine("size += 1 + (sizeof(int) * 4);");
+                return;
+            default:
+                throw new InvalidOperationException($"Unsupported generated binary value kind '{value.ValueKindName}'.");
+        }
+    }
+
+    private static void EmitWriteBinaryValue(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent,
+        string suffix)
+    {
+        if (value.IsArray)
+        {
+            EmitWriteBinaryArrayValue(source, value, expression, indent, suffix);
+            return;
+        }
+
+        if (value.ValueKindName == "Object")
+        {
+            EmitWriteBinaryObjectValue(source, value, expression, indent);
+            return;
+        }
+
+        if (value.IsNullableValueType)
+        {
+            source.Append(indent)
+                .Append("if (!")
+                .Append(expression)
+                .AppendLine(".HasValue)");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("    WriteByte(destination, ref position, NullTag);");
+            source.Append(indent).AppendLine("}");
+            source.Append(indent).AppendLine("else");
+            source.Append(indent).AppendLine("{");
+            EmitWriteBinaryScalarValue(source, value, expression + ".Value", indent + "    ");
+            source.Append(indent).AppendLine("}");
+            return;
+        }
+
+        EmitWriteBinaryScalarValue(source, value, expression, indent);
+    }
+
+    private static void EmitWriteBinaryArrayValue(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent,
+        string suffix)
+    {
+        BinaryValueSpec element = value.Element ?? throw new InvalidOperationException("Array binary value is missing its element spec.");
+        string countVariable = "count" + suffix;
+        string bufferVariable = "buffer" + suffix;
+        string itemVariable = "item" + suffix;
+
+        source.Append(indent)
+            .Append("if (")
+            .Append(expression)
+            .AppendLine(" is null)");
+        source.Append(indent).AppendLine("{");
+        source.Append(indent).AppendLine("    WriteByte(destination, ref position, NullTag);");
+        source.Append(indent).AppendLine("}");
+        source.Append(indent).AppendLine("else");
+        source.Append(indent).AppendLine("{");
+        source.Append(indent).AppendLine("    WriteByte(destination, ref position, ArrayTag);");
+        source.Append(indent)
+            .Append("    if (!global::System.Linq.Enumerable.TryGetNonEnumeratedCount<")
+            .Append(element.TypeName)
+            .Append(">(")
+            .Append(expression)
+            .Append(", out int ")
+            .Append(countVariable)
+            .AppendLine("))");
+        source.Append(indent).AppendLine("    {");
+        source.Append(indent)
+            .Append("        var ")
+            .Append(bufferVariable)
+            .Append(" = new global::System.Collections.Generic.List<")
+            .Append(element.TypeName)
+            .AppendLine(">();");
+        source.Append(indent)
+            .Append("        foreach (var ")
+            .Append(itemVariable)
+            .Append(" in ")
+            .Append(expression)
+            .AppendLine(")");
+        source.Append(indent)
+            .Append("            ")
+            .Append(bufferVariable)
+            .Append(".Add(")
+            .Append(itemVariable)
+            .AppendLine(");");
+        source.Append(indent)
+            .Append("        WriteVarint(destination, ref position, (ulong)")
+            .Append(bufferVariable)
+            .AppendLine(".Count);");
+        source.Append(indent)
+            .Append("        foreach (var ")
+            .Append(itemVariable)
+            .Append(" in ")
+            .Append(bufferVariable)
+            .AppendLine(")");
+        source.Append(indent).AppendLine("        {");
+        EmitWriteBinaryValue(source, element, itemVariable, indent + "            ", suffix + "_item");
+        source.Append(indent).AppendLine("        }");
+        source.Append(indent).AppendLine("    }");
+        source.Append(indent).AppendLine("    else");
+        source.Append(indent).AppendLine("    {");
+        source.Append(indent)
+            .Append("        WriteVarint(destination, ref position, (ulong)")
+            .Append(countVariable)
+            .AppendLine(");");
+        source.Append(indent)
+            .Append("        foreach (var ")
+            .Append(itemVariable)
+            .Append(" in ")
+            .Append(expression)
+            .AppendLine(")");
+        source.Append(indent).AppendLine("        {");
+        EmitWriteBinaryValue(source, element, itemVariable, indent + "            ", suffix + "_item");
+        source.Append(indent).AppendLine("        }");
+        source.Append(indent).AppendLine("    }");
+        source.Append(indent).AppendLine("}");
+    }
+
+    private static void EmitWriteBinaryObjectValue(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent)
+    {
+        BinaryTypeSpec objectType = value.ObjectType ?? throw new InvalidOperationException("Object binary value is missing its type spec.");
+
+        if (value.IsNullableValueType)
+        {
+            source.Append(indent)
+                .Append("if (!")
+                .Append(expression)
+                .AppendLine(".HasValue)");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("    WriteByte(destination, ref position, NullTag);");
+            source.Append(indent).AppendLine("}");
+            source.Append(indent).AppendLine("else");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("    WriteByte(destination, ref position, ObjectTag);");
+            source.Append(indent)
+                .Append("    WriteBinary_")
+                .Append(objectType.SafeIdentifier)
+                .Append("(destination, ref position, ")
+                .Append(expression)
+                .AppendLine(".Value);");
+            source.Append(indent).AppendLine("}");
+            return;
+        }
+
+        if (value.CanBeNull)
+        {
+            source.Append(indent)
+                .Append("if (")
+                .Append(expression)
+                .AppendLine(" is null)");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("    WriteByte(destination, ref position, NullTag);");
+            source.Append(indent).AppendLine("}");
+            source.Append(indent).AppendLine("else");
+            source.Append(indent).AppendLine("{");
+            source.Append(indent).AppendLine("    WriteByte(destination, ref position, ObjectTag);");
+            source.Append(indent)
+                .Append("    WriteBinary_")
+                .Append(objectType.SafeIdentifier)
+                .Append("(destination, ref position, ")
+                .Append(expression)
+                .AppendLine(");");
+            source.Append(indent).AppendLine("}");
+            return;
+        }
+
+        source.Append(indent).AppendLine("WriteByte(destination, ref position, ObjectTag);");
+        source.Append(indent)
+            .Append("WriteBinary_")
+            .Append(objectType.SafeIdentifier)
+            .Append("(destination, ref position, ")
+            .Append(expression)
+            .AppendLine(");");
+    }
+
+    private static void EmitWriteBinaryScalarValue(
+        StringBuilder source,
+        BinaryValueSpec value,
+        string expression,
+        string indent)
+    {
+        switch (value.ValueKindName)
+        {
+            case "String":
+                source.Append(indent)
+                    .Append("WriteBinaryString(destination, ref position, ")
+                    .Append(expression)
+                    .AppendLine(");");
+                return;
+            case "Guid":
+                source.Append(indent)
+                    .Append("WriteBinaryString(destination, ref position, ")
+                    .Append(expression)
+                    .AppendLine(".ToString(\"D\"));");
+                return;
+            case "DateOnly":
+            case "TimeOnly":
+                source.Append(indent)
+                    .Append("WriteBinaryString(destination, ref position, ")
+                    .Append(expression)
+                    .AppendLine(".ToString(\"O\", global::System.Globalization.CultureInfo.InvariantCulture));");
+                return;
+            case "Enum":
+                source.Append(indent)
+                    .Append("WriteBinaryInteger(destination, ref position, global::System.Convert.ToInt64(")
+                    .Append(expression)
+                    .AppendLine(", global::System.Globalization.CultureInfo.InvariantCulture));");
+                return;
+            case "Boolean":
+                source.Append(indent)
+                    .Append("WriteByte(destination, ref position, ")
+                    .Append(expression)
+                    .AppendLine(" ? TrueTag : FalseTag);");
+                return;
+            case "Byte":
+            case "SByte":
+            case "Int16":
+            case "UInt16":
+            case "Int32":
+            case "UInt32":
+            case "Int64":
+                source.Append(indent)
+                    .Append("WriteBinaryInteger(destination, ref position, (long)")
+                    .Append(expression)
+                    .AppendLine(");");
+                return;
+            case "Single":
+                source.Append(indent)
+                    .Append("WriteBinaryDouble(destination, ref position, (double)")
+                    .Append(expression)
+                    .AppendLine(");");
+                return;
+            case "Double":
+                source.Append(indent)
+                    .Append("WriteBinaryDouble(destination, ref position, ")
+                    .Append(expression)
+                    .AppendLine(");");
+                return;
+            case "Decimal":
+                source.Append(indent)
+                    .Append("WriteBinaryDecimal(destination, ref position, ")
+                    .Append(expression)
+                    .AppendLine(");");
+                return;
+            default:
+                throw new InvalidOperationException($"Unsupported generated binary value kind '{value.ValueKindName}'.");
+        }
+    }
+
+    private static void EmitBinaryPrimitiveHelpers(StringBuilder source)
+    {
+        source.AppendLine("    private static int GetBinaryStringSize(string? value)");
+        source.AppendLine("        => value is null ? 1 : 1 + GetLengthPrefixedStringSize(value);");
+        source.AppendLine();
+        source.AppendLine("    private static int GetLengthPrefixedStringSize(string value)");
+        source.AppendLine("    {");
+        source.AppendLine("        int byteCount = global::System.Text.Encoding.UTF8.GetByteCount(value);");
+        source.AppendLine("        return GetVarintSize((ulong)byteCount) + byteCount;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static int GetLengthPrefixedUtf8Size(global::System.ReadOnlySpan<byte> value)");
+        source.AppendLine("        => GetVarintSize((ulong)value.Length) + value.Length;");
+        source.AppendLine();
+        source.AppendLine("    private static int GetVarintSize(ulong value)");
+        source.AppendLine("        => global::CSharpDB.Storage.Serialization.Varint.SizeOf(value);");
+        source.AppendLine();
+        source.AppendLine("    private static bool IsBinaryRecordPayload(global::System.ReadOnlySpan<byte> payload)");
+        source.AppendLine("        => payload.Length >= 3 && payload[0] == RecordFormatMarker && payload[1] == RecordFormatMagic && payload[2] == RecordFormatVersion;");
+        source.AppendLine();
+        source.AppendLine("    private static int ReadBinaryRecordNullBitmap(global::System.ReadOnlySpan<byte> payload, ref int position, int byteCount)");
+        source.AppendLine("    {");
+        source.AppendLine("        int start = position;");
+        source.AppendLine("        EnsureAvailable(payload, position, byteCount);");
+        source.AppendLine("        position += byteCount;");
+        source.AppendLine("        return start;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool IsBinaryRecordNull(global::System.ReadOnlySpan<byte> payload, int nullBitmapStart, int fieldIndex)");
+        source.AppendLine("        => (payload[nullBitmapStart + (fieldIndex >> 3)] & (1 << (fieldIndex & 7))) != 0;");
+        source.AppendLine();
+        source.AppendLine("    private static void SetBinaryRecordNull(global::System.Span<byte> destination, int nullBitmapStart, int fieldIndex)");
+        source.AppendLine("        => destination[nullBitmapStart + (fieldIndex >> 3)] = (byte)(destination[nullBitmapStart + (fieldIndex >> 3)] | (1 << (fieldIndex & 7)));");
+        source.AppendLine();
+        source.AppendLine("    private static string ReadBinaryRecordString(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => global::System.Text.Encoding.UTF8.GetString(ReadLengthPrefixedBytes(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.ReadOnlySpan<byte> ReadBinaryRecordStringUtf8(global::System.ReadOnlySpan<byte> payload, scoped ref int position)");
+        source.AppendLine("        => ReadLengthPrefixedBytes(payload, ref position);");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.Guid ReadBinaryRecordGuid(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, 16);");
+        source.AppendLine("        global::System.Guid value = new global::System.Guid(payload.Slice(position, 16));");
+        source.AppendLine("        position += 16;");
+        source.AppendLine("        return value;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.DateOnly ReadBinaryRecordDateOnly(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => global::System.DateOnly.FromDayNumber(ReadBinaryRecordInt32(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.TimeOnly ReadBinaryRecordTimeOnly(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => new global::System.TimeOnly(ReadInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static TEnum ReadBinaryRecordEnum<TEnum>(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        where TEnum : struct");
+        source.AppendLine("        => (TEnum)global::System.Enum.ToObject(typeof(TEnum), ReadInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static bool ReadBinaryRecordBoolean(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => ReadByte(payload, ref position) != 0;");
+        source.AppendLine();
+        source.AppendLine("    private static byte ReadBinaryRecordByte(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => ReadByte(payload, ref position);");
+        source.AppendLine();
+        source.AppendLine("    private static sbyte ReadBinaryRecordSByte(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => unchecked((sbyte)ReadByte(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static short ReadBinaryRecordInt16(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, sizeof(short));");
+        source.AppendLine("        short value = global::System.Buffers.Binary.BinaryPrimitives.ReadInt16LittleEndian(payload[position..]);");
+        source.AppendLine("        position += sizeof(short);");
+        source.AppendLine("        return value;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static ushort ReadBinaryRecordUInt16(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, sizeof(ushort));");
+        source.AppendLine("        ushort value = global::System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(payload[position..]);");
+        source.AppendLine("        position += sizeof(ushort);");
+        source.AppendLine("        return value;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static int ReadBinaryRecordInt32(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, sizeof(int));");
+        source.AppendLine("        int value = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[position..]);");
+        source.AppendLine("        position += sizeof(int);");
+        source.AppendLine("        return value;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static uint ReadBinaryRecordUInt32(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, sizeof(uint));");
+        source.AppendLine("        uint value = global::System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload[position..]);");
+        source.AppendLine("        position += sizeof(uint);");
+        source.AppendLine("        return value;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static float ReadBinaryRecordSingle(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => global::System.BitConverter.Int32BitsToSingle(ReadBinaryRecordInt32(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static double ReadBinaryRecordDouble(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => global::System.BitConverter.Int64BitsToDouble(ReadInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static decimal ReadBinaryRecordDecimal(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, sizeof(int) * 4);");
+        source.AppendLine("        int lo = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[position..]);");
+        source.AppendLine("        int mid = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 4)..]);");
+        source.AppendLine("        int hi = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 8)..]);");
+        source.AppendLine("        int flags = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 12)..]);");
+        source.AppendLine("        position += sizeof(int) * 4;");
+        source.AppendLine("        return new decimal(new int[] { lo, mid, hi, flags });");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static string? ReadBinaryString(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag == NullTag)");
+        source.AppendLine("            return null;");
+        source.AppendLine();
+        source.AppendLine("        EnsureTag(tag, StringTag);");
+        source.AppendLine("        return global::System.Text.Encoding.UTF8.GetString(ReadLengthPrefixedBytes(payload, ref position));");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static string ReadRequiredBinaryString(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => ReadBinaryString(payload, ref position)");
+        source.AppendLine("           ?? throw new global::CSharpDB.Primitives.CSharpDbException(global::CSharpDB.Primitives.ErrorCode.CorruptDatabase, \"Generated binary collection payload contained null for a required string value.\");");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.Guid ReadBinaryGuid(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => global::System.Guid.Parse(ReadRequiredBinaryString(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.Guid? ReadNullableBinaryGuid(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        string? value = ReadBinaryString(payload, ref position);");
+        source.AppendLine("        return value is null ? null : global::System.Guid.Parse(value);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.DateOnly ReadBinaryDateOnly(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => global::System.DateOnly.ParseExact(ReadRequiredBinaryString(payload, ref position), \"O\", global::System.Globalization.CultureInfo.InvariantCulture);");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.DateOnly? ReadNullableBinaryDateOnly(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        string? value = ReadBinaryString(payload, ref position);");
+        source.AppendLine("        return value is null ? null : global::System.DateOnly.ParseExact(value, \"O\", global::System.Globalization.CultureInfo.InvariantCulture);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.TimeOnly ReadBinaryTimeOnly(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => global::System.TimeOnly.ParseExact(ReadRequiredBinaryString(payload, ref position), \"O\", global::System.Globalization.CultureInfo.InvariantCulture);");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.TimeOnly? ReadNullableBinaryTimeOnly(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        string? value = ReadBinaryString(payload, ref position);");
+        source.AppendLine("        return value is null ? null : global::System.TimeOnly.ParseExact(value, \"O\", global::System.Globalization.CultureInfo.InvariantCulture);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static TEnum ReadBinaryEnum<TEnum>(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        where TEnum : struct");
+        source.AppendLine("        => (TEnum)global::System.Enum.ToObject(typeof(TEnum), ReadBinaryInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static TEnum? ReadNullableBinaryEnum<TEnum>(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        where TEnum : struct");
+        source.AppendLine("    {");
+        source.AppendLine("        long? value = ReadNullableBinaryInt64(payload, ref position);");
+        source.AppendLine("        return value.HasValue ? (TEnum)global::System.Enum.ToObject(typeof(TEnum), value.Value) : null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool ReadBinaryBoolean(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag == TrueTag)");
+        source.AppendLine("            return true;");
+        source.AppendLine("        if (tag == FalseTag)");
+        source.AppendLine("            return false;");
+        source.AppendLine();
+        source.AppendLine("        ThrowUnexpectedTag(tag, TrueTag);");
+        source.AppendLine("        return false;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool? ReadNullableBinaryBoolean(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag == NullTag)");
+        source.AppendLine("            return null;");
+        source.AppendLine("        if (tag == TrueTag)");
+        source.AppendLine("            return true;");
+        source.AppendLine("        if (tag == FalseTag)");
+        source.AppendLine("            return false;");
+        source.AppendLine();
+        source.AppendLine("        ThrowUnexpectedTag(tag, TrueTag);");
+        source.AppendLine("        return null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static byte ReadBinaryByte(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => checked((byte)ReadBinaryInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static byte? ReadNullableBinaryByte(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        long? value = ReadNullableBinaryInt64(payload, ref position);");
+        source.AppendLine("        return value.HasValue ? checked((byte)value.Value) : null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static sbyte ReadBinarySByte(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => checked((sbyte)ReadBinaryInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static sbyte? ReadNullableBinarySByte(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        long? value = ReadNullableBinaryInt64(payload, ref position);");
+        source.AppendLine("        return value.HasValue ? checked((sbyte)value.Value) : null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static short ReadBinaryInt16(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => checked((short)ReadBinaryInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static short? ReadNullableBinaryInt16(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        long? value = ReadNullableBinaryInt64(payload, ref position);");
+        source.AppendLine("        return value.HasValue ? checked((short)value.Value) : null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static ushort ReadBinaryUInt16(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => checked((ushort)ReadBinaryInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static ushort? ReadNullableBinaryUInt16(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        long? value = ReadNullableBinaryInt64(payload, ref position);");
+        source.AppendLine("        return value.HasValue ? checked((ushort)value.Value) : null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static int ReadBinaryInt32(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => checked((int)ReadBinaryInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static int? ReadNullableBinaryInt32(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        long? value = ReadNullableBinaryInt64(payload, ref position);");
+        source.AppendLine("        return value.HasValue ? checked((int)value.Value) : null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static uint ReadBinaryUInt32(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => checked((uint)ReadBinaryInt64(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static uint? ReadNullableBinaryUInt32(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        long? value = ReadNullableBinaryInt64(payload, ref position);");
+        source.AppendLine("        return value.HasValue ? checked((uint)value.Value) : null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static long ReadBinaryInt64(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => ReadBinaryIntegerPayload(payload, ref position, ReadByte(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static long? ReadNullableBinaryInt64(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        return tag == NullTag ? null : ReadBinaryIntegerPayload(payload, ref position, tag);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static long ReadBinaryIntegerPayload(global::System.ReadOnlySpan<byte> payload, ref int position, byte tag)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureTag(tag, IntegerTag);");
+        source.AppendLine("        return ReadInt64(payload, ref position);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static float ReadBinarySingle(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => checked((float)ReadBinaryDouble(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static float? ReadNullableBinarySingle(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        double? value = ReadNullableBinaryDouble(payload, ref position);");
+        source.AppendLine("        return value.HasValue ? checked((float)value.Value) : null;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static double ReadBinaryDouble(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => ReadBinaryDoublePayload(payload, ref position, ReadByte(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static double? ReadNullableBinaryDouble(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        return tag == NullTag ? null : ReadBinaryDoublePayload(payload, ref position, tag);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static double ReadBinaryDoublePayload(global::System.ReadOnlySpan<byte> payload, ref int position, byte tag)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureTag(tag, DoubleTag);");
+        source.AppendLine("        return global::System.BitConverter.Int64BitsToDouble(ReadInt64(payload, ref position));");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static decimal ReadBinaryDecimal(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("        => ReadBinaryDecimalPayload(payload, ref position, ReadByte(payload, ref position));");
+        source.AppendLine();
+        source.AppendLine("    private static decimal? ReadNullableBinaryDecimal(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        return tag == NullTag ? null : ReadBinaryDecimalPayload(payload, ref position, tag);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static decimal ReadBinaryDecimalPayload(global::System.ReadOnlySpan<byte> payload, ref int position, byte tag)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureTag(tag, DecimalTag);");
+        source.AppendLine("        EnsureAvailable(payload, position, sizeof(int) * 4);");
+        source.AppendLine("        int lo = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[position..]);");
+        source.AppendLine("        int mid = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 4)..]);");
+        source.AppendLine("        int hi = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 8)..]);");
+        source.AppendLine("        int flags = global::System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(payload[(position + 12)..]);");
+        source.AppendLine("        position += sizeof(int) * 4;");
+        source.AppendLine("        return new decimal(new int[] { lo, mid, hi, flags });");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void SkipBinaryValue(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        switch (tag)");
+        source.AppendLine("        {");
+        source.AppendLine("            case NullTag:");
+        source.AppendLine("            case FalseTag:");
+        source.AppendLine("            case TrueTag:");
+        source.AppendLine("                return;");
+        source.AppendLine("            case StringTag:");
+        source.AppendLine("                _ = ReadLengthPrefixedBytes(payload, ref position);");
+        source.AppendLine("                return;");
+        source.AppendLine("            case IntegerTag:");
+        source.AppendLine("            case DoubleTag:");
+        source.AppendLine("                EnsureAvailable(payload, position, sizeof(long));");
+        source.AppendLine("                position += sizeof(long);");
+        source.AppendLine("                return;");
+        source.AppendLine("            case DecimalTag:");
+        source.AppendLine("                EnsureAvailable(payload, position, sizeof(int) * 4);");
+        source.AppendLine("                position += sizeof(int) * 4;");
+        source.AppendLine("                return;");
+        source.AppendLine("            case ObjectTag:");
+        source.AppendLine("                SkipBinaryObject(payload, ref position);");
+        source.AppendLine("                return;");
+        source.AppendLine("            case ArrayTag:");
+        source.AppendLine("                ulong elementCount = ReadVarint(payload, ref position);");
+        source.AppendLine("                for (ulong i = 0; i < elementCount; i++)");
+        source.AppendLine("                    SkipBinaryValue(payload, ref position);");
+        source.AppendLine("                return;");
+        source.AppendLine("            default:");
+        source.AppendLine("                ThrowUnexpectedTag(tag, NullTag);");
+        source.AppendLine("                return;");
+        source.AppendLine("        }");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void SkipBinaryObject(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        ulong fieldCount = ReadVarint(payload, ref position);");
+        source.AppendLine("        for (ulong i = 0; i < fieldCount; i++)");
+        source.AppendLine("        {");
+        source.AppendLine("            _ = ReadLengthPrefixedBytes(payload, ref position);");
+        source.AppendLine("            SkipBinaryValue(payload, ref position);");
+        source.AppendLine("        }");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static byte ReadByte(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, 1);");
+        source.AppendLine("        return payload[position++];");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static ulong ReadVarint(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, 1);");
+        source.AppendLine("        ulong value = global::CSharpDB.Storage.Serialization.Varint.Read(payload[position..], out int bytesRead);");
+        source.AppendLine("        EnsureAvailable(payload, position, bytesRead);");
+        source.AppendLine("        position += bytesRead;");
+        source.AppendLine("        return value;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static global::System.ReadOnlySpan<byte> ReadLengthPrefixedBytes(global::System.ReadOnlySpan<byte> payload, scoped ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        int length = checked((int)ReadVarint(payload, ref position));");
+        source.AppendLine("        EnsureAvailable(payload, position, length);");
+        source.AppendLine("        global::System.ReadOnlySpan<byte> value = payload.Slice(position, length);");
+        source.AppendLine("        position += length;");
+        source.AppendLine("        return value;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool TryReadExpectedFieldName(global::System.ReadOnlySpan<byte> payload, ref int position, global::System.ReadOnlySpan<byte> expected)");
+        source.AppendLine("    {");
+        source.AppendLine("        int start = position;");
+        source.AppendLine("        global::System.ReadOnlySpan<byte> fieldName = ReadLengthPrefixedBytes(payload, ref position);");
+        source.AppendLine("        if (!fieldName.SequenceEqual(expected))");
+        source.AppendLine("        {");
+        source.AppendLine("            position = start;");
+        source.AppendLine("            return false;");
+        source.AppendLine("        }");
+        source.AppendLine();
+        source.AppendLine("        return true;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool TryReadExpectedObjectFieldCount(global::System.ReadOnlySpan<byte> payload, ref int position, int expectedFieldCount)");
+        source.AppendLine("    {");
+        source.AppendLine("        int current = position;");
+        source.AppendLine("        ulong fieldCount = ReadVarint(payload, ref current);");
+        source.AppendLine("        if (fieldCount != (ulong)expectedFieldCount)");
+        source.AppendLine("            return false;");
+        source.AppendLine();
+        source.AppendLine("        position = current;");
+        source.AppendLine("        return true;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool TrySkipExpectedBinaryField(global::System.ReadOnlySpan<byte> payload, ref int position, global::System.ReadOnlySpan<byte> expected)");
+        source.AppendLine("    {");
+        source.AppendLine("        if (!TryReadExpectedFieldName(payload, ref position, expected))");
+        source.AppendLine("            return false;");
+        source.AppendLine();
+        source.AppendLine("        SkipBinaryValue(payload, ref position);");
+        source.AppendLine("        return true;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void SkipBinaryField(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        _ = ReadLengthPrefixedBytes(payload, ref position);");
+        source.AppendLine("        SkipBinaryValue(payload, ref position);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool TryReadBinaryObjectPayload(global::System.ReadOnlySpan<byte> payload, ref int position, out int objectStart, out int objectLength)");
+        source.AppendLine("    {");
+        source.AppendLine("        objectStart = 0;");
+        source.AppendLine("        objectLength = 0;");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag != ObjectTag)");
+        source.AppendLine("            return false;");
+        source.AppendLine();
+        source.AppendLine("        objectStart = position;");
+        source.AppendLine("        SkipBinaryObject(payload, ref position);");
+        source.AppendLine("        objectLength = position - objectStart;");
+        source.AppendLine("        return true;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool TryReadBinaryPayloadFieldValue(global::System.ReadOnlySpan<byte> payload, ref int position, out global::CSharpDB.Primitives.DbValue value)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        switch (tag)");
+        source.AppendLine("        {");
+        source.AppendLine("            case StringTag:");
+        source.AppendLine("                value = global::CSharpDB.Primitives.DbValue.FromText(global::System.Text.Encoding.UTF8.GetString(ReadLengthPrefixedBytes(payload, ref position)));");
+        source.AppendLine("                return true;");
+        source.AppendLine("            case IntegerTag:");
+        source.AppendLine("                value = global::CSharpDB.Primitives.DbValue.FromInteger(ReadInt64(payload, ref position));");
+        source.AppendLine("                return true;");
+        source.AppendLine("            case DoubleTag:");
+        source.AppendLine("                value = global::CSharpDB.Primitives.DbValue.FromReal(global::System.BitConverter.Int64BitsToDouble(ReadInt64(payload, ref position)));");
+        source.AppendLine("                return true;");
+        source.AppendLine("            default:");
+        source.AppendLine("                value = default;");
+        source.AppendLine("                return false;");
+        source.AppendLine("        }");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool TryReadBinaryPayloadFieldInt64(global::System.ReadOnlySpan<byte> payload, ref int position, out long value)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag == IntegerTag)");
+        source.AppendLine("        {");
+        source.AppendLine("            value = ReadInt64(payload, ref position);");
+        source.AppendLine("            return true;");
+        source.AppendLine("        }");
+        source.AppendLine();
+        source.AppendLine("        value = 0;");
+        source.AppendLine("        return false;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool TryReadBinaryPayloadFieldText(global::System.ReadOnlySpan<byte> payload, ref int position, out string? value)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag == StringTag)");
+        source.AppendLine("        {");
+        source.AppendLine("            value = global::System.Text.Encoding.UTF8.GetString(ReadLengthPrefixedBytes(payload, ref position));");
+        source.AppendLine("            return true;");
+        source.AppendLine("        }");
+        source.AppendLine();
+        source.AppendLine("        value = null;");
+        source.AppendLine("        return false;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static bool TryReadBinaryPayloadFieldTextUtf8(global::System.ReadOnlySpan<byte> payload, scoped ref int position, out global::System.ReadOnlySpan<byte> value)");
+        source.AppendLine("    {");
+        source.AppendLine("        byte tag = ReadByte(payload, ref position);");
+        source.AppendLine("        if (tag == StringTag)");
+        source.AppendLine("        {");
+        source.AppendLine("            value = ReadLengthPrefixedBytes(payload, ref position);");
+        source.AppendLine("            return true;");
+        source.AppendLine("        }");
+        source.AppendLine();
+        source.AppendLine("        value = default;");
+        source.AppendLine("        return false;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static long ReadInt64(global::System.ReadOnlySpan<byte> payload, ref int position)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(payload, position, sizeof(long));");
+        source.AppendLine("        long value = global::System.Buffers.Binary.BinaryPrimitives.ReadInt64LittleEndian(payload[position..]);");
+        source.AppendLine("        position += sizeof(long);");
+        source.AppendLine("        return value;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void EnsureTag(byte actual, byte expected)");
+        source.AppendLine("    {");
+        source.AppendLine("        if (actual != expected)");
+        source.AppendLine("            ThrowUnexpectedTag(actual, expected);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void EnsureAvailable(global::System.ReadOnlySpan<byte> payload, int position, int count)");
+        source.AppendLine("    {");
+        source.AppendLine("        if (count < 0 || position < 0 || payload.Length - position < count)");
+        source.AppendLine("            throw new global::CSharpDB.Primitives.CSharpDbException(global::CSharpDB.Primitives.ErrorCode.CorruptDatabase, \"Invalid generated binary collection payload length.\");");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void ThrowUnexpectedTag(byte actual, byte expected)");
+        source.AppendLine("        => throw new global::CSharpDB.Primitives.CSharpDbException(global::CSharpDB.Primitives.ErrorCode.CorruptDatabase, $\"Invalid generated binary collection payload tag {actual}; expected {expected}.\");");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryString(global::System.Span<byte> destination, ref int position, string? value)");
+        source.AppendLine("    {");
+        source.AppendLine("        if (value is null)");
+        source.AppendLine("        {");
+        source.AppendLine("            WriteByte(destination, ref position, NullTag);");
+        source.AppendLine("            return;");
+        source.AppendLine("        }");
+        source.AppendLine();
+        source.AppendLine("        WriteByte(destination, ref position, StringTag);");
+        source.AppendLine("        WriteLengthPrefixedString(destination, ref position, value);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordGuid(global::System.Span<byte> destination, ref int position, global::System.Guid value)");
+        source.AppendLine("    {");
+        source.AppendLine("        EnsureAvailable(destination, position, 16);");
+        source.AppendLine("        if (!value.TryWriteBytes(destination.Slice(position, 16)))");
+        source.AppendLine("            throw new global::System.InvalidOperationException(\"Failed to write generated binary record Guid value.\");");
+        source.AppendLine("        position += 16;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordDateOnly(global::System.Span<byte> destination, ref int position, global::System.DateOnly value)");
+        source.AppendLine("        => WriteBinaryRecordInt32(destination, ref position, value.DayNumber);");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordTimeOnly(global::System.Span<byte> destination, ref int position, global::System.TimeOnly value)");
+        source.AppendLine("        => WriteInt64(destination, ref position, value.Ticks);");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordEnum<TEnum>(global::System.Span<byte> destination, ref int position, TEnum value)");
+        source.AppendLine("        where TEnum : struct");
+        source.AppendLine("        => WriteInt64(destination, ref position, global::System.Convert.ToInt64(value, global::System.Globalization.CultureInfo.InvariantCulture));");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordBoolean(global::System.Span<byte> destination, ref int position, bool value)");
+        source.AppendLine("        => WriteByte(destination, ref position, value ? (byte)1 : (byte)0);");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordByte(global::System.Span<byte> destination, ref int position, byte value)");
+        source.AppendLine("        => WriteByte(destination, ref position, value);");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordSByte(global::System.Span<byte> destination, ref int position, sbyte value)");
+        source.AppendLine("        => WriteByte(destination, ref position, unchecked((byte)value));");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordInt16(global::System.Span<byte> destination, ref int position, short value)");
+        source.AppendLine("    {");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt16LittleEndian(destination.Slice(position, sizeof(short)), value);");
+        source.AppendLine("        position += sizeof(short);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordUInt16(global::System.Span<byte> destination, ref int position, ushort value)");
+        source.AppendLine("    {");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(destination.Slice(position, sizeof(ushort)), value);");
+        source.AppendLine("        position += sizeof(ushort);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordInt32(global::System.Span<byte> destination, ref int position, int value)");
+        source.AppendLine("    {");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(destination.Slice(position, sizeof(int)), value);");
+        source.AppendLine("        position += sizeof(int);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordUInt32(global::System.Span<byte> destination, ref int position, uint value)");
+        source.AppendLine("    {");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(destination.Slice(position, sizeof(uint)), value);");
+        source.AppendLine("        position += sizeof(uint);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordSingle(global::System.Span<byte> destination, ref int position, float value)");
+        source.AppendLine("        => WriteBinaryRecordInt32(destination, ref position, global::System.BitConverter.SingleToInt32Bits(value));");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordDouble(global::System.Span<byte> destination, ref int position, double value)");
+        source.AppendLine("        => WriteInt64(destination, ref position, global::System.BitConverter.DoubleToInt64Bits(value));");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryRecordDecimal(global::System.Span<byte> destination, ref int position, decimal value)");
+        source.AppendLine("    {");
+        source.AppendLine("        int[] bits = decimal.GetBits(value);");
+        source.AppendLine("        global::System.Span<byte> span = destination.Slice(position, sizeof(int) * 4);");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(span, bits[0]);");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(span[4..], bits[1]);");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(span[8..], bits[2]);");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(span[12..], bits[3]);");
+        source.AppendLine("        position += sizeof(int) * 4;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryInteger(global::System.Span<byte> destination, ref int position, long value)");
+        source.AppendLine("    {");
+        source.AppendLine("        WriteByte(destination, ref position, IntegerTag);");
+        source.AppendLine("        WriteInt64(destination, ref position, value);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryDouble(global::System.Span<byte> destination, ref int position, double value)");
+        source.AppendLine("    {");
+        source.AppendLine("        WriteByte(destination, ref position, DoubleTag);");
+        source.AppendLine("        WriteInt64(destination, ref position, global::System.BitConverter.DoubleToInt64Bits(value));");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBinaryDecimal(global::System.Span<byte> destination, ref int position, decimal value)");
+        source.AppendLine("    {");
+        source.AppendLine("        WriteByte(destination, ref position, DecimalTag);");
+        source.AppendLine("        int[] bits = decimal.GetBits(value);");
+        source.AppendLine("        global::System.Span<byte> span = destination.Slice(position, sizeof(int) * 4);");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(span, bits[0]);");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(span[4..], bits[1]);");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(span[8..], bits[2]);");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(span[12..], bits[3]);");
+        source.AppendLine("        position += sizeof(int) * 4;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteByte(global::System.Span<byte> destination, ref int position, byte value)");
+        source.AppendLine("    {");
+        source.AppendLine("        destination[position] = value;");
+        source.AppendLine("        position++;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteVarint(global::System.Span<byte> destination, ref int position, ulong value)");
+        source.AppendLine("    {");
+        source.AppendLine("        position += global::CSharpDB.Storage.Serialization.Varint.Write(destination[position..], value);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteBytes(global::System.Span<byte> destination, ref int position, global::System.ReadOnlySpan<byte> value)");
+        source.AppendLine("    {");
+        source.AppendLine("        value.CopyTo(destination[position..]);");
+        source.AppendLine("        position += value.Length;");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteLengthPrefixedString(global::System.Span<byte> destination, ref int position, string value)");
+        source.AppendLine("    {");
+        source.AppendLine("        int byteCount = global::System.Text.Encoding.UTF8.GetByteCount(value);");
+        source.AppendLine("        WriteVarint(destination, ref position, (ulong)byteCount);");
+        source.AppendLine("        position += global::System.Text.Encoding.UTF8.GetBytes(value.AsSpan(), destination.Slice(position, byteCount));");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteLengthPrefixedUtf8(global::System.Span<byte> destination, ref int position, global::System.ReadOnlySpan<byte> value)");
+        source.AppendLine("    {");
+        source.AppendLine("        WriteVarint(destination, ref position, (ulong)value.Length);");
+        source.AppendLine("        WriteBytes(destination, ref position, value);");
+        source.AppendLine("    }");
+        source.AppendLine();
+        source.AppendLine("    private static void WriteInt64(global::System.Span<byte> destination, ref int position, long value)");
+        source.AppendLine("    {");
+        source.AppendLine("        global::System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(destination.Slice(position, sizeof(long)), value);");
+        source.AppendLine("        position += sizeof(long);");
+        source.AppendLine("    }");
+    }
+
     private readonly struct CollectionGenerationResult
     {
         public CollectionGenerationResult(CollectionModelTarget? target, ImmutableArray<Diagnostic> diagnostics)
@@ -1048,7 +4098,8 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
             string jsonContextTypeName,
             string partialTypeKeyword,
             string safeIdentifier,
-            ImmutableArray<CollectionFieldSpec> fields)
+            ImmutableArray<CollectionFieldSpec> fields,
+            BinaryTypeSpec? binaryModel)
         {
             NamespaceName = namespaceName;
             TypeName = typeName;
@@ -1057,6 +4108,7 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
             PartialTypeKeyword = partialTypeKeyword;
             SafeIdentifier = safeIdentifier;
             Fields = fields;
+            BinaryModel = binaryModel;
         }
 
         public string? NamespaceName { get; }
@@ -1072,6 +4124,8 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         public string SafeIdentifier { get; }
 
         public ImmutableArray<CollectionFieldSpec> Fields { get; }
+
+        public BinaryTypeSpec? BinaryModel { get; }
     }
 
     private readonly struct CollectionFieldSpec
@@ -1111,6 +4165,193 @@ public sealed class CollectionModelGenerator : IIncrementalGenerator
         public string AccessorExpression { get; }
 
         public string? AccessorHelperSource { get; }
+    }
+
+    private sealed class BinaryTypeSpec
+    {
+        public BinaryTypeSpec(
+            string typeName,
+            string safeIdentifier,
+            ImmutableArray<BinaryMemberSpec> members,
+            BinaryConstructorSpec constructor)
+        {
+            TypeName = typeName;
+            SafeIdentifier = safeIdentifier;
+            Members = members;
+            Constructor = constructor;
+        }
+
+        public string TypeName { get; }
+
+        public string SafeIdentifier { get; }
+
+        public ImmutableArray<BinaryMemberSpec> Members { get; }
+
+        public BinaryConstructorSpec Constructor { get; }
+    }
+
+    private readonly struct BinaryConstructorSpec
+    {
+        public BinaryConstructorSpec(ImmutableArray<int> parameterMemberIndexes)
+        {
+            ParameterMemberIndexes = parameterMemberIndexes;
+        }
+
+        public ImmutableArray<int> ParameterMemberIndexes { get; }
+    }
+
+    private readonly struct BinaryFieldReaderSpec
+    {
+        public BinaryFieldReaderSpec(
+            ImmutableArray<int> memberIndexes,
+            BinaryValueSpec value,
+            string dataKindName)
+        {
+            MemberIndexes = memberIndexes;
+            Value = value;
+            DataKindName = dataKindName;
+        }
+
+        public ImmutableArray<int> MemberIndexes { get; }
+
+        public BinaryValueSpec Value { get; }
+
+        public string DataKindName { get; }
+    }
+
+    private readonly struct BinaryMemberCandidate
+    {
+        public BinaryMemberCandidate(
+            ISymbol member,
+            ITypeSymbol type,
+            BinaryValueSpec value)
+        {
+            Member = member;
+            Type = type;
+            Value = value;
+        }
+
+        public ISymbol Member { get; }
+
+        public ITypeSymbol Type { get; }
+
+        public BinaryValueSpec Value { get; }
+    }
+
+    private readonly struct BinaryMemberSpec
+    {
+        public BinaryMemberSpec(
+            string clrName,
+            string escapedClrName,
+            string jsonName,
+            BinaryValueSpec value)
+        {
+            ClrName = clrName;
+            EscapedClrName = escapedClrName;
+            JsonName = jsonName;
+            Value = value;
+        }
+
+        public string ClrName { get; }
+
+        public string EscapedClrName { get; }
+
+        public string JsonName { get; }
+
+        public BinaryValueSpec Value { get; }
+    }
+
+    private sealed class BinaryValueSpec
+    {
+        private BinaryValueSpec(
+            string typeName,
+            string effectiveTypeName,
+            string valueKindName,
+            bool canBeNull,
+            bool isNullableValueType,
+            bool isArray,
+            bool isArrayType,
+            BinaryValueSpec? element,
+            BinaryTypeSpec? objectType)
+        {
+            TypeName = typeName;
+            EffectiveTypeName = effectiveTypeName;
+            ValueKindName = valueKindName;
+            CanBeNull = canBeNull;
+            IsNullableValueType = isNullableValueType;
+            IsArray = isArray;
+            IsArrayType = isArrayType;
+            Element = element;
+            ObjectType = objectType;
+        }
+
+        public static BinaryValueSpec ForScalar(
+            string typeName,
+            string effectiveTypeName,
+            string valueKindName,
+            bool canBeNull,
+            bool isNullableValueType)
+            => new(
+                typeName,
+                effectiveTypeName,
+                valueKindName,
+                canBeNull,
+                isNullableValueType,
+                isArray: false,
+                isArrayType: false,
+                element: null,
+                objectType: null);
+
+        public static BinaryValueSpec ForObject(
+            string typeName,
+            string effectiveTypeName,
+            bool canBeNull,
+            bool isNullableValueType,
+            BinaryTypeSpec objectType)
+            => new(
+                typeName,
+                effectiveTypeName,
+                "Object",
+                canBeNull,
+                isNullableValueType,
+                isArray: false,
+                isArrayType: false,
+                element: null,
+                objectType);
+
+        public static BinaryValueSpec ForArray(
+            string typeName,
+            bool isArrayType,
+            bool canBeNull,
+            BinaryValueSpec element)
+            => new(
+                typeName,
+                typeName,
+                "Array",
+                canBeNull,
+                isNullableValueType: false,
+                isArray: true,
+                isArrayType,
+                element,
+                objectType: null);
+
+        public string TypeName { get; }
+
+        public string EffectiveTypeName { get; }
+
+        public string ValueKindName { get; }
+
+        public bool CanBeNull { get; }
+
+        public bool IsNullableValueType { get; }
+
+        public bool IsArray { get; }
+
+        public bool IsArrayType { get; }
+
+        public BinaryValueSpec? Element { get; }
+
+        public BinaryTypeSpec? ObjectType { get; }
     }
 
     private readonly struct FieldPathSegment

--- a/src/CSharpDB.Generators/README.md
+++ b/src/CSharpDB.Generators/README.md
@@ -5,6 +5,8 @@ Source generator for CSharpDB generated collection models.
 Use this package with `CSharpDB.Engine` when you want:
 
 - generated collection codecs backed by a `System.Text.Json` source-generated context
+- generated binary direct-payload writes for supported document graphs, with
+  source-generated JSON fallback for unsupported binary shapes
 - generated `CollectionField<,>` descriptors such as `User.Collection.Email`
 - flattened nested descriptors such as `User.Collection.Address_City` and `User.Collection.Orders_Sku`
 - trim-safe typed collection access through `Database.GetGeneratedCollectionAsync<T>(...)`
@@ -41,6 +43,10 @@ renamed with `JsonPropertyName`.
 
 Unsupported public members are ignored with a build warning (`CDBGEN007`) so
 generator coverage gaps fail loudly instead of silently omitting descriptors.
+When every serialized public member in the document graph maps to the supported
+binary collection payload shape, generated collections write the binary
+direct-payload format. If a member does not fit that binary shape, generated
+collections keep the existing source-generated JSON payload path.
 
 At runtime, `GetGeneratedCollectionAsync<T>(...)` also expects existing
 collection indexes for that document type to bind through registered generated

--- a/src/CSharpDB.Storage/Indexing/OrderedTextIndexKeyCodec.cs
+++ b/src/CSharpDB.Storage/Indexing/OrderedTextIndexKeyCodec.cs
@@ -32,11 +32,19 @@ internal static class OrderedTextIndexKeyCodec
         }
 
 Pack:
+        return PackUtf8Prefix(utf8Prefix, totalByteCount);
+    }
+
+    public static long ComputeKey(ReadOnlySpan<byte> utf8)
+        => PackUtf8Prefix(utf8, utf8.Length);
+
+    private static long PackUtf8Prefix(ReadOnlySpan<byte> utf8, int totalByteCount)
+    {
         int symbolCount = Math.Min(totalByteCount, MaxPrefixBytes);
         ulong packed = 0;
 
         for (int i = 0; i < symbolCount; i++)
-            packed = (packed << BitsPerSymbol) | (uint)(utf8Prefix[i] + 1);
+            packed = (packed << BitsPerSymbol) | (uint)(utf8[i] + 1);
 
         if (totalByteCount < MaxPrefixBytes)
             packed <<= BitsPerSymbol;

--- a/src/CSharpDB.Storage/Serialization/CollectionBinaryDocumentCodec.cs
+++ b/src/CSharpDB.Storage/Serialization/CollectionBinaryDocumentCodec.cs
@@ -116,17 +116,35 @@ internal static class CollectionBinaryDocumentCodec
         return TryReadValueFromObject(payload, 0, pathSegmentsUtf8, out value);
     }
 
+    public static bool TryReadValue(ReadOnlySpan<byte> payload, ReadOnlySpan<byte> pathSegmentUtf8, out DbValue value)
+        => TryReadValueFromObject(payload, pathSegmentUtf8, out value);
+
     public static bool TryReadInt64(ReadOnlySpan<byte> payload, byte[][] pathSegmentsUtf8, out long value)
     {
         ArgumentNullException.ThrowIfNull(pathSegmentsUtf8);
         return TryReadInt64FromObject(payload, 0, pathSegmentsUtf8, out value);
     }
 
+    public static bool TryReadInt64(ReadOnlySpan<byte> payload, ReadOnlySpan<byte> pathSegmentUtf8, out long value)
+        => TryReadInt64FromObject(payload, pathSegmentUtf8, out value);
+
     public static bool TryReadString(ReadOnlySpan<byte> payload, byte[][] pathSegmentsUtf8, out string? value)
     {
         ArgumentNullException.ThrowIfNull(pathSegmentsUtf8);
         return TryReadStringFromObject(payload, 0, pathSegmentsUtf8, out value);
     }
+
+    public static bool TryReadString(ReadOnlySpan<byte> payload, ReadOnlySpan<byte> pathSegmentUtf8, out string? value)
+        => TryReadStringFromObject(payload, pathSegmentUtf8, out value);
+
+    public static bool TryReadStringUtf8(ReadOnlySpan<byte> payload, byte[][] pathSegmentsUtf8, out ReadOnlySpan<byte> value)
+    {
+        ArgumentNullException.ThrowIfNull(pathSegmentsUtf8);
+        return TryReadStringUtf8FromObject(payload, 0, pathSegmentsUtf8, out value);
+    }
+
+    public static bool TryReadStringUtf8(ReadOnlySpan<byte> payload, ReadOnlySpan<byte> pathSegmentUtf8, out ReadOnlySpan<byte> value)
+        => TryReadStringUtf8FromObject(payload, pathSegmentUtf8, out value);
 
     public static bool TryReadBoolean(ReadOnlySpan<byte> payload, byte[][] pathSegmentsUtf8, out bool value)
     {
@@ -180,6 +198,12 @@ internal static class CollectionBinaryDocumentCodec
         return TryTextEqualsFromObject(payload, 0, pathSegmentsUtf8, expectedValue);
     }
 
+    public static bool TryTextEquals(ReadOnlySpan<byte> payload, ReadOnlySpan<byte> pathSegmentUtf8, string expectedValue)
+    {
+        ArgumentNullException.ThrowIfNull(expectedValue);
+        return TryTextEqualsFromObject(payload, pathSegmentUtf8, expectedValue);
+    }
+
     public static byte[] EncodeJsonUtf8(ReadOnlySpan<byte> payload)
     {
         var output = new ArrayBufferWriter<byte>();
@@ -208,6 +232,20 @@ internal static class CollectionBinaryDocumentCodec
         return TryConvertValue(tag, payload.Slice(valueStart, valueLength), out value);
     }
 
+    private static bool TryReadValueFromObject(
+        ReadOnlySpan<byte> payload,
+        ReadOnlySpan<byte> pathSegmentUtf8,
+        out DbValue value)
+    {
+        if (!TryFindValue(payload, pathSegmentUtf8, out byte tag, out int valueStart, out int valueLength))
+        {
+            value = default;
+            return false;
+        }
+
+        return TryConvertValue(tag, payload.Slice(valueStart, valueLength), out value);
+    }
+
     private static bool TryTextEqualsFromObject(
         ReadOnlySpan<byte> payload,
         int pathIndex,
@@ -218,6 +256,15 @@ internal static class CollectionBinaryDocumentCodec
                TryTextEquals(tag, payload.Slice(valueStart, valueLength), expectedValue);
     }
 
+    private static bool TryTextEqualsFromObject(
+        ReadOnlySpan<byte> payload,
+        ReadOnlySpan<byte> pathSegmentUtf8,
+        string expectedValue)
+    {
+        return TryFindValue(payload, pathSegmentUtf8, out byte tag, out int valueStart, out int valueLength) &&
+               TryTextEquals(tag, payload.Slice(valueStart, valueLength), expectedValue);
+    }
+
     private static bool TryReadInt64FromObject(
         ReadOnlySpan<byte> payload,
         int pathIndex,
@@ -225,6 +272,23 @@ internal static class CollectionBinaryDocumentCodec
         out long value)
     {
         if (!TryFindValue(payload, pathIndex, pathSegmentsUtf8, out byte tag, out int valueStart, out int valueLength) ||
+            tag != IntegerTag ||
+            valueLength != sizeof(long))
+        {
+            value = 0;
+            return false;
+        }
+
+        value = BinaryPrimitives.ReadInt64LittleEndian(payload.Slice(valueStart, valueLength));
+        return true;
+    }
+
+    private static bool TryReadInt64FromObject(
+        ReadOnlySpan<byte> payload,
+        ReadOnlySpan<byte> pathSegmentUtf8,
+        out long value)
+    {
+        if (!TryFindValue(payload, pathSegmentUtf8, out byte tag, out int valueStart, out int valueLength) ||
             tag != IntegerTag ||
             valueLength != sizeof(long))
         {
@@ -250,6 +314,55 @@ internal static class CollectionBinaryDocumentCodec
         }
 
         value = Encoding.UTF8.GetString(payload.Slice(valueStart, valueLength));
+        return true;
+    }
+
+    private static bool TryReadStringFromObject(
+        ReadOnlySpan<byte> payload,
+        ReadOnlySpan<byte> pathSegmentUtf8,
+        out string? value)
+    {
+        if (!TryFindValue(payload, pathSegmentUtf8, out byte tag, out int valueStart, out int valueLength) ||
+            tag != StringTag)
+        {
+            value = null;
+            return false;
+        }
+
+        value = Encoding.UTF8.GetString(payload.Slice(valueStart, valueLength));
+        return true;
+    }
+
+    private static bool TryReadStringUtf8FromObject(
+        ReadOnlySpan<byte> payload,
+        int pathIndex,
+        byte[][] pathSegmentsUtf8,
+        out ReadOnlySpan<byte> value)
+    {
+        if (!TryFindValue(payload, pathIndex, pathSegmentsUtf8, out byte tag, out int valueStart, out int valueLength) ||
+            tag != StringTag)
+        {
+            value = default;
+            return false;
+        }
+
+        value = payload.Slice(valueStart, valueLength);
+        return true;
+    }
+
+    private static bool TryReadStringUtf8FromObject(
+        ReadOnlySpan<byte> payload,
+        ReadOnlySpan<byte> pathSegmentUtf8,
+        out ReadOnlySpan<byte> value)
+    {
+        if (!TryFindValue(payload, pathSegmentUtf8, out byte tag, out int valueStart, out int valueLength) ||
+            tag != StringTag)
+        {
+            value = default;
+            return false;
+        }
+
+        value = payload.Slice(valueStart, valueLength);
         return true;
     }
 
@@ -542,6 +655,14 @@ internal static class CollectionBinaryDocumentCodec
         return false;
     }
 
+    private static bool TryFindValue(
+        ReadOnlySpan<byte> payload,
+        ReadOnlySpan<byte> pathSegmentUtf8,
+        out byte tag,
+        out int valueStart,
+        out int valueLength)
+        => TryFindCurrentValue(payload, pathSegmentUtf8, out tag, out valueStart, out valueLength);
+
     private static bool TryFindCurrentValue(
         ReadOnlySpan<byte> payload,
         int pathIndex,
@@ -556,6 +677,35 @@ internal static class CollectionBinaryDocumentCodec
         {
             ReadOnlySpan<byte> fieldName = ReadLengthPrefixedBytes(payload, ref position);
             if (!fieldName.SequenceEqual(pathSegmentsUtf8[pathIndex]))
+            {
+                if (!TrySkipValue(payload, ref position))
+                    break;
+
+                continue;
+            }
+
+            return TryReadValuePayload(payload, ref position, out tag, out valueStart, out valueLength);
+        }
+
+        tag = default;
+        valueStart = 0;
+        valueLength = 0;
+        return false;
+    }
+
+    private static bool TryFindCurrentValue(
+        ReadOnlySpan<byte> payload,
+        ReadOnlySpan<byte> pathSegmentUtf8,
+        out byte tag,
+        out int valueStart,
+        out int valueLength)
+    {
+        int position = 0;
+        ulong fieldCount = ReadVarint(payload, ref position);
+        for (ulong i = 0; i < fieldCount; i++)
+        {
+            ReadOnlySpan<byte> fieldName = ReadLengthPrefixedBytes(payload, ref position);
+            if (!fieldName.SequenceEqual(pathSegmentUtf8))
             {
                 if (!TrySkipValue(payload, ref position))
                     break;

--- a/src/CSharpDB.Storage/Serialization/CollectionPayloadCodec.cs
+++ b/src/CSharpDB.Storage/Serialization/CollectionPayloadCodec.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Text;
 using CSharpDB.Primitives;
 
@@ -12,6 +14,9 @@ public static class CollectionPayloadCodec
     internal const byte LegacyJsonFormatMarker = 0xC1;
     internal const byte BinaryFormatMarker = 0xC2;
     internal const byte BinaryFormatVersion = 0x01;
+    internal const byte GeneratedRecordFormatMarker = 0xD0;
+    internal const byte GeneratedRecordFormatMagic = 0xF0;
+    internal const byte GeneratedRecordFormatVersion = 0x01;
 
     public static bool IsDirectPayload(ReadOnlySpan<byte> payload)
         => TryReadHeader(payload, out _);
@@ -24,20 +29,19 @@ public static class CollectionPayloadCodec
 
     internal static bool TryReadFastHeader(ReadOnlySpan<byte> payload, out Header header)
     {
+        if (TryReadFastHeaderFields(
+                payload,
+                out CollectionPayloadFormat format,
+                out int keyStart,
+                out int keyByteCount,
+                out int documentStart))
+        {
+            header = new Header(format, keyStart, keyByteCount, documentStart);
+            return true;
+        }
+
         header = default;
-
-        try
-        {
-            if (TryReadLegacyHeader(payload, out header))
-                return HasPlausibleJsonPayload(payload[header.DocumentStart..]);
-
-            return TryReadBinaryHeader(payload, out header);
-        }
-        catch (Exception ex) when (ex is CSharpDbException or ArgumentOutOfRangeException or IndexOutOfRangeException or OverflowException)
-        {
-            header = default;
-            return false;
-        }
+        return false;
     }
 
     internal static ReadOnlySpan<byte> GetKeyUtf8(ReadOnlySpan<byte> payload, Header header)
@@ -104,6 +108,129 @@ public static class CollectionPayloadCodec
         return payload;
     }
 
+    public static byte[] EncodeBinary<TState>(
+        string key,
+        int documentPayloadLength,
+        SpanAction<byte, TState> writeDocumentPayload,
+        TState state)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(writeDocumentPayload);
+        ArgumentOutOfRangeException.ThrowIfNegative(documentPayloadLength);
+
+        int keyByteCount = Encoding.UTF8.GetByteCount(key);
+        int keyLengthSize = Varint.SizeOf((ulong)keyByteCount);
+        byte[] payload = GC.AllocateUninitializedArray<byte>(2 + keyLengthSize + keyByteCount + documentPayloadLength);
+        payload[0] = BinaryFormatMarker;
+        payload[1] = BinaryFormatVersion;
+
+        int position = 2;
+        position += Varint.Write(payload.AsSpan(position), (ulong)keyByteCount);
+        position += Encoding.UTF8.GetBytes(key.AsSpan(), payload.AsSpan(position, keyByteCount));
+        writeDocumentPayload(payload.AsSpan(position, documentPayloadLength), state);
+        return payload;
+    }
+
+    public static byte[] EncodeBinary(
+        string key,
+        int documentPayloadLength,
+        out int documentPayloadStart)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentOutOfRangeException.ThrowIfNegative(documentPayloadLength);
+
+        int keyByteCount = Encoding.UTF8.GetByteCount(key);
+        int keyLengthSize = Varint.SizeOf((ulong)keyByteCount);
+        byte[] payload = GC.AllocateUninitializedArray<byte>(2 + keyLengthSize + keyByteCount + documentPayloadLength);
+        payload[0] = BinaryFormatMarker;
+        payload[1] = BinaryFormatVersion;
+
+        int position = 2;
+        position += Varint.Write(payload.AsSpan(position), (ulong)keyByteCount);
+        position += Encoding.UTF8.GetBytes(key.AsSpan(), payload.AsSpan(position, keyByteCount));
+        documentPayloadStart = position;
+        return payload;
+    }
+
+    public static bool TryDecodeDirectPayloadKey(ReadOnlySpan<byte> payload, out string key)
+    {
+        if (TryReadFastHeaderFields(
+                payload,
+                out _,
+                out int keyStart,
+                out int keyByteCount,
+                out _))
+        {
+            key = Encoding.UTF8.GetString(payload.Slice(keyStart, keyByteCount));
+            return true;
+        }
+
+        key = string.Empty;
+        return false;
+    }
+
+    public static bool TryDirectPayloadKeyEquals(
+        ReadOnlySpan<byte> payload,
+        ReadOnlySpan<byte> expectedKeyUtf8,
+        out bool equals)
+    {
+        if (TryReadFastHeaderFields(
+                payload,
+                out _,
+                out int keyStart,
+                out int keyByteCount,
+                out _))
+        {
+            equals = payload.Slice(keyStart, keyByteCount).SequenceEqual(expectedKeyUtf8);
+            return true;
+        }
+
+        equals = false;
+        return false;
+    }
+
+    public static bool TryDirectPayloadKeyEquals(
+        ReadOnlySpan<byte> payload,
+        string expectedKey,
+        out bool equals)
+    {
+        ArgumentNullException.ThrowIfNull(expectedKey);
+
+        if (TryReadFastHeaderFields(
+                payload,
+                out _,
+                out int keyStart,
+                out int keyByteCount,
+                out _))
+        {
+            equals = KeyUtf8EqualsString(payload.Slice(keyStart, keyByteCount), expectedKey);
+            return true;
+        }
+
+        equals = false;
+        return false;
+    }
+
+    public static bool TryGetBinaryDocumentPayload(
+        ReadOnlySpan<byte> payload,
+        out ReadOnlySpan<byte> documentPayload)
+    {
+        if (TryReadFastHeaderFields(
+                payload,
+                out CollectionPayloadFormat format,
+                out _,
+                out _,
+                out int documentStart) &&
+            format == CollectionPayloadFormat.Binary)
+        {
+            documentPayload = payload[documentStart..];
+            return true;
+        }
+
+        documentPayload = default;
+        return false;
+    }
+
     public static bool KeyEquals(ReadOnlySpan<byte> payload, ReadOnlySpan<byte> expectedKeyUtf8)
     {
         var header = ReadHeader(payload);
@@ -119,9 +246,18 @@ public static class CollectionPayloadCodec
     public static string DecodeJson(ReadOnlySpan<byte> payload)
     {
         var header = ReadHeader(payload);
-        return header.Format == CollectionPayloadFormat.LegacyJson
-            ? Encoding.UTF8.GetString(payload[header.DocumentStart..])
-            : CollectionBinaryDocumentCodec.DecodeJson(payload[header.DocumentStart..]);
+        if (header.Format == CollectionPayloadFormat.LegacyJson)
+            return Encoding.UTF8.GetString(payload[header.DocumentStart..]);
+
+        ReadOnlySpan<byte> documentPayload = payload[header.DocumentStart..];
+        if (IsGeneratedRecordDocumentPayload(documentPayload))
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                "Generated record collection payloads require their generated collection codec for JSON conversion.");
+        }
+
+        return CollectionBinaryDocumentCodec.DecodeJson(documentPayload);
     }
 
     public static bool JsonEquals(ReadOnlySpan<byte> payload, ReadOnlySpan<byte> expectedUtf8)
@@ -130,7 +266,9 @@ public static class CollectionPayloadCodec
         if (header.Format == CollectionPayloadFormat.LegacyJson)
             return payload[header.DocumentStart..].SequenceEqual(expectedUtf8);
 
-        return CollectionBinaryDocumentCodec.EncodeJsonUtf8(payload[header.DocumentStart..]).AsSpan().SequenceEqual(expectedUtf8);
+        ReadOnlySpan<byte> documentPayload = payload[header.DocumentStart..];
+        return !IsGeneratedRecordDocumentPayload(documentPayload) &&
+               CollectionBinaryDocumentCodec.EncodeJsonUtf8(documentPayload).AsSpan().SequenceEqual(expectedUtf8);
     }
 
     public static ReadOnlySpan<byte> GetJsonUtf8(ReadOnlySpan<byte> payload)
@@ -177,7 +315,7 @@ public static class CollectionPayloadCodec
                 return HasPlausibleJsonPayload(payload[header.DocumentStart..]);
 
             if (TryReadBinaryHeader(payload, out header))
-                return CollectionBinaryDocumentCodec.IsValidDocument(payload[header.DocumentStart..]);
+                return IsKnownBinaryDocumentPayload(payload[header.DocumentStart..]);
 
             return false;
         }
@@ -185,6 +323,61 @@ public static class CollectionPayloadCodec
         {
             return false;
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryReadFastHeaderFields(
+        ReadOnlySpan<byte> payload,
+        out CollectionPayloadFormat format,
+        out int keyStart,
+        out int keyByteCount,
+        out int documentStart)
+    {
+        int lengthOffset;
+        if (payload.Length >= 3 &&
+            payload[0] == BinaryFormatMarker &&
+            payload[1] == BinaryFormatVersion)
+        {
+            format = CollectionPayloadFormat.Binary;
+            lengthOffset = 2;
+        }
+        else if (payload.Length >= 2 && payload[0] == LegacyJsonFormatMarker)
+        {
+            format = CollectionPayloadFormat.LegacyJson;
+            lengthOffset = 1;
+        }
+        else
+        {
+            return FailFastHeaderFields(out format, out keyStart, out keyByteCount, out documentStart);
+        }
+
+        if (!TryReadInt32Varint(payload, lengthOffset, out keyByteCount, out int keyLengthBytes))
+            return FailFastHeaderFields(out format, out keyStart, out keyByteCount, out documentStart);
+
+        keyStart = lengthOffset + keyLengthBytes;
+        if (keyByteCount > payload.Length - keyStart)
+            return FailFastHeaderFields(out format, out keyStart, out keyByteCount, out documentStart);
+
+        documentStart = keyStart + keyByteCount;
+        if (documentStart >= payload.Length)
+            return FailFastHeaderFields(out format, out keyStart, out keyByteCount, out documentStart);
+
+        return format != CollectionPayloadFormat.LegacyJson ||
+               HasPlausibleJsonPayload(payload[documentStart..]);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool FailFastHeaderFields(
+        out CollectionPayloadFormat format,
+        out int keyStart,
+        out int keyByteCount,
+        out int documentStart)
+    {
+        format = default;
+        keyStart = 0;
+        keyByteCount = 0;
+        documentStart = 0;
+        return false;
     }
 
     private static bool TryReadLegacyHeader(ReadOnlySpan<byte> payload, out Header header)
@@ -219,6 +412,16 @@ public static class CollectionPayloadCodec
         return true;
     }
 
+    private static bool IsKnownBinaryDocumentPayload(ReadOnlySpan<byte> payload)
+        => IsGeneratedRecordDocumentPayload(payload) ||
+           CollectionBinaryDocumentCodec.IsValidDocument(payload);
+
+    private static bool IsGeneratedRecordDocumentPayload(ReadOnlySpan<byte> payload)
+        => payload.Length >= 3 &&
+           payload[0] == GeneratedRecordFormatMarker &&
+           payload[1] == GeneratedRecordFormatMagic &&
+           payload[2] == GeneratedRecordFormatVersion;
+
     private static bool HasPlausibleJsonPayload(ReadOnlySpan<byte> jsonUtf8)
     {
         for (int i = 0; i < jsonUtf8.Length; i++)
@@ -238,6 +441,89 @@ public static class CollectionPayloadCodec
         }
 
         return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryReadInt32Varint(
+        ReadOnlySpan<byte> payload,
+        int offset,
+        out int value,
+        out int bytesRead)
+    {
+        ulong result = 0;
+        int shift = 0;
+
+        for (int i = 0; i < 5; i++)
+        {
+            int index = offset + i;
+            if ((uint)index >= (uint)payload.Length)
+                break;
+
+            byte b = payload[index];
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0)
+            {
+                if (result > int.MaxValue)
+                    break;
+
+                value = (int)result;
+                bytesRead = i + 1;
+                return true;
+            }
+
+            shift += 7;
+        }
+
+        value = 0;
+        bytesRead = 0;
+        return false;
+    }
+
+    private static bool KeyUtf8EqualsString(ReadOnlySpan<byte> keyUtf8, string expectedKey)
+    {
+        if (keyUtf8.Length == expectedKey.Length)
+        {
+            bool ascii = true;
+            for (int i = 0; i < expectedKey.Length; i++)
+            {
+                char c = expectedKey[i];
+                if (c > 0x7F)
+                {
+                    ascii = false;
+                    break;
+                }
+
+                if (keyUtf8[i] != (byte)c)
+                    return false;
+            }
+
+            if (ascii)
+                return true;
+        }
+
+        int byteCount = Encoding.UTF8.GetByteCount(expectedKey);
+        if (byteCount != keyUtf8.Length)
+            return false;
+
+        const int StackallocKeyThreshold = 256;
+        byte[]? rented = null;
+        Span<byte> expectedKeyUtf8 = byteCount <= StackallocKeyThreshold
+            ? stackalloc byte[StackallocKeyThreshold]
+            : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+        try
+        {
+            int written = Encoding.UTF8.GetBytes(expectedKey.AsSpan(), expectedKeyUtf8);
+            return keyUtf8.SequenceEqual(expectedKeyUtf8[..written]);
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                expectedKeyUtf8[..byteCount].Clear();
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
     }
 
     internal enum CollectionPayloadFormat : byte

--- a/tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj
+++ b/tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\src\CSharpDB.Data\CSharpDB.Data.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.EntityFrameworkCore\CSharpDB.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Execution\CSharpDB.Execution.csproj" />
+    <ProjectReference Include="..\..\src\CSharpDB.Generators\CSharpDB.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\CSharpDB.Sql\CSharpDB.Sql.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Storage\CSharpDB.Storage.csproj" />
   </ItemGroup>

--- a/tests/CSharpDB.Benchmarks/HISTORY.md
+++ b/tests/CSharpDB.Benchmarks/HISTORY.md
@@ -7,7 +7,135 @@ This file preserves the benchmark release logs, failed-run notes, investigation 
 
 Performance benchmarks for the CSharpDB embedded database engine.
 
-The current main README is promoted from the April 21, 2026 release-core run and the April 22, 2026 UTC guardrail compare. Earlier April 21 release-prep failures are retained below as investigation history, not as the current published state.
+The current main README is promoted from the April 26, 2026 release-core run and the April 27, 2026 UTC guardrail compare. Earlier release-prep failures are retained below as investigation history, not as the current published state.
+
+## April 26-27, 2026 Release-Core Promotion
+
+The stable README was refreshed after the collection binary payload work from a balanced release-core run, not from the diagnostic collection-only sweep.
+
+```powershell
+dotnet run -c Release --project .\tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --release-core --repeat 3 --repro
+pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Run-Perf-Guardrails.ps1 -Mode release
+pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Compare-Baseline.ps1 `
+  -ThresholdsPath .\tests\CSharpDB.Benchmarks\perf-thresholds.json `
+  -CurrentMicroResultsDir .\tests\CSharpDB.Benchmarks\results\.tmp-current-micro-run `
+  -ReportPath .\tests\CSharpDB.Benchmarks\results\perf-guardrails-last.md
+pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Update-BenchmarkReadme.ps1 -RunManifest .\tests\CSharpDB.Benchmarks\release-core-manifest.json
+```
+
+| Item | Result |
+|------|--------|
+| Release-core status | `completed` |
+| Release-core completion | `Sunday, April 26, 2026 about 4:03 PM PT` |
+| Release-core duration | `about 68 minutes` |
+| Initial guardrail wrapper compare | `Compared 185 rows against baseline. PASS=174, WARN=0, SKIP=0, FAIL=11` |
+| Final guardrail compare | `Compared 185 rows against baseline. PASS=185, WARN=0, SKIP=0, FAIL=0` |
+| Final guardrail report | `tests/CSharpDB.Benchmarks/results/perf-guardrails-last.md` |
+| Final compare timestamp | `2026-04-27 01:18:39Z` |
+| Runner | `Intel i9-11900K, 16 logical cores, Windows 10.0.26300, .NET SDK 10.0.203, .NET runtime 10.0.7` |
+| Commit | `b7cb52ee2c30f31538e96480b6d055ff52439c26 plus uncommitted collection binary payload and benchmark updates` |
+
+The first release guardrail wrapper completed benchmark collection but failed the compare with volatile samples in `CollationIndexBenchmarks`, `CollectionIndexBenchmarks`, and `CompositeIndexBenchmarks`. A focused retry refreshed only those three micro CSVs, then the official compare passed with `PASS=185, WARN=0, SKIP=0, FAIL=0`. The release-core source artifacts were not replaced by targeted micro runs.
+
+| Artifact | Path |
+|----------|------|
+| Durable master comparison | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/master-table-20260426-215529-median-of-3.csv` |
+| Durable SQL batching | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/durable-sql-batching-20260426-221413-median-of-3.csv` |
+| Concurrent durable write | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/concurrent-write-diagnostics-20260426-223659-median-of-3.csv` |
+| Hybrid storage mode | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-storage-mode-20260426-224331-median-of-3.csv` |
+| Hybrid hot-set read | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-hot-set-read-20260426-225908-median-of-3.csv` |
+| Hybrid cold open | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-cold-open-20260426-225949-median-of-3.csv` |
+| SQLite comparison | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/sqlite-compare-20260426-230045-median-of-3.csv` |
+
+## April 26, 2026 Collection Binary Payload Fast-Path Investigation
+
+This was a focused diagnostic and recovery run for collection binary payload work. It was not a release-core promotion and does not update the stable README scorecard.
+
+The work investigated regressions seen after source-generated collection fast paths, generated record payload encoding, and targeted UTF-8 span plumbing for text index/read/compare paths. A same-machine HEAD baseline worktree was created at `.tmp/baseline-head-collection-20260426`, and the full `*Collection*` benchmark filter was run against both HEAD and the working tree.
+
+Initial collection comparison:
+
+| Item | Result |
+|------|--------|
+| Current rows | `70` |
+| Matched HEAD baseline rows | `60` |
+| Faster matched rows | `50` |
+| Slower matched rows | `10` |
+| Median matched speedup | `+4.1%` |
+| Mean matched speedup | `+4.8%` |
+| Comparison CSV | `.tmp/collection-benchmark-comparison-current-vs-head-20260426.csv` |
+
+The most actionable regressions were small direct payload/header and unbound field-reader paths:
+
+| Benchmark | HEAD baseline | Before recovery | Notes |
+|-----------|--------------:|----------------:|-------|
+| Collection field read (missing field) | `201.81 ns` | `223.22 ns` | Allocations unchanged in the first comparison; path shared header parsing and per-call property-name metadata. |
+| Collection decode (direct payload) | `317.90 ns` | `333.80 ns` | Error bars overlapped, but the direct payload decode path parsed the same header twice through `DecodeKey` and `DecodeDocument`. |
+| Collection cold get (file-backed, cache-pressured) | `51.588 us` | `57.036 us` | Treated as noisy file/cache/async behavior, not directly tied to the codec path. |
+
+Recovery changes:
+
+- `CollectionDocumentCodec<T>.Decode` now parses direct payload headers once and decodes the key/document from that single header.
+- `CollectionIndexedFieldReader` now uses stack/rented UTF-8 spans for top-level string-property reads instead of allocating a `byte[]` plus `byte[][]` per call.
+- `CollectionBinaryDocumentCodec` now has single-segment `ReadOnlySpan<byte>` lookup overloads for top-level binary document field access.
+- `CollectionPayloadCodec` fast header parsing was adjusted for the common binary payload marker first.
+
+Focused recovery benchmark comparison:
+
+| Benchmark | HEAD baseline | Before recovery | After recovery | After vs before | After vs baseline | Allocation after |
+|-----------|--------------:|----------------:|---------------:|----------------:|------------------:|-----------------:|
+| Collection field read (missing field) | `201.81 ns` | `223.22 ns` | `136.73 ns` | `+38.7%` | `+32.2%` | `0 B` |
+| Collection decode (direct payload) | `317.90 ns` | `333.80 ns` | `155.20 ns` | `+53.5%` | `+51.2%` | `328 B` |
+| Collection field read (early field) | `120.07 ns` | `108.60 ns` | `49.77 ns` | `+54.2%` | `+58.5%` | `48 B` |
+| Collection field read (middle field) | `107.15 ns` | `95.52 ns` | `67.96 ns` | `+28.9%` | `+36.6%` | `0 B` |
+| Collection field read (late field) | `158.71 ns` | `146.20 ns` | `112.27 ns` | `+23.2%` | `+29.3%` | `0 B` |
+| Collection field compare (late text field) | `187.12 ns` | `159.55 ns` | `97.60 ns` | `+38.8%` | `+47.8%` | `0 B` |
+| Collection field compare (late text field, bound accessor) | `160.29 ns` | `128.03 ns` | `92.83 ns` | `+27.5%` | `+42.1%` | `0 B` |
+
+Collection path-index follow-up:
+
+The April 7 path-index spot-check table remains a historical snapshot and was not overwritten. After the recovery changes, the focused `*CollectionIndexBenchmarks*` filter was rerun on the final working tree to cover the same path-index area. This is still diagnostic data, not a release-core promotion; read it against the April 26 same-machine HEAD artifact, not as a replacement for the April 7 dated snapshot.
+
+| Benchmark | April 26 HEAD baseline | April 26 final | Final vs baseline | Allocation final |
+|-----------|-----------------------:|---------------:|------------------:|-----------------:|
+| Collection FindByIndex nested path equality | `2,408.209 us` | `1,116.247 us` | `+53.6%` | `754.83 KB` |
+| Collection FindByPath nested path equality | `2,485.552 us` | `1,096.847 us` | `+55.9%` | `754.83 KB` |
+| Collection FindByIndex array path equality | `2,720.115 us` | `1,303.300 us` | `+52.1%` | `1254.25 KB` |
+| Collection FindByPath array path equality | `2,706.758 us` | `1,310.859 us` | `+51.6%` | `1254.25 KB` |
+| Collection FindByPath nested array path equality | `4,211.142 us` | `2,176.966 us` | `+48.3%` | `1742.67 KB` |
+| Collection FindByPath integer range | `1,017.047 us` | `587.753 us` | `+42.2%` | `307.28 KB` |
+| Collection FindByPath text range | `1,103.269 us` | `632.086 us` | `+42.7%` | `499.5 KB` |
+| Collection FindByPath Guid equality | `12.388 us` | `5.034 us` | `+59.4%` | `15.26 KB` |
+| Collection FindByPath DateOnly range | `2,176.684 us` | `1,093.622 us` | `+49.8%` | `835.63 KB` |
+
+Artifacts:
+
+| Artifact | Path |
+|----------|------|
+| Preserved April 26 HEAD benchmark reports | `.tmp/baseline-head-collection-20260426-results` |
+| Final collection index rerun report | `BenchmarkDotNet.Artifacts/results/CSharpDB.Benchmarks.Micro.CollectionIndexBenchmarks-report.csv` |
+
+Commands run:
+
+```powershell
+dotnet run -c Release --project tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --filter "*Collection*"
+dotnet run -c Release --project tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --filter "*CollectionFieldExtractionBenchmarks*"
+dotnet run -c Release --project tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --filter "*CollectionPayloadBenchmarks*"
+dotnet run -c Release --project tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --filter "*CollectionIndexBenchmarks*"
+dotnet build CSharpDB.slnx -c Release --no-restore
+dotnet test CSharpDB.slnx -c Release --no-build -m:1 -- RunConfiguration.DisableParallelization=true
+```
+
+Verification:
+
+| Check | Result |
+|-------|--------|
+| Release build | `passed` |
+| Non-parallel unit tests | `passed: 1,652 tests` |
+| Focused field extraction benchmarks | `completed` |
+| Focused payload benchmarks | `completed` |
+| Focused collection index benchmarks | `completed` |
+| Recovery comparison CSV | `.tmp/collection-recovery-comparison-20260426.csv` |
 
 ## April 21-22, 2026 Release-Core Promotion
 
@@ -787,6 +915,8 @@ Source: `BenchmarkDotNet.Artifacts/results/CSharpDB.Benchmarks.Micro.WalCoreBenc
 The important result for async I/O batching is still the staged-vs-direct comparison: the repeated-`AppendFrameAsync(...)` path stays close to the direct batched WAL path instead of collapsing into one durable write per page before commit, while manual checkpoint cost rises sharply as the frame threshold grows.
 
 ### Collection Path Index Spot Checks (April 7, 2026)
+
+This April 7 table is retained unchanged as a dated historical spot check. See the April 26 collection binary payload investigation above for the newer diagnostic path-index rerun; the two sections should not be treated as a release-to-release promotion comparison.
 
 | Metric | Mean | Allocated | Notes |
 |--------|------|-----------|-------|

--- a/tests/CSharpDB.Benchmarks/Micro/GeneratedCollectionCodecBenchmarks.cs
+++ b/tests/CSharpDB.Benchmarks/Micro/GeneratedCollectionCodecBenchmarks.cs
@@ -1,0 +1,378 @@
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BenchmarkDotNet.Attributes;
+using CSharpDB.Benchmarks.Infrastructure;
+using CSharpDB.Engine;
+using CSharpDB.Primitives;
+using CSharpDB.Storage.Serialization;
+
+namespace CSharpDB.Benchmarks.Micro;
+
+[MemoryDiagnoser]
+[Config(typeof(CollectionInProcessBenchmarkConfig))]
+public class GeneratedCollectionEncodeBenchmarks : GeneratedCollectionCodecBenchmarkBase
+{
+    [Benchmark(Baseline = true, Description = "Generated collection encode (source-gen JSON payload)")]
+    public byte[] Encode_SourceGeneratedJsonPayload()
+        => JsonCodec.Encode(Key, JsonDocument);
+
+    [Benchmark(Description = "Generated collection encode (source-gen binary payload)")]
+    public byte[] Encode_SourceGeneratedBinaryPayload()
+        => BinaryCodec.Encode(Key, BinaryDocument);
+}
+
+[MemoryDiagnoser]
+[Config(typeof(CollectionInProcessBenchmarkConfig))]
+public class GeneratedCollectionIndexedFieldBenchmarks : GeneratedCollectionCodecBenchmarkBase
+{
+    private long _sink;
+
+    [Benchmark(Baseline = true, Description = "Generated collection indexed field read (source-gen JSON payload)")]
+    public void ReadIndexedField_SourceGeneratedJsonPayload()
+    {
+        if (CollectionIndexedFieldReader.TryReadValue(JsonPayload, ScoreAccessor, out var value) &&
+            value.Type == DbType.Integer)
+        {
+            _sink = value.AsInteger;
+        }
+        else
+        {
+            _sink = -1;
+        }
+    }
+
+    [Benchmark(Description = "Generated collection indexed field read (source-gen binary payload)")]
+    public void ReadIndexedField_SourceGeneratedBinaryPayload()
+    {
+        if (ScoreField.TryReadPayloadInt64(BinaryPayload, out long score))
+        {
+            _sink = score;
+        }
+        else
+        {
+            _sink = -1;
+        }
+    }
+}
+
+[MemoryDiagnoser]
+[Config(typeof(CollectionInProcessBenchmarkConfig))]
+public class GeneratedCollectionTextFieldBenchmarks : GeneratedCollectionCodecBenchmarkBase
+{
+    private int _sink;
+
+    [Benchmark(Baseline = true, Description = "Generated collection text field read (source-gen JSON payload)")]
+    public void ReadTextField_SourceGeneratedJsonPayload()
+    {
+        if (CollectionIndexedFieldReader.TryReadString(JsonPayload, EmailAccessor, out string? email) &&
+            email is not null)
+        {
+            _sink = email.Length;
+        }
+        else
+        {
+            _sink = -1;
+        }
+    }
+
+    [Benchmark(Description = "Generated collection text field read (source-gen binary UTF-8 payload)")]
+    public void ReadTextField_SourceGeneratedBinaryPayload()
+    {
+        if (EmailField.TryReadPayloadStringUtf8(BinaryPayload, out ReadOnlySpan<byte> emailUtf8))
+        {
+            _sink = emailUtf8.Length;
+        }
+        else
+        {
+            _sink = -1;
+        }
+    }
+}
+
+[MemoryDiagnoser]
+[Config(typeof(CollectionInProcessBenchmarkConfig))]
+public class GeneratedCollectionPayloadKeyBenchmarks : GeneratedCollectionCodecBenchmarkBase
+{
+    [Benchmark(Baseline = true, Description = "Generated collection key match (source-gen JSON payload)")]
+    public bool PayloadMatchesKey_SourceGeneratedJsonPayload()
+        => JsonCodec.PayloadMatchesKey(JsonPayload, Key);
+
+    [Benchmark(Description = "Generated collection key match (source-gen binary payload)")]
+    public bool PayloadMatchesKey_SourceGeneratedBinaryPayload()
+        => BinaryCodec.PayloadMatchesKey(BinaryPayload, Key);
+}
+
+[MemoryDiagnoser]
+[Config(typeof(CollectionInProcessBenchmarkConfig))]
+public class GeneratedCollectionDecodeBenchmarks : GeneratedCollectionCodecBenchmarkBase
+{
+    [Benchmark(Baseline = true, Description = "Generated collection decode (source-gen JSON payload)")]
+    public JsonSourceBenchDoc Decode_SourceGeneratedJsonPayload()
+        => JsonCodec.DecodeDocument(JsonPayload);
+
+    [Benchmark(Description = "Generated collection decode (source-gen binary payload)")]
+    public GeneratedBinaryBenchDoc Decode_SourceGeneratedBinaryPayload()
+        => BinaryCodec.DecodeDocument(BinaryPayload);
+}
+
+public abstract class GeneratedCollectionCodecBenchmarkBase
+{
+    protected const string Key = "doc:42";
+
+    private CollectionModelRegistration? _jsonRegistration;
+
+    private protected CollectionDocumentCodec<GeneratedBinaryBenchDoc> BinaryCodec { get; private set; } = null!;
+
+    private protected CollectionDocumentCodec<JsonSourceBenchDoc> JsonCodec { get; private set; } = null!;
+
+    private protected GeneratedBinaryBenchDoc BinaryDocument { get; private set; } = null!;
+
+    private protected JsonSourceBenchDoc JsonDocument { get; private set; } = null!;
+
+    private protected byte[] BinaryPayload { get; private set; } = null!;
+
+    private protected byte[] JsonPayload { get; private set; } = null!;
+
+    private protected CollectionFieldAccessor ScoreAccessor { get; private set; } = null!;
+
+    private protected CollectionFieldAccessor EmailAccessor { get; private set; } = null!;
+
+    private protected CollectionField<GeneratedBinaryBenchDoc, int> ScoreField { get; private set; } = null!;
+
+    private protected CollectionField<GeneratedBinaryBenchDoc, string> EmailField { get; private set; } = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _jsonRegistration = CollectionModelRegistry.Register<JsonSourceBenchDoc>(new JsonSourceBenchDocCollectionModel());
+
+        BinaryCodec = new CollectionDocumentCodec<GeneratedBinaryBenchDoc>(new DefaultRecordSerializer());
+        JsonCodec = new CollectionDocumentCodec<JsonSourceBenchDoc>(new DefaultRecordSerializer());
+
+        BinaryDocument = new GeneratedBinaryBenchDoc(
+            "Alice Example",
+            37,
+            "Alpha",
+            "alice@example.com",
+            912,
+            "west",
+            "active",
+            7,
+            "gold",
+            3,
+            new GeneratedBinaryBenchProfile("enterprise", new GeneratedBinaryBenchAddress("Seattle", 98101)));
+        JsonDocument = new JsonSourceBenchDoc(
+            BinaryDocument.Name,
+            BinaryDocument.Age,
+            BinaryDocument.Category,
+            BinaryDocument.Email,
+            BinaryDocument.Score,
+            BinaryDocument.Region,
+            BinaryDocument.Status,
+            BinaryDocument.Revision,
+            BinaryDocument.Tier,
+            BinaryDocument.Flags,
+            new JsonSourceBenchProfile(
+                BinaryDocument.Profile.Segment,
+                new JsonSourceBenchAddress(
+                    BinaryDocument.Profile.Address.City,
+                    BinaryDocument.Profile.Address.ZipCode)));
+
+        BinaryPayload = BinaryCodec.Encode(Key, BinaryDocument);
+        JsonPayload = JsonCodec.Encode(Key, JsonDocument);
+        ScoreAccessor = CollectionFieldAccessor.FromFieldPath("score");
+        EmailAccessor = CollectionFieldAccessor.FromFieldPath("email");
+        ScoreField = GeneratedBinaryBenchDoc.Collection.Score;
+        EmailField = GeneratedBinaryBenchDoc.Collection.Email;
+
+        if (!CollectionPayloadCodec.IsBinaryPayload(BinaryPayload))
+            throw new InvalidOperationException("Generated binary benchmark payload did not use the generated binary path.");
+
+        if (!CollectionPayloadCodec.IsDirectPayload(JsonPayload) || CollectionPayloadCodec.IsBinaryPayload(JsonPayload))
+            throw new InvalidOperationException("Generated JSON benchmark payload did not use the direct JSON path.");
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+        => _jsonRegistration?.Dispose();
+}
+
+[CollectionModel(typeof(GeneratedCollectionCodecJsonContext))]
+public sealed partial record GeneratedBinaryBenchDoc(
+    string Name,
+    int Age,
+    string Category,
+    string Email,
+    int Score,
+    string Region,
+    string Status,
+    int Revision,
+    string Tier,
+    int Flags,
+    GeneratedBinaryBenchProfile Profile);
+
+public sealed partial record GeneratedBinaryBenchProfile(string Segment, GeneratedBinaryBenchAddress Address);
+
+public sealed partial record GeneratedBinaryBenchAddress(string City, int ZipCode);
+
+public sealed record JsonSourceBenchDoc(
+    string Name,
+    int Age,
+    string Category,
+    string Email,
+    int Score,
+    string Region,
+    string Status,
+    int Revision,
+    string Tier,
+    int Flags,
+    JsonSourceBenchProfile Profile);
+
+public sealed record JsonSourceBenchProfile(string Segment, JsonSourceBenchAddress Address);
+
+public sealed record JsonSourceBenchAddress(string City, int ZipCode);
+
+internal sealed class JsonSourceBenchDocCollectionModel : ICollectionModel<JsonSourceBenchDoc>
+{
+    public ICollectionDocumentCodec<JsonSourceBenchDoc> CreateCodec(IRecordSerializer recordSerializer)
+        => new JsonSourceBenchDocCollectionCodec(recordSerializer);
+
+    public bool TryGetField(
+        string fieldPath,
+        [NotNullWhen(true)] out CollectionField<JsonSourceBenchDoc>? field)
+    {
+        field = null;
+        return false;
+    }
+}
+
+internal sealed class JsonSourceBenchDocCollectionCodec : ICollectionDocumentCodec<JsonSourceBenchDoc>
+{
+    private const int StackallocKeyThreshold = 256;
+
+    private readonly IRecordSerializer _recordSerializer;
+    private readonly bool _usesDirectPayloadFormat;
+
+    public JsonSourceBenchDocCollectionCodec(IRecordSerializer recordSerializer)
+    {
+        _recordSerializer = recordSerializer ?? throw new ArgumentNullException(nameof(recordSerializer));
+        _usesDirectPayloadFormat = recordSerializer is DefaultRecordSerializer;
+    }
+
+    public byte[] Encode(string key, JsonSourceBenchDoc document)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(document);
+
+        if (_usesDirectPayloadFormat)
+        {
+            byte[] jsonUtf8 = JsonSerializer.SerializeToUtf8Bytes(
+                document,
+                GeneratedCollectionCodecJsonContext.Default.JsonSourceBenchDoc);
+            return CollectionPayloadCodec.Encode(key, jsonUtf8);
+        }
+
+        string json = JsonSerializer.Serialize(
+            document,
+            GeneratedCollectionCodecJsonContext.Default.JsonSourceBenchDoc);
+        return _recordSerializer.Encode(
+        [
+            DbValue.FromText(key),
+            DbValue.FromText(json),
+        ]);
+    }
+
+    public (string Key, JsonSourceBenchDoc Document) Decode(ReadOnlySpan<byte> payload)
+        => (DecodeKey(payload), DecodeDocument(payload));
+
+    public JsonSourceBenchDoc DecodeDocument(ReadOnlySpan<byte> payload)
+    {
+        if (_usesDirectPayloadFormat && CollectionPayloadCodec.IsDirectPayload(payload))
+        {
+            if (!CollectionPayloadCodec.IsBinaryPayload(payload))
+            {
+                return JsonSerializer.Deserialize(
+                           CollectionPayloadCodec.GetJsonUtf8(payload),
+                           GeneratedCollectionCodecJsonContext.Default.JsonSourceBenchDoc)
+                       ?? throw new InvalidOperationException("Generated JSON benchmark payload deserialized to null.");
+            }
+
+            string json = CollectionPayloadCodec.DecodeJson(payload);
+            return JsonSerializer.Deserialize(
+                       json,
+                       GeneratedCollectionCodecJsonContext.Default.JsonSourceBenchDoc)
+                   ?? throw new InvalidOperationException("Generated JSON benchmark payload deserialized to null.");
+        }
+
+        var values = _recordSerializer.Decode(payload);
+        return JsonSerializer.Deserialize(
+                   values[1].AsText,
+                   GeneratedCollectionCodecJsonContext.Default.JsonSourceBenchDoc)
+               ?? throw new InvalidOperationException("Generated JSON benchmark payload deserialized to null.");
+    }
+
+    public string DecodeKey(ReadOnlySpan<byte> payload)
+    {
+        if (_usesDirectPayloadFormat && CollectionPayloadCodec.TryDecodeDirectPayloadKey(payload, out string key))
+            return key;
+
+        var values = _recordSerializer.DecodeUpTo(payload, 0);
+        return values[0].AsText;
+    }
+
+    public bool TryDecodeDocumentForKey(
+        ReadOnlySpan<byte> payload,
+        string expectedKey,
+        [NotNullWhen(true)] out JsonSourceBenchDoc? document)
+    {
+        if (!PayloadMatchesKey(payload, expectedKey))
+        {
+            document = null;
+            return false;
+        }
+
+        document = DecodeDocument(payload);
+        return true;
+    }
+
+    public bool PayloadMatchesKey(ReadOnlySpan<byte> payload, string expectedKey)
+    {
+        ArgumentNullException.ThrowIfNull(expectedKey);
+
+        if (_usesDirectPayloadFormat && CollectionPayloadCodec.TryDirectPayloadKeyEquals(payload, expectedKey, out bool directEquals))
+            return directEquals;
+
+        int byteCount = Encoding.UTF8.GetByteCount(expectedKey);
+        byte[]? rented = null;
+        Span<byte> utf8 = byteCount <= StackallocKeyThreshold
+            ? stackalloc byte[StackallocKeyThreshold]
+            : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+        try
+        {
+            int written = Encoding.UTF8.GetBytes(expectedKey.AsSpan(), utf8);
+            ReadOnlySpan<byte> expectedKeyUtf8 = utf8[..written];
+
+            if (_recordSerializer.TryColumnTextEquals(payload, 0, expectedKeyUtf8, out bool equals))
+                return equals;
+
+            return DecodeKey(payload) == expectedKey;
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                utf8[..byteCount].Clear();
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(GeneratedBinaryBenchDoc))]
+[JsonSerializable(typeof(JsonSourceBenchDoc))]
+internal sealed partial class GeneratedCollectionCodecJsonContext : JsonSerializerContext;

--- a/tests/CSharpDB.Benchmarks/README.md
+++ b/tests/CSharpDB.Benchmarks/README.md
@@ -26,7 +26,7 @@ Current release health:
 |---|---|
 | Latest release guardrail | `PASS` |
 | Latest compare | `PASS=185, WARN=0, SKIP=0, FAIL=0` |
-| Promotion state | Current published tables are promoted from the April 21, 2026 release-core suite |
+| Promotion state | Current published tables are promoted from the April 26, 2026 release-core suite |
 | Durability default | CSharpDB values are durable unless a row explicitly says otherwise |
 
 ## Core Performance Scorecard
@@ -40,25 +40,25 @@ The generated block below contains the scorecard first, then the current core re
 
 | Field | Value |
 |---|---|
-| Published snapshot | April 21, 2026 release-core snapshot |
-| Run date | Release-core artifacts captured April 21, 2026; release guardrail compare captured April 22, 2026 UTC |
-| Promotion status | Promoted after release-core suite and release guardrail compare passed |
+| Published snapshot | April 26, 2026 release-core snapshot |
+| Run date | Release-core artifacts captured April 26, 2026 PT; release guardrail compare captured April 27, 2026 UTC |
+| Promotion status | Promoted after release-core suite and release guardrail compare passed; focused micro retry replaced volatile guardrail samples |
 | Latest release guardrail | PASS=185, WARN=0, SKIP=0, FAIL=0 |
-| Runner | Intel i9-11900K, 16 logical cores, Windows 10.0.26300, .NET SDK 10.0.202, .NET runtime 10.0.6 |
+| Runner | Intel i9-11900K, 16 logical cores, Windows 10.0.26300, .NET SDK 10.0.203, .NET runtime 10.0.7 |
 | Repro mode | priority=High, affinity=0xFF when captured with --repro |
-| Commit | 4e12bbe6eed58ffa7b7cf85371093008c292ec13 plus uncommitted release-prep fixes |
+| Commit | b7cb52ee2c30f31538e96480b6d055ff52439c26 plus uncommitted collection binary payload and benchmark updates |
 
 ### Approved Source Artifacts
 
 | Artifact | Command | Source CSV |
 |---|---|---|
-| `master` | `--master-table --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/master-table-20260421-212338-median-of-3.csv` |
-| `batching` | `--durable-sql-batching --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/durable-sql-batching-20260421-214227-median-of-3.csv` |
-| `concurrent` | `--concurrent-write-diagnostics --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/concurrent-write-diagnostics-20260421-220505-median-of-3.csv` |
-| `storage` | `--hybrid-storage-mode --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-storage-mode-20260421-221135-median-of-3.csv` |
-| `hotset` | `--hybrid-hot-set-read --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-hot-set-read-20260421-222712-median-of-3.csv` |
-| `coldopen` | `--hybrid-cold-open --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-cold-open-20260421-222743-median-of-3.csv` |
-| `sqlite` | `--sqlite-compare --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/sqlite-compare-20260421-222824-median-of-3.csv` |
+| `master` | `--master-table --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/master-table-20260426-215529-median-of-3.csv` |
+| `batching` | `--durable-sql-batching --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/durable-sql-batching-20260426-221413-median-of-3.csv` |
+| `concurrent` | `--concurrent-write-diagnostics --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/concurrent-write-diagnostics-20260426-223659-median-of-3.csv` |
+| `storage` | `--hybrid-storage-mode --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-storage-mode-20260426-224331-median-of-3.csv` |
+| `hotset` | `--hybrid-hot-set-read --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-hot-set-read-20260426-225908-median-of-3.csv` |
+| `coldopen` | `--hybrid-cold-open --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-cold-open-20260426-225949-median-of-3.csv` |
+| `sqlite` | `--sqlite-compare --repeat 3 --repro` | `tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/sqlite-compare-20260426-230045-median-of-3.csv` |
 
 ### Scorecard
 
@@ -66,16 +66,16 @@ These are the headline rows readers should use first. Detailed tables below map 
 
 | Area | Metric | Result | Source |
 |---|---|---|---|
-| Release health | Latest guardrail compare | PASS: PASS=185, FAIL=0 | `Run-Perf-Guardrails.ps1 -Mode release` |
-| SQL durable write | Single INSERT | 279.4 ops/sec | `master` |
-| SQL durable write | Batch x100 | 26.71K rows/sec | `master` |
-| SQL hot read | Point lookup | 1.33M ops/sec | `master` |
-| SQL concurrent read | 8 readers, reused snapshots x32 | 10.77M COUNT(*) ops/sec | `master` |
-| Collection hot read | Point Get | 1.67M ops/sec | `master` |
-| Single-writer ingest | InsertBatch B1000 | 204.03K rows/sec | `batching` |
-| Concurrent durable write | W8, 250us commit window | 1.04K commits/sec | `concurrent` |
-| Resident hot set | Hybrid hot-set SQL burst | 535.39K ops/sec | `hotset` |
-| Local SQLite reference | SQLite WAL+FULL B1000 | 192.06K rows/sec | `sqlite` |
+| Release health | Latest guardrail compare | PASS: PASS=185, FAIL=0 | `Compare-Baseline.ps1` after focused micro retry |
+| SQL durable write | Single INSERT | 450.4 ops/sec | `master` |
+| SQL durable write | Batch x100 | 41.88K rows/sec | `master` |
+| SQL hot read | Point lookup | 1.27M ops/sec | `master` |
+| SQL concurrent read | 8 readers, reused snapshots x32 | 9.97M COUNT(*) ops/sec | `master` |
+| Collection hot read | Point Get | 1.60M ops/sec | `master` |
+| Single-writer ingest | InsertBatch B1000 | 233.06K rows/sec | `batching` |
+| Concurrent durable write | W8, 250us commit window | 891.0 commits/sec | `concurrent` |
+| Resident hot set | Hybrid hot-set SQL burst | 311.62K ops/sec | `hotset` |
+| Local SQLite reference | SQLite WAL+FULL B1000 | 203.30K rows/sec | `sqlite` |
 
 ## Current Core Results
 
@@ -85,21 +85,21 @@ These detailed tables are generated from the approved source artifacts listed ab
 
 | Surface | Single write | Batch x100 | Point read | Concurrent read |
 |---|---|---|---|---|
-| SQL file-backed | 279.4 ops/sec | 26.71K rows/sec | 1.33M ops/sec | 10.77M COUNT(*) ops/sec |
-| SQL hybrid incremental-durable | 277.3 ops/sec | 26.19K rows/sec | 1.37M ops/sec | 10.35M COUNT(*) ops/sec |
-| SQL in-memory | 212.04K ops/sec | 889.37K rows/sec | 1.35M ops/sec | 10.71M COUNT(*) ops/sec |
-| Collection file-backed | 273.5 ops/sec | 25.92K docs/sec | 1.67M ops/sec | - |
-| Collection hybrid incremental-durable | 264.8 ops/sec | 25.02K docs/sec | 1.66M ops/sec | - |
-| Collection in-memory | 222.67K ops/sec | 912.56K docs/sec | 1.59M ops/sec | - |
+| SQL file-backed | 450.4 ops/sec | 41.88K rows/sec | 1.27M ops/sec | 9.97M COUNT(*) ops/sec |
+| SQL hybrid incremental-durable | 449.3 ops/sec | 41.77K rows/sec | 1.29M ops/sec | 10.27M COUNT(*) ops/sec |
+| SQL in-memory | 194.98K ops/sec | 708.75K rows/sec | 1.24M ops/sec | 10.09M COUNT(*) ops/sec |
+| Collection file-backed | 447.3 ops/sec | 42.28K docs/sec | 1.60M ops/sec | - |
+| Collection hybrid incremental-durable | 450.8 ops/sec | 42.34K docs/sec | 1.66M ops/sec | - |
+| Collection in-memory | 205.25K ops/sec | 872.89K docs/sec | 1.59M ops/sec | - |
 
 ### Single-Writer Durable Ingest
 
 | Batch shape | Rows/sec | P50 | P99 |
 |---|---|---|---|
-| InsertBatch B1 | 277.0 rows/sec | 3.4365 ms | 7.7126 ms |
-| InsertBatch B100 | 25.87K rows/sec | 3.6300 ms | 8.3708 ms |
-| InsertBatch B1000 | 204.03K rows/sec | 4.1034 ms | 9.5599 ms |
-| InsertBatch B10000 | 798.25K rows/sec | 8.7019 ms | 119.0664 ms |
+| InsertBatch B1 | 358.4 rows/sec | 2.7074 ms | 4.1941 ms |
+| InsertBatch B100 | 33.92K rows/sec | 2.7875 ms | 4.2581 ms |
+| InsertBatch B1000 | 233.06K rows/sec | 3.5123 ms | 7.7143 ms |
+| InsertBatch B10000 | 618.81K rows/sec | 10.9217 ms | 162.9867 ms |
 
 ### Concurrent Durable Writes
 
@@ -107,45 +107,45 @@ Each row is total successful commits/sec across one shared engine. The intended 
 
 | Scenario | Commits/sec | Commits/flush | P50 | P99 |
 |---|---|---|---|---|
-| W4, window 0 | 270.5 commits/sec | 1.00 | 14.2462 ms | 23.3782 ms |
-| W4, window 250us | 517.4 commits/sec | 1.99 | 7.3000 ms | 16.8764 ms |
-| W8, window 0 | 266.2 commits/sec | 1.00 | 29.7311 ms | 42.0490 ms |
-| W8, window 250us | 1.04K commits/sec | 3.98 | 7.3218 ms | 15.3828 ms |
+| W4, window 0 | 231.1 commits/sec | 1.00 | 17.0038 ms | 23.3867 ms |
+| W4, window 250us | 449.6 commits/sec | 1.99 | 8.6405 ms | 15.8344 ms |
+| W8, window 0 | 240.5 commits/sec | 1.00 | 32.8008 ms | 41.7800 ms |
+| W8, window 250us | 891.0 commits/sec | 3.92 | 8.4358 ms | 16.9718 ms |
 
 ### Storage Mode Hot Steady State
 
 | Mode | SQL insert | SQL batch x100 | SQL point lookup | Collection put | Collection batch x100 | Collection get |
 |---|---|---|---|---|---|---|
-| File-backed | 276.9 ops/sec | 26.09K rows/sec | 1.30M ops/sec | 263.3 ops/sec | 26.28K docs/sec | 1.58M ops/sec |
-| Hybrid incremental-durable | 266.5 ops/sec | 25.62K rows/sec | 1.32M ops/sec | 279.1 ops/sec | 26.40K docs/sec | 1.67M ops/sec |
-| In-memory | 217.87K ops/sec | 852.21K rows/sec | 1.29M ops/sec | 236.68K ops/sec | 911.14K docs/sec | 1.74M ops/sec |
+| File-backed | 383.4 ops/sec | 33.66K rows/sec | 777.29K ops/sec | 387.5 ops/sec | 34.87K docs/sec | 862.93K ops/sec |
+| Hybrid incremental-durable | 377.7 ops/sec | 33.97K rows/sec | 721.75K ops/sec | 379.1 ops/sec | 34.56K docs/sec | 864.55K ops/sec |
+| In-memory | 123.41K ops/sec | 449.84K rows/sec | 711.22K ops/sec | 124.92K ops/sec | 519.03K docs/sec | 872.07K ops/sec |
 
 ### Resident Hot-Set Reads
 
 | Mode | SQL hot burst | SQL P50 | Collection hot burst | Collection P50 |
 |---|---|---|---|---|
-| File-backed | 41.41K ops/sec | 0.0257 ms | 38.17K ops/sec | 0.0270 ms |
-| Hybrid incremental-durable | 36.25K ops/sec | 0.0267 ms | 43.53K ops/sec | 0.0226 ms |
-| Hybrid hot-set incremental-durable | 535.39K ops/sec | 0.0012 ms | 761.72K ops/sec | 0.0011 ms |
-| In-memory | 94.14K ops/sec | 0.0020 ms | 99.35K ops/sec | 0.0021 ms |
+| File-backed | 27.88K ops/sec | 0.0346 ms | 28.98K ops/sec | 0.0329 ms |
+| Hybrid incremental-durable | 27.16K ops/sec | 0.0366 ms | 29.22K ops/sec | 0.0341 ms |
+| Hybrid hot-set incremental-durable | 311.62K ops/sec | 0.0031 ms | 295.45K ops/sec | 0.0029 ms |
+| In-memory | 84.82K ops/sec | 0.0049 ms | 122.39K ops/sec | 0.0044 ms |
 
 ### Cold Open And First Read
 
 | Mode | SQL open+first lookup P50 | Collection open+first get P50 |
 |---|---|---|
-| File-backed | 13.8203 ms | 13.2537 ms |
-| Hybrid incremental-durable | 13.4234 ms | 13.4727 ms |
-| Hybrid hot-set incremental-durable | 57.0473 ms | 81.2153 ms |
-| In-memory | 8.0593 ms | 12.0583 ms |
+| File-backed | 18.1275 ms | 20.0627 ms |
+| Hybrid incremental-durable | 19.9048 ms | 19.4950 ms |
+| Hybrid hot-set incremental-durable | 89.5360 ms | 134.5282 ms |
+| In-memory | 15.8719 ms | 21.7409 ms |
 
 ### Local SQLite Matched Rows
 
 | Engine / row | Throughput | P50 | P99 |
 |---|---|---|---|
-| CSharpDB InsertBatch B1000 | 204.03K rows/sec | 4.1034 ms | 9.5599 ms |
-| SQLite WAL+FULL prepared B1000 | 192.06K rows/sec | 4.7479 ms | 18.1078 ms |
-| CSharpDB SQL point lookup | 1.33M ops/sec | 0.0005 ms | 0.0021 ms |
-| SQLite WAL+FULL point lookup | 138.33K ops/sec | 0.0058 ms | 0.0188 ms |
+| CSharpDB InsertBatch B1000 | 233.06K rows/sec | 3.5123 ms | 7.7143 ms |
+| SQLite WAL+FULL prepared B1000 | 203.30K rows/sec | 4.6622 ms | 22.0984 ms |
+| CSharpDB SQL point lookup | 1.27M ops/sec | 0.0005 ms | 0.0026 ms |
+| SQLite WAL+FULL point lookup | 70.21K ops/sec | 0.0119 ms | 0.0369 ms |
 <!-- BENCHMARK_RESULTS_END -->
 
 ## Core Benchmark Map

--- a/tests/CSharpDB.Benchmarks/release-core-manifest.json
+++ b/tests/CSharpDB.Benchmarks/release-core-manifest.json
@@ -1,49 +1,49 @@
 {
   "schemaVersion": 1,
   "metadata": {
-    "Published snapshot": "April 21, 2026 release-core snapshot",
-    "Run date": "Release-core artifacts captured April 21, 2026; release guardrail compare captured April 22, 2026 UTC",
-    "Promotion status": "Promoted after release-core suite and release guardrail compare passed",
+    "Published snapshot": "April 26, 2026 release-core snapshot",
+    "Run date": "Release-core artifacts captured April 26, 2026 PT; release guardrail compare captured April 27, 2026 UTC",
+    "Promotion status": "Promoted after release-core suite and release guardrail compare passed; focused micro retry replaced volatile guardrail samples",
     "Latest release guardrail": "PASS=185, WARN=0, SKIP=0, FAIL=0",
-    "Runner": "Intel i9-11900K, 16 logical cores, Windows 10.0.26300, .NET SDK 10.0.202, .NET runtime 10.0.6",
+    "Runner": "Intel i9-11900K, 16 logical cores, Windows 10.0.26300, .NET SDK 10.0.203, .NET runtime 10.0.7",
     "Repro mode": "priority=High, affinity=0xFF when captured with --repro",
-    "Commit": "4e12bbe6eed58ffa7b7cf85371093008c292ec13 plus uncommitted release-prep fixes"
+    "Commit": "b7cb52ee2c30f31538e96480b6d055ff52439c26 plus uncommitted collection binary payload and benchmark updates"
   },
   "artifacts": [
     {
       "id": "master",
       "command": "--master-table --repeat 3 --repro",
-      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/master-table-20260421-212338-median-of-3.csv"
+      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/master-table-20260426-215529-median-of-3.csv"
     },
     {
       "id": "batching",
       "command": "--durable-sql-batching --repeat 3 --repro",
-      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/durable-sql-batching-20260421-214227-median-of-3.csv"
+      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/durable-sql-batching-20260426-221413-median-of-3.csv"
     },
     {
       "id": "concurrent",
       "command": "--concurrent-write-diagnostics --repeat 3 --repro",
-      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/concurrent-write-diagnostics-20260421-220505-median-of-3.csv"
+      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/concurrent-write-diagnostics-20260426-223659-median-of-3.csv"
     },
     {
       "id": "storage",
       "command": "--hybrid-storage-mode --repeat 3 --repro",
-      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-storage-mode-20260421-221135-median-of-3.csv"
+      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-storage-mode-20260426-224331-median-of-3.csv"
     },
     {
       "id": "hotset",
       "command": "--hybrid-hot-set-read --repeat 3 --repro",
-      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-hot-set-read-20260421-222712-median-of-3.csv"
+      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-hot-set-read-20260426-225908-median-of-3.csv"
     },
     {
       "id": "coldopen",
       "command": "--hybrid-cold-open --repeat 3 --repro",
-      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-cold-open-20260421-222743-median-of-3.csv"
+      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/hybrid-cold-open-20260426-225949-median-of-3.csv"
     },
     {
       "id": "sqlite",
       "command": "--sqlite-compare --repeat 3 --repro",
-      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/sqlite-compare-20260421-222824-median-of-3.csv"
+      "path": "tests/CSharpDB.Benchmarks/bin/Release/net10.0/results/sqlite-compare-20260426-230045-median-of-3.csv"
     }
   ],
   "sections": [
@@ -59,7 +59,7 @@
             { "value": "Release health" },
             { "value": "Latest guardrail compare" },
             { "value": "PASS: PASS=185, FAIL=0" },
-            { "value": "`Run-Perf-Guardrails.ps1 -Mode release`" }
+            { "value": "`Compare-Baseline.ps1` after focused micro retry" }
           ]
         },
         {

--- a/tests/CSharpDB.Tests/CollectionBinaryDocumentCodecTests.cs
+++ b/tests/CSharpDB.Tests/CollectionBinaryDocumentCodecTests.cs
@@ -198,6 +198,12 @@ public sealed class CollectionBinaryDocumentCodecTests
                 [System.Text.Encoding.UTF8.GetBytes("city")],
                 out string? city));
         Assert.Equal("Seattle", city);
+        Assert.True(
+            CollectionBinaryDocumentCodec.TryReadStringUtf8(
+                nestedDocument,
+                [System.Text.Encoding.UTF8.GetBytes("city")],
+                out ReadOnlySpan<byte> cityUtf8));
+        Assert.Equal("Seattle", System.Text.Encoding.UTF8.GetString(cityUtf8));
     }
 
     [Fact]

--- a/tests/CSharpDB.Tests/GeneratedCollectionModelTests.cs
+++ b/tests/CSharpDB.Tests/GeneratedCollectionModelTests.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text;
 using System.Diagnostics.CodeAnalysis;
 using CSharpDB.Engine;
+using CSharpDB.Primitives;
 using CSharpDB.Storage.Serialization;
 
 namespace CSharpDB.Tests;
@@ -25,6 +27,134 @@ public sealed class GeneratedCollectionModelTests
         Assert.Single(matches);
         Assert.Equal("u1", matches[0].Key);
         Assert.Equal("alpha@example.com", matches[0].Value.Email);
+    }
+
+    [Fact]
+    public void GeneratedCollectionModel_EncodesGeneratedDirectPayloadsAsBinary()
+    {
+        var codec = new CollectionDocumentCodec<GeneratedUser>(new DefaultRecordSerializer());
+        var expected = new GeneratedUser("alpha@example.com", 30);
+
+        byte[] payload = codec.Encode("u1", expected);
+        var actual = codec.Decode(payload);
+
+        Assert.True(CollectionPayloadCodec.IsDirectPayload(payload));
+        Assert.True(CollectionPayloadCodec.IsBinaryPayload(payload));
+        Assert.Equal("u1", actual.Key);
+        Assert.Equal(expected, actual.Document);
+    }
+
+    [Fact]
+    public void GeneratedCollectionModel_BinaryPayloadUsesCompactRecordFormat()
+    {
+        var codec = new CollectionDocumentCodec<GeneratedUser>(new DefaultRecordSerializer());
+        var expected = new GeneratedUser("alpha@example.com", 30);
+
+        byte[] payload = codec.Encode("u1", expected);
+        ReadOnlySpan<byte> documentPayload = CollectionPayloadCodec.GetBinaryDocumentPayload(payload);
+
+        Assert.Equal(0xD0, documentPayload[0]);
+        Assert.Equal(0xF0, documentPayload[1]);
+        Assert.Equal(0x01, documentPayload[2]);
+        Assert.True(documentPayload.Length < 32);
+        Assert.Equal(expected, codec.DecodeDocument(payload));
+    }
+
+    [Fact]
+    public void GeneratedCollectionModel_PayloadMatchesKey_UsesDirectUtf8KeyComparison()
+    {
+        var codec = new CollectionDocumentCodec<GeneratedUser>(new DefaultRecordSerializer());
+
+        byte[] payload = codec.Encode("u:é", new GeneratedUser("alpha@example.com", 30));
+
+        Assert.True(codec.PayloadMatchesKey(payload, "u:é"));
+        Assert.False(codec.PayloadMatchesKey(payload, "u:e"));
+        Assert.True(CollectionPayloadCodec.TryDirectPayloadKeyEquals(payload, "u:é", out bool equals));
+        Assert.True(equals);
+    }
+
+    [Fact]
+    public void GeneratedCollectionModel_GeneratedFieldsReadDirectBinaryPayloads()
+    {
+        var codec = new CollectionDocumentCodec<GeneratedUser>(new DefaultRecordSerializer());
+        byte[] payload = codec.Encode("u1", new GeneratedUser("alpha@example.com", 30));
+
+        Assert.True(GeneratedUser.Collection.Age.TryReadPayloadInt64(payload, out long age));
+        Assert.Equal(30, age);
+        Assert.True(GeneratedUser.Collection.Age.TryReadPayloadValue(payload, out DbValue ageValue));
+        Assert.Equal(DbType.Integer, ageValue.Type);
+        Assert.Equal(30, ageValue.AsInteger);
+
+        Assert.True(GeneratedUser.Collection.Email.TryReadPayloadString(payload, out string? email));
+        Assert.Equal("alpha@example.com", email);
+        Assert.True(GeneratedUser.Collection.Email.TryReadPayloadStringUtf8(payload, out ReadOnlySpan<byte> emailUtf8));
+        Assert.Equal("alpha@example.com", Encoding.UTF8.GetString(emailUtf8));
+        Assert.True(GeneratedUser.Collection.Email.TryReadPayloadValue(payload, out DbValue emailValue));
+        Assert.Equal(DbType.Text, emailValue.Type);
+        Assert.Equal("alpha@example.com", emailValue.AsText);
+    }
+
+    [Fact]
+    public void GeneratedCollectionModel_GeneratedNestedFieldsReadDirectBinaryPayloads()
+    {
+        var codec = new CollectionDocumentCodec<NestedGeneratedUser>(new DefaultRecordSerializer());
+        byte[] payload = codec.Encode("u1", new NestedGeneratedUser("Alice", new NestedGeneratedAddress("Seattle", 98101)));
+
+        Assert.True(NestedGeneratedUser.Collection.Address_ZipCode.TryReadPayloadInt64(payload, out long zipCode));
+        Assert.Equal(98101, zipCode);
+        Assert.True(NestedGeneratedUser.Collection.Address_City.TryReadPayloadString(payload, out string? city));
+        Assert.Equal("Seattle", city);
+        Assert.True(NestedGeneratedUser.Collection.Address_City.TryReadPayloadStringUtf8(payload, out ReadOnlySpan<byte> cityUtf8));
+        Assert.Equal("Seattle", Encoding.UTF8.GetString(cityUtf8));
+    }
+
+    [Fact]
+    public void GeneratedCollectionModel_BinaryPayloadHonorsJsonPropertyNameAttributes()
+    {
+        var codec = new CollectionDocumentCodec<RenamedGeneratedUser>(new DefaultRecordSerializer());
+
+        byte[] payload = codec.Encode("u1", new RenamedGeneratedUser("alpha@example.com", 24));
+        var actual = codec.DecodeDocument(payload);
+
+        Assert.True(CollectionPayloadCodec.IsBinaryPayload(payload));
+        Assert.Equal("alpha@example.com", actual.Email);
+        Assert.Equal(24, actual.Age);
+        Assert.True(RenamedGeneratedUser.Collection.Email.TryReadPayloadString(payload, out string? email));
+        Assert.Equal("alpha@example.com", email);
+        Assert.True(RenamedGeneratedUser.Collection.Age.TryReadPayloadInt64(payload, out long age));
+        Assert.Equal(24, age);
+    }
+
+    [Fact]
+    public void GeneratedCollectionModel_KeepsJsonPayloadForUnsupportedBinaryShapes()
+    {
+        var codec = new CollectionDocumentCodec<DateTimeGeneratedUser>(new DefaultRecordSerializer());
+        var expected = new DateTimeGeneratedUser(
+            "alpha@example.com",
+            new DateTime(2026, 4, 26, 12, 30, 0, DateTimeKind.Utc));
+
+        byte[] payload = codec.Encode("u1", expected);
+        var actual = codec.Decode(payload);
+
+        Assert.True(CollectionPayloadCodec.IsDirectPayload(payload));
+        Assert.False(CollectionPayloadCodec.IsBinaryPayload(payload));
+        Assert.Equal("u1", actual.Key);
+        Assert.Equal(expected, actual.Document);
+    }
+
+    [Fact]
+    public void GeneratedCollectionModel_KeepsJsonPayloadForSinglePassEnumerableShapes()
+    {
+        var codec = new CollectionDocumentCodec<EnumerableGeneratedUser>(new DefaultRecordSerializer());
+
+        byte[] payload = codec.Encode("u1", new EnumerableGeneratedUser("Alice", ["alpha", "beta"]));
+        var actual = codec.Decode(payload);
+
+        Assert.True(CollectionPayloadCodec.IsDirectPayload(payload));
+        Assert.False(CollectionPayloadCodec.IsBinaryPayload(payload));
+        Assert.Equal("u1", actual.Key);
+        Assert.Equal("Alice", actual.Document.Name);
+        Assert.Equal(["alpha", "beta"], actual.Document.Tags);
     }
 
     [Fact]
@@ -449,6 +579,11 @@ internal sealed partial record GeneratedUser(string Email, int Age);
 
 internal sealed record UnannotatedGeneratedCollectionUser(string Email);
 
+#pragma warning disable CDBGEN007
+[CollectionModel(typeof(DateTimeGeneratedUserJsonContext))]
+internal sealed partial record DateTimeGeneratedUser(string Email, DateTime UpdatedAt);
+#pragma warning restore CDBGEN007
+
 [CollectionModel(typeof(RenamedGeneratedUserJsonContext))]
 internal sealed partial record RenamedGeneratedUser(
     [property: JsonPropertyName("email_address")] string Email,
@@ -456,6 +591,9 @@ internal sealed partial record RenamedGeneratedUser(
 
 [CollectionModel(typeof(TaggedGeneratedUserJsonContext))]
 internal sealed partial record TaggedGeneratedUser(string Name, IReadOnlyList<string> Tags);
+
+[CollectionModel(typeof(EnumerableGeneratedUserJsonContext))]
+internal sealed partial record EnumerableGeneratedUser(string Name, IEnumerable<string> Tags);
 
 [CollectionModel(typeof(NestedGeneratedUserJsonContext))]
 internal sealed partial record NestedGeneratedUser(string Name, NestedGeneratedAddress Address);
@@ -481,12 +619,20 @@ internal sealed partial record ManualLinkedUser(string Name, ManualLinkedUser? N
 internal sealed partial class GeneratedUserGeneratedJsonContext : JsonSerializerContext;
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(DateTimeGeneratedUser))]
+internal sealed partial class DateTimeGeneratedUserJsonContext : JsonSerializerContext;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(RenamedGeneratedUser))]
 internal sealed partial class RenamedGeneratedUserJsonContext : JsonSerializerContext;
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(TaggedGeneratedUser))]
 internal sealed partial class TaggedGeneratedUserJsonContext : JsonSerializerContext;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(EnumerableGeneratedUser))]
+internal sealed partial class EnumerableGeneratedUserJsonContext : JsonSerializerContext;
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(NestedGeneratedUser))]

--- a/tests/CSharpDB.Tests/OrderedTextIndexKeyCodecTests.cs
+++ b/tests/CSharpDB.Tests/OrderedTextIndexKeyCodecTests.cs
@@ -25,6 +25,7 @@ public sealed class OrderedTextIndexKeyCodecTests
         long expected = ComputeReferenceKey(text);
 
         Assert.Equal(expected, OrderedTextIndexKeyCodec.ComputeKey(text));
+        Assert.Equal(expected, OrderedTextIndexKeyCodec.ComputeKey(Encoding.UTF8.GetBytes(text)));
     }
 
     private static long ComputeReferenceKey(string text)

--- a/www/admin-ui-mockups/command-palette.html
+++ b/www/admin-ui-mockups/command-palette.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Command Palette — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    .sidebar { padding: 10px; font-size: 12px; color: var(--text-secondary); filter: blur(2px); opacity: 0.6; }
+    .sidebar .grp { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; padding: 8px 6px 4px; }
+    .sidebar .it { padding: 4px 6px; display: flex; align-items: center; gap: 6px; }
+
+    /* dim the rest of the app while palette is open */
+    .titlebar, .tabstrip, .body, .statusbar { filter: blur(2px); }
+    .body { pointer-events: none; }
+    .scrim {
+        position: fixed; inset: 0;
+        background: rgba(10, 11, 19, 0.55);
+        z-index: 90;
+    }
+
+    /* Palette modal */
+    .palette {
+        position: fixed;
+        top: 14vh;
+        left: 50%;
+        transform: translateX(-50%);
+        width: min(640px, 92vw);
+        background: var(--bg-elevated);
+        border: 1px solid var(--border-light);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-popup);
+        z-index: 100;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        max-height: 70vh;
+    }
+
+    .palette-search {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 14px 18px;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .palette-search .bi-search { color: var(--text-muted); font-size: 16px; }
+    .palette-search input {
+        flex: 1;
+        background: transparent;
+        border: none;
+        outline: none;
+        color: var(--text-primary);
+        font-size: 15px;
+        font-family: var(--font-ui);
+    }
+    .palette-search input::placeholder { color: var(--text-muted); }
+    .palette-search .esc { color: var(--text-muted); font-size: 11px; }
+
+    /* Filter chips */
+    .chips {
+        display: flex;
+        gap: 6px;
+        padding: 10px 18px;
+        border-bottom: 1px solid var(--border-color);
+        flex-wrap: wrap;
+    }
+    .chip {
+        padding: 3px 10px;
+        font-size: 11px;
+        border: 1px solid var(--border-color);
+        border-radius: 999px;
+        color: var(--text-secondary);
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+    }
+    .chip:hover { border-color: var(--border-light); color: var(--text-primary); }
+    .chip.active {
+        background: rgba(122,162,247,0.12);
+        border-color: rgba(122,162,247,0.4);
+        color: var(--accent-blue);
+        font-weight: 600;
+    }
+
+    /* Result groups */
+    .results {
+        overflow-y: auto;
+        padding: 8px 0 12px;
+        flex: 1;
+    }
+    .group-label {
+        padding: 8px 18px 4px;
+        color: var(--text-muted);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+    }
+    .res {
+        display: grid;
+        grid-template-columns: 28px 1fr auto;
+        align-items: center;
+        gap: 12px;
+        padding: 9px 18px;
+        cursor: pointer;
+    }
+    .res:hover { background: var(--bg-hover); }
+    .res.selected {
+        background: rgba(122,162,247,0.12);
+        border-left: 2px solid var(--accent-blue);
+        padding-left: 16px;
+    }
+    .res .ico {
+        width: 24px; height: 24px;
+        border-radius: 6px;
+        display: grid; place-items: center;
+        font-size: 12px;
+        background: var(--bg-tertiary);
+    }
+    .res .label { font-size: 13px; color: var(--text-primary); }
+    .res .label .hint { color: var(--text-muted); font-size: 11px; margin-left: 6px; font-family: var(--font-mono); }
+    .res .label mark {
+        background: rgba(122,162,247,0.18);
+        color: var(--accent-blue);
+        padding: 0 2px;
+        border-radius: 2px;
+    }
+    .res .right { display: flex; gap: 4px; align-items: center; }
+    .res .badge {
+        font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px;
+        padding: 2px 6px; border-radius: 4px;
+        background: rgba(122,162,247,0.12); color: var(--accent-blue);
+        font-weight: 600;
+    }
+    .res .badge.action { background: rgba(187,154,247,0.12); color: var(--accent-magenta); }
+    .res .badge.form { background: rgba(187,154,247,0.12); color: var(--accent-magenta); }
+    .res .badge.report { background: rgba(125,207,255,0.12); color: var(--accent-cyan); }
+    .res .badge.proc { background: rgba(255,158,100,0.12); color: var(--accent-orange); }
+
+    /* Footer */
+    .palette-foot {
+        padding: 10px 18px;
+        border-top: 1px solid var(--border-color);
+        display: flex;
+        gap: 16px;
+        font-size: 11px;
+        color: var(--text-muted);
+        background: var(--bg-secondary);
+    }
+    .palette-foot .group { display: inline-flex; align-items: center; gap: 5px; }
+</style>
+</head>
+<body>
+<div class="app">
+
+    <!-- TITLEBAR (dimmed background) -->
+    <div class="titlebar">
+        <div class="brand">
+            <div class="logo">C#</div>
+            <span>CSharpDB Studio</span>
+            <span class="dbname">— relational.db</span>
+        </div>
+        <button class="db-switcher"><i class="bi bi-database"></i> relational.db <i class="bi bi-caret-down-fill"></i></button>
+        <button class="palette-launcher"><i class="bi bi-search"></i> Search anything… <span class="kbd">Ctrl K</span></button>
+        <div class="spacer"></div>
+        <span class="conn-pill"><span class="dot"></span> Connected</span>
+    </div>
+
+    <div class="body">
+        <aside class="sidebar">
+            <div class="grp">★ Pinned</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Orders</div>
+            <div class="grp">▾ Tables · 24</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Orders</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Invoices</div>
+        </aside>
+        <div class="content">
+            <div class="tabstrip">
+                <div class="tab active"><i class="bi bi-grid-1x2 icon-table"></i> Dashboard</div>
+                <div class="tab"><i class="bi bi-table icon-table"></i> Customers <i class="bi bi-x"></i></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="statusbar">
+        <span class="pill ok"><span class="dot"></span> Connected</span>
+    </div>
+</div>
+
+<!-- Scrim overlay -->
+<div class="scrim"></div>
+
+<!-- Command palette modal -->
+<div class="palette">
+    <div class="palette-search">
+        <i class="bi bi-search"></i>
+        <input value="cust" placeholder="Search tables, forms, reports, procedures, or actions…" />
+        <span class="esc kbd">Esc</span>
+    </div>
+
+    <div class="chips">
+        <span class="chip active">All</span>
+        <span class="chip"><i class="bi bi-lightning"></i> Actions</span>
+        <span class="chip"><i class="bi bi-table icon-table"></i> Tables · 4</span>
+        <span class="chip"><i class="bi bi-eye icon-view"></i> Views · 1</span>
+        <span class="chip"><i class="bi bi-ui-checks-grid icon-form"></i> Forms · 2</span>
+        <span class="chip"><i class="bi bi-file-earmark-richtext icon-report"></i> Reports · 1</span>
+        <span class="chip"><i class="bi bi-gear-wide-connected icon-trigger"></i> Procedures · 1</span>
+    </div>
+
+    <div class="results">
+
+        <div class="group-label">Tables</div>
+        <div class="res selected">
+            <div class="ico"><i class="bi bi-table icon-table"></i></div>
+            <div class="label"><mark>Cust</mark>omers <span class="hint">1,247 rows</span></div>
+            <div class="right">
+                <span class="badge">Open</span>
+                <span class="kbd">↵</span>
+            </div>
+        </div>
+        <div class="res">
+            <div class="ico"><i class="bi bi-table icon-table"></i></div>
+            <div class="label"><mark>Cust</mark>omerAddresses <span class="hint">2,109 rows</span></div>
+            <div class="right"><span class="badge">Open</span></div>
+        </div>
+        <div class="res">
+            <div class="ico"><i class="bi bi-table icon-table"></i></div>
+            <div class="label"><mark>Cust</mark>omerNotes <span class="hint">514 rows</span></div>
+            <div class="right"><span class="badge">Open</span></div>
+        </div>
+
+        <div class="group-label">Forms</div>
+        <div class="res">
+            <div class="ico"><i class="bi bi-ui-checks-grid icon-form"></i></div>
+            <div class="label"><mark>Cust</mark>omer Form <span class="hint">→ Customers</span></div>
+            <div class="right"><span class="badge form">Form</span></div>
+        </div>
+
+        <div class="group-label">Reports</div>
+        <div class="res">
+            <div class="ico"><i class="bi bi-file-earmark-richtext icon-report"></i></div>
+            <div class="label"><mark>Cust</mark>omer Sales Report <span class="hint">→ vw_customer_sales</span></div>
+            <div class="right"><span class="badge report">Report</span></div>
+        </div>
+
+        <div class="group-label">Procedures</div>
+        <div class="res">
+            <div class="ico"><i class="bi bi-gear-wide-connected icon-trigger"></i></div>
+            <div class="label">recalc_<mark>cust</mark>omer_balances</div>
+            <div class="right"><span class="badge proc">Proc</span></div>
+        </div>
+
+        <div class="group-label">Actions</div>
+        <div class="res">
+            <div class="ico"><i class="bi bi-terminal" style="color: var(--accent-blue);"></i></div>
+            <div class="label">Run: <code style="font-family: var(--font-mono); color: var(--accent-green);">SELECT * FROM Customers LIMIT 50</code></div>
+            <div class="right">
+                <span class="badge action">Action</span>
+                <span class="kbd">Ctrl ↵</span>
+            </div>
+        </div>
+        <div class="res">
+            <div class="ico"><i class="bi bi-plus-lg" style="color: var(--accent-magenta);"></i></div>
+            <div class="label">New Form for <b>Customers</b></div>
+            <div class="right"><span class="badge action">Action</span></div>
+        </div>
+        <div class="res">
+            <div class="ico"><i class="bi bi-trash3" style="color: var(--accent-red);"></i></div>
+            <div class="label">Drop table <b>Customers</b><span class="hint">requires confirm</span></div>
+            <div class="right"><span class="badge action" style="background: rgba(247,118,142,0.12); color: var(--accent-red);">Danger</span></div>
+        </div>
+
+    </div>
+
+    <div class="palette-foot">
+        <span class="group"><span class="kbd">↑</span><span class="kbd">↓</span> Navigate</span>
+        <span class="group"><span class="kbd">↵</span> Open</span>
+        <span class="group"><span class="kbd">Ctrl ↵</span> Open in new tab</span>
+        <span class="group"><span class="kbd">Tab</span> Filter by type</span>
+        <span class="group"><span class="kbd">Esc</span> Dismiss</span>
+        <div style="flex:1"></div>
+        <span>9 results in 3 ms</span>
+    </div>
+</div>
+
+<!-- Annotations -->
+<div class="notes">
+    <header><i class="bi bi-lightbulb"></i> Reality check vs. the live screen</header>
+    <ul>
+        <li><b style="color: var(--accent-green);">ALREADY EXISTS</b> — sidebar text-filter input that narrows the visible tree (case-insensitive substring match), keyboard shortcuts Ctrl+N (new query) / Ctrl+B (toggle sidebar) / Ctrl+Enter (run query) / Ctrl+W (close tab) / Ctrl+Shift+L (theme), right-click context menus on every object kind with "Open / Design / Select Top 50 / Drop" actions, modal confirm for danger ops, autocomplete inside the SQL editor.</li>
+        <li><b style="color: var(--accent-red);">DOES NOT EXIST TODAY</b> — there is no Ctrl+K palette or any global "search anything" entry point. Users must locate items via the sidebar tree or open them from a tab.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Ctrl+K palette</b> — fuzzy search across tables, views, forms, reports, procedures, and saved queries in one input.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Action items inline</b> — "Run: SELECT TOP 50 FROM X", "New Form for X", "Drop X". Surfaces what's currently buried in right-click menus.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Type filter chips</b> with keyboard Tab cycling.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Title-bar launcher</b> ("Search anything…") for discoverability.</li>
+        <li><span class="pin"></span> Danger actions still route through the existing <code>Modal.ConfirmAsync</code> with <code>isDanger:true</code> — reuses what's there.</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/dashboard.html
+++ b/www/admin-ui-mockups/dashboard.html
@@ -1,0 +1,504 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Dashboard — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    /* Compact sidebar so the dashboard is the focus */
+    .sidebar { padding: 10px; font-size: 12px; color: var(--text-secondary); }
+    .sidebar .grp { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; padding: 8px 6px 4px; }
+    .sidebar .it { padding: 4px 6px; display: flex; align-items: center; gap: 6px; border-radius: 4px; cursor: pointer; }
+    .sidebar .it:hover { background: var(--bg-hover); color: var(--text-primary); }
+    .sidebar .it i { font-size: 13px; }
+
+    /* Dashboard layout */
+    .dash {
+        padding: 22px 28px 60px;
+        max-width: 1280px;
+        width: 100%;
+    }
+    .dash-header {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        margin-bottom: 22px;
+    }
+    .dash-header h1 { font-size: 22px; font-weight: 700; letter-spacing: -0.01em; }
+    .dash-header .crumb { color: var(--text-muted); font-size: 12px; margin-bottom: 4px; }
+    .dash-header .actions { display: flex; gap: 8px; }
+
+    /* Stat row */
+    .stats {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 12px;
+        margin-bottom: 22px;
+    }
+    .stat {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        padding: 14px 16px;
+        position: relative;
+    }
+    .stat .label { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; }
+    .stat .value { font-size: 26px; font-weight: 700; margin-top: 4px; letter-spacing: -0.02em; color: var(--text-primary); }
+    .stat .delta { font-size: 11px; margin-top: 4px; }
+    .stat .delta.up { color: var(--accent-green); }
+    .stat .delta.dn { color: var(--accent-red); }
+    .stat .icon { position: absolute; top: 14px; right: 16px; font-size: 18px; opacity: 0.45; }
+
+    .stat .bar { background: var(--bg-tertiary); border-radius: 4px; height: 6px; margin-top: 10px; overflow: hidden; }
+    .stat .bar > span { display: block; height: 100%; background: var(--accent-blue); border-radius: 4px; }
+    .stat .bar.warn > span { background: var(--accent-yellow); }
+    .stat .meta { color: var(--text-muted); font-size: 11px; margin-top: 6px; display: flex; justify-content: space-between; }
+
+    /* Two-column body */
+    .grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 18px;
+    }
+
+    .panel {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+    }
+    .panel header {
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .panel h3 { font-size: 13px; font-weight: 600; }
+    .panel header .more { color: var(--text-muted); font-size: 11px; cursor: pointer; }
+    .panel header .more:hover { color: var(--text-primary); }
+
+    /* Top tables */
+    .tt-row {
+        display: grid;
+        grid-template-columns: 1fr 80px 100px 36px;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--border-color);
+        font-size: 12px;
+    }
+    .tt-row:last-child { border-bottom: none; }
+    .tt-row .tname { display: flex; align-items: center; gap: 8px; color: var(--text-primary); }
+    .tt-row .tname .bi { color: var(--accent-blue); }
+    .tt-row .rows { color: var(--text-secondary); text-align: right; font-variant-numeric: tabular-nums; }
+    .tt-row .spark { display: flex; align-items: end; gap: 2px; height: 18px; }
+    .tt-row .spark span { width: 4px; background: var(--accent-blue); opacity: 0.6; border-radius: 1px; }
+    .tt-row .open { color: var(--text-muted); cursor: pointer; text-align: right; }
+    .tt-row .open:hover { color: var(--accent-blue); }
+
+    /* Activity feed */
+    .act-row {
+        display: grid;
+        grid-template-columns: 28px 1fr 80px;
+        align-items: start;
+        gap: 10px;
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--border-color);
+        font-size: 12px;
+    }
+    .act-row:last-child { border-bottom: none; }
+    .act-row .ico {
+        width: 24px; height: 24px;
+        border-radius: 6px;
+        display: grid; place-items: center;
+        font-size: 12px;
+    }
+    .act-row .ico.q { background: rgba(122,162,247,0.12); color: var(--accent-blue); }
+    .act-row .ico.e { background: rgba(187,154,247,0.12); color: var(--accent-magenta); }
+    .act-row .ico.s { background: rgba(158,206,106,0.12); color: var(--accent-green); }
+    .act-row .ico.w { background: rgba(247,118,142,0.12); color: var(--accent-red); }
+    .act-row .body .title { color: var(--text-primary); }
+    .act-row .body .sub { color: var(--text-muted); font-size: 11px; margin-top: 2px; font-family: var(--font-mono); }
+    .act-row .when { color: var(--text-muted); font-size: 11px; text-align: right; }
+
+    /* Pinned grid */
+    .pinned {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+        padding: 12px;
+    }
+    .pin {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-md);
+        padding: 9px 11px;
+        font-size: 12px;
+        cursor: pointer;
+    }
+    .pin:hover { border-color: var(--border-light); background: var(--bg-hover); }
+    .pin .bi { font-size: 14px; }
+
+    /* Quick actions */
+    .qa {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+        padding: 12px;
+    }
+    .qa-btn {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        align-items: flex-start;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-md);
+        padding: 12px;
+        cursor: pointer;
+        font-size: 12px;
+        color: var(--text-primary);
+    }
+    .qa-btn:hover { background: var(--bg-hover); border-color: var(--border-light); }
+    .qa-btn .ico { font-size: 16px; color: var(--accent-blue); }
+    .qa-btn .sub { color: var(--text-muted); font-size: 11px; }
+    .qa-btn .kbd { margin-top: 2px; font-size: 9px; }
+
+    /* Health */
+    .health {
+        padding: 12px 16px;
+    }
+    .h-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 6px 0;
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border-color);
+    }
+    .h-row:last-child { border-bottom: none; }
+    .h-row .lbl { color: var(--text-secondary); }
+    .h-row .val { font-variant-numeric: tabular-nums; color: var(--text-primary); }
+    .h-row .val.warn { color: var(--accent-yellow); }
+    .h-row .val.ok { color: var(--accent-green); }
+</style>
+</head>
+<body>
+<div class="app">
+
+    <!-- TITLEBAR -->
+    <div class="titlebar">
+        <div class="brand">
+            <div class="logo">C#</div>
+            <span>CSharpDB Studio</span>
+            <span class="dbname">— relational.db</span>
+        </div>
+        <button class="db-switcher">
+            <i class="bi bi-database"></i> relational.db
+            <i class="bi bi-caret-down-fill"></i>
+        </button>
+        <button class="palette-launcher">
+            <i class="bi bi-search"></i> Search anything…
+            <span class="kbd">Ctrl K</span>
+        </button>
+        <div class="tb-actions">
+            <button class="tb-btn"><i class="bi bi-plus"></i> New Query</button>
+            <button class="tb-btn"><i class="bi bi-table"></i> New Table</button>
+            <button class="tb-btn"><i class="bi bi-ui-checks-grid"></i> New Form</button>
+        </div>
+        <div class="spacer"></div>
+        <span class="conn-pill"><span class="dot"></span> Connected</span>
+        <button class="tb-btn icon-only" title="Theme"><i class="bi bi-moon-stars"></i></button>
+        <button class="tb-btn icon-only" title="Sidebar"><i class="bi bi-layout-sidebar-inset"></i></button>
+        <button class="tb-btn icon-only" title="Help"><i class="bi bi-keyboard"></i></button>
+    </div>
+
+    <!-- BODY -->
+    <div class="body">
+        <!-- Mini sidebar -->
+        <aside class="sidebar">
+            <div class="grp">★ Pinned</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Orders</div>
+            <div class="grp">⏱ Recent</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Invoices</div>
+            <div class="it"><i class="bi bi-ui-checks-grid icon-form"></i> Customer Form</div>
+            <div class="grp">▾ Tables · 24</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Orders</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> OrderItems</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Products</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Invoices</div>
+            <div class="grp">▸ Forms · 8</div>
+            <div class="grp">▸ Reports · 5</div>
+            <div class="grp">▸ Views · 6</div>
+            <div class="grp">▸ Procedures · 11</div>
+        </aside>
+
+        <!-- Main content -->
+        <div class="content">
+            <div class="tabstrip">
+                <div class="tab active"><i class="bi bi-grid-1x2 icon-table"></i> Dashboard</div>
+                <div class="tab"><i class="bi bi-table icon-table"></i> Customers <i class="bi bi-x"></i></div>
+                <div class="tab dirty"><i class="bi bi-terminal icon-system"></i> Query 1 <i class="bi bi-x"></i></div>
+                <button class="tab-new"><i class="bi bi-plus"></i></button>
+            </div>
+
+            <div class="dash">
+                <div class="dash-header">
+                    <div>
+                        <div class="crumb">relational.db</div>
+                        <h1>Dashboard</h1>
+                    </div>
+                    <div class="actions">
+                        <button class="btn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+                        <button class="btn primary"><i class="bi bi-plus-lg"></i> New Query</button>
+                    </div>
+                </div>
+
+                <!-- Stat cards -->
+                <div class="stats">
+                    <div class="stat">
+                        <div class="label">Tables</div>
+                        <div class="value">24</div>
+                        <div class="delta up">+2 this week</div>
+                        <i class="bi bi-table icon icon-table"></i>
+                    </div>
+                    <div class="stat">
+                        <div class="label">Views</div>
+                        <div class="value">6</div>
+                        <div class="delta">no change</div>
+                        <i class="bi bi-eye icon icon-view"></i>
+                    </div>
+                    <div class="stat">
+                        <div class="label">Procedures</div>
+                        <div class="value">11</div>
+                        <div class="delta up">+1 today</div>
+                        <i class="bi bi-gear-wide-connected icon icon-trigger"></i>
+                    </div>
+                    <div class="stat">
+                        <div class="label">Indexes</div>
+                        <div class="value">38</div>
+                        <div class="delta">across 14 tables</div>
+                        <i class="bi bi-lightning icon icon-index"></i>
+                    </div>
+                    <div class="stat">
+                        <div class="label">Storage</div>
+                        <div class="value">2.4 <span style="font-size: 14px; color: var(--text-secondary);">GB</span></div>
+                        <div class="bar warn"><span style="width: 68%"></span></div>
+                        <div class="meta"><span>2.4 GB used</span><span>3.5 GB cap</span></div>
+                    </div>
+                </div>
+
+                <div class="grid">
+                    <!-- LEFT column -->
+                    <div>
+                        <div class="panel" style="margin-bottom: 18px;">
+                            <header>
+                                <h3>Top tables by row count</h3>
+                                <span class="more">View all 24 →</span>
+                            </header>
+                            <div class="tt-row">
+                                <div class="tname"><i class="bi bi-table"></i> Customers</div>
+                                <div class="rows">1,247</div>
+                                <div class="spark">
+                                    <span style="height: 30%"></span><span style="height: 40%"></span>
+                                    <span style="height: 55%"></span><span style="height: 60%"></span>
+                                    <span style="height: 80%"></span><span style="height: 90%"></span>
+                                    <span style="height: 100%"></span>
+                                </div>
+                                <div class="open">→</div>
+                            </div>
+                            <div class="tt-row">
+                                <div class="tname"><i class="bi bi-table"></i> Orders</div>
+                                <div class="rows">8,912</div>
+                                <div class="spark">
+                                    <span style="height: 50%"></span><span style="height: 60%"></span>
+                                    <span style="height: 70%"></span><span style="height: 65%"></span>
+                                    <span style="height: 85%"></span><span style="height: 80%"></span>
+                                    <span style="height: 95%"></span>
+                                </div>
+                                <div class="open">→</div>
+                            </div>
+                            <div class="tt-row">
+                                <div class="tname"><i class="bi bi-table"></i> OrderItems</div>
+                                <div class="rows">24,310</div>
+                                <div class="spark">
+                                    <span style="height: 70%"></span><span style="height: 75%"></span>
+                                    <span style="height: 85%"></span><span style="height: 80%"></span>
+                                    <span style="height: 90%"></span><span style="height: 100%"></span>
+                                    <span style="height: 95%"></span>
+                                </div>
+                                <div class="open">→</div>
+                            </div>
+                            <div class="tt-row">
+                                <div class="tname"><i class="bi bi-table"></i> Invoices</div>
+                                <div class="rows">5,103</div>
+                                <div class="spark">
+                                    <span style="height: 25%"></span><span style="height: 30%"></span>
+                                    <span style="height: 45%"></span><span style="height: 50%"></span>
+                                    <span style="height: 60%"></span><span style="height: 70%"></span>
+                                    <span style="height: 80%"></span>
+                                </div>
+                                <div class="open">→</div>
+                            </div>
+                            <div class="tt-row">
+                                <div class="tname"><i class="bi bi-table"></i> Products</div>
+                                <div class="rows">412</div>
+                                <div class="spark">
+                                    <span style="height: 90%"></span><span style="height: 92%"></span>
+                                    <span style="height: 88%"></span><span style="height: 91%"></span>
+                                    <span style="height: 90%"></span><span style="height: 95%"></span>
+                                    <span style="height: 92%"></span>
+                                </div>
+                                <div class="open">→</div>
+                            </div>
+                        </div>
+
+                        <div class="panel">
+                            <header>
+                                <h3>Recent activity</h3>
+                                <span class="more">Open log →</span>
+                            </header>
+                            <div class="act-row">
+                                <div class="ico q"><i class="bi bi-terminal"></i></div>
+                                <div class="body">
+                                    <div class="title">Ran query on Customers</div>
+                                    <div class="sub">SELECT * FROM Customers WHERE status = 'active' LIMIT 50</div>
+                                </div>
+                                <div class="when">2m ago</div>
+                            </div>
+                            <div class="act-row">
+                                <div class="ico e"><i class="bi bi-pencil-square"></i></div>
+                                <div class="body">
+                                    <div class="title">Edited form <b>Customer Form</b></div>
+                                    <div class="sub">Added field "loyaltyTier"</div>
+                                </div>
+                                <div class="when">14m ago</div>
+                            </div>
+                            <div class="act-row">
+                                <div class="ico s"><i class="bi bi-check-circle"></i></div>
+                                <div class="body">
+                                    <div class="title">Created procedure <b>recalc_invoices</b></div>
+                                    <div class="sub">11 statements · validated</div>
+                                </div>
+                                <div class="when">1h ago</div>
+                            </div>
+                            <div class="act-row">
+                                <div class="ico w"><i class="bi bi-exclamation-triangle"></i></div>
+                                <div class="body">
+                                    <div class="title">Pipeline <b>nightly_etl</b> finished with warnings</div>
+                                    <div class="sub">3 of 1,204 rows skipped (type mismatch)</div>
+                                </div>
+                                <div class="when">3h ago</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- RIGHT column -->
+                    <div>
+                        <div class="panel" style="margin-bottom: 18px;">
+                            <header>
+                                <h3>Pinned</h3>
+                                <span class="more"><i class="bi bi-pin-angle"></i></span>
+                            </header>
+                            <div class="pinned">
+                                <div class="pin"><i class="bi bi-table icon-table"></i> Customers</div>
+                                <div class="pin"><i class="bi bi-table icon-table"></i> Orders</div>
+                                <div class="pin"><i class="bi bi-ui-checks-grid icon-form"></i> Customer Form</div>
+                                <div class="pin"><i class="bi bi-file-earmark-richtext icon-report"></i> Sales Report</div>
+                                <div class="pin"><i class="bi bi-terminal icon-system"></i> "Active customers"</div>
+                                <div class="pin"><i class="bi bi-gear-wide-connected icon-trigger"></i> recalc_invoices</div>
+                            </div>
+                        </div>
+
+                        <div class="panel" style="margin-bottom: 18px;">
+                            <header><h3>Quick actions</h3></header>
+                            <div class="qa">
+                                <button class="qa-btn">
+                                    <i class="ico bi bi-terminal"></i>
+                                    <span>New Query</span>
+                                    <span class="sub">Open a SQL editor tab</span>
+                                    <span class="kbd">Ctrl N</span>
+                                </button>
+                                <button class="qa-btn">
+                                    <i class="ico bi bi-table"></i>
+                                    <span>New Table</span>
+                                    <span class="sub">Open the table designer</span>
+                                </button>
+                                <button class="qa-btn">
+                                    <i class="ico bi bi-ui-checks-grid"></i>
+                                    <span>New Form</span>
+                                    <span class="sub">Generate from a table</span>
+                                </button>
+                                <button class="qa-btn">
+                                    <i class="ico bi bi-file-earmark-richtext"></i>
+                                    <span>New Report</span>
+                                    <span class="sub">Pick table or view</span>
+                                </button>
+                                <button class="qa-btn">
+                                    <i class="ico bi bi-diagram-3"></i>
+                                    <span>New Pipeline</span>
+                                    <span class="sub">Build an ETL flow</span>
+                                </button>
+                                <button class="qa-btn">
+                                    <i class="ico bi bi-hdd-stack"></i>
+                                    <span>Storage</span>
+                                    <span class="sub">Inspect file usage</span>
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="panel">
+                            <header>
+                                <h3>Health</h3>
+                                <span class="more">Run full check →</span>
+                            </header>
+                            <div class="health">
+                                <div class="h-row"><span class="lbl">Last integrity check</span><span class="val ok">2h ago · OK</span></div>
+                                <div class="h-row"><span class="lbl">Open writer transactions</span><span class="val">1</span></div>
+                                <div class="h-row"><span class="lbl">Storage pressure</span><span class="val warn">68%</span></div>
+                                <div class="h-row"><span class="lbl">Background jobs</span><span class="val">2 running</span></div>
+                                <div class="h-row"><span class="lbl">WAL fsync mode</span><span class="val">HybridIncrementalDurable</span></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- STATUS BAR -->
+    <div class="statusbar">
+        <span class="pill ok"><span class="dot"></span> Connected</span>
+        <span class="pill"><i class="bi bi-database"></i> relational.db</span>
+        <span class="pill">24 tables · 6 views · 11 procs</span>
+        <span class="pill action"><i class="bi bi-arrow-repeat"></i> 2 background jobs</span>
+        <div class="spacer" style="flex:1"></div>
+        <span class="pill warn"><i class="bi bi-hdd"></i> 2.4 GB / 3.5 GB</span>
+        <span class="pill action"><i class="bi bi-bell"></i> 3 notifications</span>
+    </div>
+</div>
+
+<!-- Annotations -->
+<div class="notes">
+    <header><i class="bi bi-lightbulb"></i> Reality check vs. the live screen</header>
+    <ul>
+        <li><b style="color: var(--accent-green);">ALREADY EXISTS</b> — current Welcome tab shows app icon, app name, four shortcut hints (Ctrl+N / Ctrl+B / Ctrl+Enter / Ctrl+Shift+L), and a grid of table cards with a "Load row counts" button. Status bar already reports table/view/procedure counts. Title bar already has Open Database / New Query / New Table / New Form / New Procedure / New Pipeline / Storage buttons plus theme/sidebar/help toggles. ANALYZE and storage stats already accessible via the Storage tab and Query tab "Stats" shortcuts.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Stat cards row</b> with deltas and a storage-pressure bar.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Top tables panel</b> with sparklines for row-count growth — today you'd run an ad-hoc query.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Recent activity feed</b> — there's no audit/activity surface today.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Pinned objects grid</b> — pinning doesn't exist anywhere yet.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-magenta);">RESTYLE: Quick action tiles</b> — same actions as the title-bar buttons, in a more discoverable card form.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Health panel</b> — surfaces integrity, open writers, storage pressure, background jobs, WAL mode in one place. Today these are scattered across StorageTab's 11 stacked sections.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Title-bar database switcher dropdown + search-style palette launcher</b> — today there's just an "Open Database" button that opens a path prompt (no recent-databases list).</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Status-bar storage pressure / background-job ticker / notification counter</b> — current status bar shows connection state, db path, and counts.</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/data-tab.html
+++ b/www/admin-ui-mockups/data-tab.html
@@ -1,0 +1,495 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Data Tab — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    .sidebar { padding: 10px; font-size: 12px; color: var(--text-secondary); }
+    .sidebar .grp { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; padding: 8px 6px 4px; }
+    .sidebar .it { padding: 4px 6px; display: flex; align-items: center; gap: 6px; border-radius: 4px; cursor: pointer; }
+    .sidebar .it:hover { background: var(--bg-hover); color: var(--text-primary); }
+    .sidebar .it.active { background: rgba(122,162,247,0.1); color: var(--text-primary); border-left: 2px solid var(--accent-blue); padding-left: 4px; }
+
+    /* Toolbar */
+    .data-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--border-color);
+        background: var(--bg-secondary);
+        flex-shrink: 0;
+    }
+    .crumb {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+    }
+    .crumb a { color: var(--text-muted); }
+    .crumb a:hover { color: var(--text-primary); text-decoration: none; }
+    .crumb .sep { color: var(--text-muted); }
+    .crumb .obj { color: var(--text-primary); font-weight: 600; display: flex; align-items: center; gap: 6px; }
+
+    .views {
+        display: flex;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+    }
+    .views button {
+        background: transparent;
+        border: none;
+        color: var(--text-muted);
+        font-size: 11px;
+        padding: 5px 12px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+    }
+    .views button:not(:last-child) { border-right: 1px solid var(--border-color); }
+    .views button:hover { color: var(--text-primary); }
+    .views button.active { color: var(--accent-blue); background: var(--bg-active); font-weight: 600; }
+
+    .toolbar-group {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 0 8px;
+        border-left: 1px solid var(--border-color);
+    }
+    .toolbar-group:first-of-type { border-left: none; padding-left: 0; }
+    .tg-btn {
+        background: transparent;
+        border: 1px solid transparent;
+        color: var(--text-secondary);
+        font-size: 11px;
+        padding: 5px 10px;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+    }
+    .tg-btn:hover { background: var(--bg-hover); color: var(--text-primary); border-color: var(--border-color); }
+    .tg-btn.primary { background: var(--accent-blue); color: #0a0b13; font-weight: 600; }
+    .tg-btn.primary:hover { filter: brightness(1.08); }
+
+    .pager {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 11px;
+        color: var(--text-muted);
+        margin-left: auto;
+    }
+    .pager .nums { color: var(--text-primary); font-variant-numeric: tabular-nums; }
+    .pager button {
+        width: 24px; height: 24px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        color: var(--text-secondary);
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+    }
+    .pager button:hover { color: var(--text-primary); }
+    .pager button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* Filter chip bar */
+    .filter-bar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 16px;
+        border-bottom: 1px solid var(--border-color);
+        background: var(--bg-primary);
+        flex-wrap: wrap;
+    }
+    .filter-bar .lbl {
+        font-size: 11px;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+    }
+    .fchip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 3px 4px 3px 10px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 999px;
+        font-size: 11.5px;
+        color: var(--text-primary);
+    }
+    .fchip .col { color: var(--accent-blue); font-weight: 600; }
+    .fchip .op { color: var(--text-muted); font-family: var(--font-mono); }
+    .fchip .val { font-family: var(--font-mono); color: var(--accent-green); }
+    .fchip .x {
+        margin-left: 2px;
+        width: 18px; height: 18px;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        color: var(--text-muted);
+        cursor: pointer;
+        font-size: 10px;
+    }
+    .fchip .x:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+    .add-filter {
+        background: transparent;
+        border: 1px dashed var(--border-color);
+        color: var(--text-muted);
+        padding: 3px 10px;
+        font-size: 11px;
+        border-radius: 999px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+    }
+    .add-filter:hover { color: var(--text-primary); border-color: var(--border-light); }
+
+    /* Data grid */
+    .grid-wrap { flex: 1; overflow: auto; }
+    table.grid {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+        font-family: var(--font-mono);
+    }
+    table.grid thead th {
+        position: sticky;
+        top: 0;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        padding: 8px 10px;
+        text-align: left;
+        color: var(--text-secondary);
+        font-family: var(--font-ui);
+        font-weight: 600;
+        font-size: 11px;
+        white-space: nowrap;
+    }
+    table.grid thead th .col-icon {
+        font-size: 10px;
+        margin-right: 5px;
+        color: var(--text-muted);
+    }
+    table.grid thead th .col-icon.int { color: var(--accent-orange); }
+    table.grid thead th .col-icon.text { color: var(--accent-cyan); }
+    table.grid thead th .col-icon.enum { color: var(--accent-magenta); }
+    table.grid thead th .col-icon.date { color: var(--accent-yellow); }
+    table.grid thead th .col-icon.bool { color: var(--accent-green); }
+    table.grid thead th .col-icon.key { color: var(--accent-yellow); }
+
+    table.grid thead th .sort {
+        margin-left: 4px;
+        opacity: 0.4;
+        font-size: 10px;
+    }
+    table.grid thead th.sorted .sort { opacity: 1; color: var(--accent-blue); }
+
+    table.grid tbody td {
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--border-color);
+        white-space: nowrap;
+        color: var(--text-primary);
+    }
+    table.grid tbody tr:hover td { background: var(--bg-hover); }
+    table.grid tbody tr.selected td { background: rgba(122,162,247,0.12); }
+    table.grid tbody td .pill-status {
+        padding: 1px 8px;
+        border-radius: 999px;
+        font-size: 10.5px;
+        font-family: var(--font-ui);
+    }
+    table.grid tbody td .pill-status.active { background: rgba(158,206,106,0.12); color: var(--accent-green); }
+    table.grid tbody td .pill-status.inactive { background: rgba(120,130,169,0.12); color: var(--text-muted); }
+    table.grid tbody td .pill-status.pending { background: rgba(224,175,104,0.12); color: var(--accent-yellow); }
+    table.grid tbody td.num { text-align: right; color: var(--accent-orange); }
+    table.grid tbody td.dt { color: var(--accent-yellow); }
+    table.grid tbody td.null { color: var(--text-muted); font-style: italic; }
+    table.grid tbody td.id { color: var(--accent-blue); font-weight: 600; }
+    .row-check { width: 28px; padding: 0 0 0 10px; }
+    .row-check input { width: 13px; height: 13px; accent-color: var(--accent-blue); }
+
+    /* Bulk action bar (when rows selected) */
+    .bulk-bar {
+        position: sticky;
+        bottom: 0;
+        background: var(--bg-elevated);
+        border-top: 1px solid var(--border-light);
+        padding: 10px 16px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 12px;
+        box-shadow: 0 -8px 24px rgba(0,0,0,0.3);
+        z-index: 5;
+    }
+    .bulk-bar .count {
+        background: var(--accent-blue);
+        color: #0a0b13;
+        padding: 2px 9px;
+        border-radius: 999px;
+        font-weight: 600;
+    }
+    .bulk-bar .actions { display: flex; gap: 6px; margin-left: auto; }
+</style>
+</head>
+<body>
+<div class="app">
+
+    <div class="titlebar">
+        <div class="brand">
+            <div class="logo">C#</div>
+            <span>CSharpDB Studio</span>
+            <span class="dbname">— relational.db</span>
+        </div>
+        <button class="db-switcher"><i class="bi bi-database"></i> relational.db <i class="bi bi-caret-down-fill"></i></button>
+        <button class="palette-launcher"><i class="bi bi-search"></i> Search anything… <span class="kbd">Ctrl K</span></button>
+        <div class="spacer"></div>
+        <span class="conn-pill"><span class="dot"></span> Connected</span>
+        <button class="tb-btn icon-only"><i class="bi bi-moon-stars"></i></button>
+        <button class="tb-btn icon-only"><i class="bi bi-layout-sidebar-inset"></i></button>
+    </div>
+
+    <div class="body">
+        <aside class="sidebar">
+            <div class="grp">★ Pinned</div>
+            <div class="it active"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Orders</div>
+            <div class="grp">⏱ Recent</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Invoices</div>
+            <div class="grp">▾ Tables · 24</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> CustomerAddresses</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> CustomerNotes</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Orders</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> OrderItems</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Invoices</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Products</div>
+        </aside>
+
+        <div class="content">
+            <div class="tabstrip">
+                <div class="tab"><i class="bi bi-grid-1x2 icon-table"></i> Dashboard</div>
+                <div class="tab active"><i class="bi bi-table icon-table"></i> Customers <i class="bi bi-x"></i></div>
+                <div class="tab dirty"><i class="bi bi-terminal icon-system"></i> Query 1 <i class="bi bi-x"></i></div>
+                <button class="tab-new"><i class="bi bi-plus"></i></button>
+            </div>
+
+            <!-- Toolbar -->
+            <div class="data-toolbar">
+                <div class="crumb">
+                    <a href="#"><i class="bi bi-table"></i> tables</a>
+                    <span class="sep">/</span>
+                    <span class="obj"><i class="bi bi-table icon-table"></i> Customers</span>
+                </div>
+
+                <div class="views">
+                    <button class="active"><i class="bi bi-grid-3x3-gap"></i> Data</button>
+                    <button><i class="bi bi-list-columns"></i> Schema</button>
+                    <button><i class="bi bi-lightning"></i> Indexes <span style="opacity:0.5;">2</span></button>
+                    <button><i class="bi bi-lightning-charge"></i> Triggers <span style="opacity:0.5;">1</span></button>
+                </div>
+
+                <div class="toolbar-group">
+                    <button class="tg-btn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+                    <button class="tg-btn primary"><i class="bi bi-plus-lg"></i> Insert row</button>
+                </div>
+
+                <div class="toolbar-group">
+                    <button class="tg-btn"><i class="bi bi-funnel"></i> Filter</button>
+                    <button class="tg-btn"><i class="bi bi-sort-down"></i> Sort</button>
+                    <button class="tg-btn"><i class="bi bi-eye"></i> Columns</button>
+                </div>
+
+                <div class="toolbar-group">
+                    <button class="tg-btn"><i class="bi bi-download"></i> Export ▾</button>
+                    <button class="tg-btn"><i class="bi bi-upload"></i> Import</button>
+                </div>
+
+                <div class="pager">
+                    <span>Rows <span class="nums">1–25</span> of <span class="nums">1,247</span></span>
+                    <button disabled><i class="bi bi-chevron-left"></i></button>
+                    <button><i class="bi bi-chevron-right"></i></button>
+                </div>
+            </div>
+
+            <!-- Filter chip bar -->
+            <div class="filter-bar">
+                <span class="lbl">Filters:</span>
+                <span class="fchip">
+                    <span class="col">status</span>
+                    <span class="op">=</span>
+                    <span class="val">'active'</span>
+                    <span class="x"><i class="bi bi-x"></i></span>
+                </span>
+                <span class="fchip">
+                    <span class="col">created_at</span>
+                    <span class="op">≥</span>
+                    <span class="val">2026-01-01</span>
+                    <span class="x"><i class="bi bi-x"></i></span>
+                </span>
+                <span class="fchip">
+                    <span class="col">name</span>
+                    <span class="op">LIKE</span>
+                    <span class="val">'%Smith%'</span>
+                    <span class="x"><i class="bi bi-x"></i></span>
+                </span>
+                <button class="add-filter"><i class="bi bi-plus-lg"></i> Add filter</button>
+                <span style="margin-left: auto; font-size: 11px; color: var(--text-muted);">
+                    Showing <b style="color: var(--text-primary);">42</b> of 1,247 rows
+                </span>
+            </div>
+
+            <!-- Grid -->
+            <div class="grid-wrap">
+                <table class="grid">
+                    <thead>
+                    <tr>
+                        <th class="row-check"><input type="checkbox"></th>
+                        <th class="sorted"><i class="bi bi-key col-icon key"></i>id <i class="bi bi-arrow-down sort"></i></th>
+                        <th><i class="bi bi-fonts col-icon text"></i>name</th>
+                        <th><i class="bi bi-envelope col-icon text"></i>email</th>
+                        <th><i class="bi bi-toggle-on col-icon enum"></i>status</th>
+                        <th><i class="bi bi-calendar3 col-icon date"></i>created_at</th>
+                        <th><i class="bi bi-hash col-icon int"></i>order_count</th>
+                        <th><i class="bi bi-fonts col-icon text"></i>notes</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="selected">
+                        <td class="row-check"><input type="checkbox" checked></td>
+                        <td class="id">1</td>
+                        <td>Alice Smith</td>
+                        <td>alice@example.com</td>
+                        <td><span class="pill-status active">active</span></td>
+                        <td class="dt">2026-01-12 09:14</td>
+                        <td class="num">12</td>
+                        <td class="null">NULL</td>
+                    </tr>
+                    <tr class="selected">
+                        <td class="row-check"><input type="checkbox" checked></td>
+                        <td class="id">2</td>
+                        <td>Bob Lee</td>
+                        <td>bob@example.com</td>
+                        <td><span class="pill-status active">active</span></td>
+                        <td class="dt">2026-01-14 11:02</td>
+                        <td class="num">3</td>
+                        <td>VIP — handle with care</td>
+                    </tr>
+                    <tr>
+                        <td class="row-check"><input type="checkbox"></td>
+                        <td class="id">3</td>
+                        <td>Carol Smith</td>
+                        <td>carol@example.com</td>
+                        <td><span class="pill-status pending">pending</span></td>
+                        <td class="dt">2026-02-03 16:48</td>
+                        <td class="num">0</td>
+                        <td class="null">NULL</td>
+                    </tr>
+                    <tr>
+                        <td class="row-check"><input type="checkbox"></td>
+                        <td class="id">4</td>
+                        <td>David Smith</td>
+                        <td>dsmith@example.com</td>
+                        <td><span class="pill-status active">active</span></td>
+                        <td class="dt">2026-02-19 08:22</td>
+                        <td class="num">7</td>
+                        <td>Net 30 terms</td>
+                    </tr>
+                    <tr>
+                        <td class="row-check"><input type="checkbox"></td>
+                        <td class="id">5</td>
+                        <td>Eve Smithers</td>
+                        <td>eve@example.com</td>
+                        <td><span class="pill-status inactive">inactive</span></td>
+                        <td class="dt">2026-03-01 14:10</td>
+                        <td class="num">22</td>
+                        <td>Migrated from legacy</td>
+                    </tr>
+                    <tr>
+                        <td class="row-check"><input type="checkbox"></td>
+                        <td class="id">6</td>
+                        <td>Frank Smithy</td>
+                        <td>frank@example.com</td>
+                        <td><span class="pill-status active">active</span></td>
+                        <td class="dt">2026-03-12 10:55</td>
+                        <td class="num">1</td>
+                        <td class="null">NULL</td>
+                    </tr>
+                    <tr>
+                        <td class="row-check"><input type="checkbox"></td>
+                        <td class="id">7</td>
+                        <td>Grace Smith-Jones</td>
+                        <td>grace@example.com</td>
+                        <td><span class="pill-status active">active</span></td>
+                        <td class="dt">2026-03-22 09:17</td>
+                        <td class="num">5</td>
+                        <td>Refer-a-friend</td>
+                    </tr>
+                    <tr>
+                        <td class="row-check"><input type="checkbox"></td>
+                        <td class="id">8</td>
+                        <td>Henry Smithfield</td>
+                        <td>hank@example.com</td>
+                        <td><span class="pill-status pending">pending</span></td>
+                        <td class="dt">2026-04-02 12:38</td>
+                        <td class="num">0</td>
+                        <td class="null">NULL</td>
+                    </tr>
+                    </tbody>
+                </table>
+
+                <!-- Bulk action bar appears when rows are selected -->
+                <div class="bulk-bar">
+                    <span class="count">2 selected</span>
+                    <span style="color: var(--text-secondary);">Apply an action to the selected rows:</span>
+                    <div class="actions">
+                        <button class="tg-btn"><i class="bi bi-pencil"></i> Bulk edit…</button>
+                        <button class="tg-btn"><i class="bi bi-clipboard"></i> Copy as INSERT</button>
+                        <button class="tg-btn"><i class="bi bi-download"></i> Export</button>
+                        <button class="tg-btn" style="color: var(--accent-red); border-color: rgba(247,118,142,0.3);"><i class="bi bi-trash3"></i> Delete</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="statusbar">
+        <span class="pill ok"><span class="dot"></span> Connected</span>
+        <span class="pill"><i class="bi bi-database"></i> relational.db</span>
+        <span class="pill"><i class="bi bi-table icon-table"></i> Customers · 1,247 rows</span>
+        <span class="pill"><i class="bi bi-funnel"></i> 3 filters · 42 visible</span>
+        <div style="flex:1"></div>
+        <span class="pill action"><i class="bi bi-clock"></i> Last refresh 2s ago</span>
+        <span class="pill warn"><i class="bi bi-hdd"></i> 2.4 GB / 3.5 GB</span>
+    </div>
+</div>
+
+<!-- Annotations -->
+<div class="notes">
+    <header><i class="bi bi-lightbulb"></i> Reality check vs. the live screen</header>
+    <ul>
+        <li><b style="color: var(--accent-green);">ALREADY EXISTS</b> — Data/Schema view switcher, Add Row, Delete (with selection count), Save, Discard, Refresh, Drop Table buttons in toolbar. Per-column filter row with Contains/StartsWith/EndsWith/Exact mode selector. Sortable headers with ↑↓ indicators. Type badges (INTEGER/TEXT/REAL/BLOB). PK badges. Pagination bar with page-size dropdown and first/prev/next/last. Inline cell editing on double-click. Right-click context menu for row actions. NULL and BLOB cell rendering.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Breadcrumb header</b> ("tables / Customers") — today the object name is right-aligned in the toolbar info area.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Filter summary chip strip</b> — a recap of all active filters as removable pills. The per-column filter row stays; this adds an overview that's currently missing.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Schema sub-tabs</b> — split the Schema view's three stacked sections (Columns, Indexes, Triggers) into sub-tabs so users don't scroll past the first section.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Export / Import</b> buttons — no export today.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Bulk action bar at bottom</b> when rows are selected — Bulk edit, Copy as INSERT, Export, Delete. Delete exists today via toolbar/context menu, but Bulk edit and Copy as INSERT are new.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-magenta);">RESTYLE</b> — type icons in column headers (replacing or supplementing the existing text badges). Status pills for enum-ish columns. Right-aligned numbers, distinct date coloring. Visual polish on top of features that already work.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Status-bar pills</b> for table-specific facts (row count, active filter count, last refresh).</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/forms-mobile.html
+++ b/www/admin-ui-mockups/forms-mobile.html
@@ -1,0 +1,760 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Elastic Forms — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    body { overflow: auto; }
+
+    /* ─── Page wrapper ───────────────────────── */
+    .page {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 32px 28px 80px;
+    }
+
+    h1 { font-size: 22px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
+    .crumb { color: var(--text-muted); font-size: 12px; margin-bottom: 4px; }
+    .lede { color: var(--text-secondary); font-size: 13px; max-width: 760px; margin-bottom: 20px; }
+
+    h2 {
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+        color: var(--text-muted);
+        margin: 32px 0 12px;
+    }
+
+    /* ─── Designer toolbar mock ──────────────── */
+    .designer-shell {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+    }
+
+    .d-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 14px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        flex-wrap: wrap;
+    }
+    .d-toolbar .grp {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding-right: 12px;
+        border-right: 1px solid var(--border-color);
+    }
+    .d-toolbar .grp:last-child { border-right: none; }
+    .d-toolbar .label {
+        font-size: 11px;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+
+    .seg {
+        display: flex;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+    }
+    .seg button {
+        background: transparent;
+        border: none;
+        color: var(--text-muted);
+        font-size: 11px;
+        padding: 5px 12px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+    }
+    .seg button:hover { color: var(--text-primary); }
+    .seg button.active {
+        color: var(--accent-blue);
+        background: var(--bg-active);
+        font-weight: 600;
+    }
+    .seg button:not(:last-child) { border-right: 1px solid var(--border-color); }
+
+    .d-toolbar .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 3px 10px;
+        font-size: 11px;
+        background: rgba(122,162,247,0.12);
+        color: var(--accent-blue);
+        border-radius: 999px;
+        font-weight: 600;
+    }
+    .d-toolbar .pill.warn { background: rgba(224,175,104,0.12); color: var(--accent-yellow); }
+
+    /* ─── Canvas with device frame ────────────── */
+    .canvas-area {
+        background: var(--bg-tertiary);
+        padding: 28px;
+        display: flex;
+        justify-content: center;
+        min-height: 580px;
+    }
+
+    /* Device frame: phone */
+    .device {
+        background: var(--bg-primary);
+        border: 1px solid var(--border-color);
+        border-radius: 18px;
+        box-shadow: 0 24px 48px rgba(0,0,0,0.4);
+        padding: 18px 14px;
+        position: relative;
+        flex-shrink: 0;
+    }
+    .device .notch {
+        position: absolute;
+        top: 6px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 50px;
+        height: 4px;
+        background: var(--border-light);
+        border-radius: 4px;
+    }
+    .device.phone { width: 380px; }
+    .device.tablet { width: 720px; }
+    .device.desktop {
+        width: 100%;
+        max-width: 980px;
+        border-radius: 8px;
+        padding: 20px;
+    }
+    .device-meta {
+        position: absolute;
+        bottom: -22px;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: 10px;
+        color: var(--text-muted);
+        white-space: nowrap;
+    }
+
+    /* The actual form viewport inside the device */
+    .form-viewport {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: 6px;
+        padding: 14px;
+        min-height: 460px;
+        position: relative;
+    }
+    .form-title {
+        font-size: 14px;
+        font-weight: 600;
+        margin-bottom: 4px;
+    }
+    .form-sub {
+        font-size: 11px;
+        color: var(--text-muted);
+        margin-bottom: 14px;
+    }
+
+    /* Field styles common */
+    .fld { display: flex; flex-direction: column; gap: 4px; }
+    .fld label {
+        font-size: 11px;
+        color: var(--text-secondary);
+        font-weight: 600;
+    }
+    .fld input, .fld select, .fld textarea {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        padding: 7px 10px;
+        color: var(--text-primary);
+        font-size: 12px;
+        font-family: var(--font-ui);
+        width: 100%;
+    }
+    .fld textarea { min-height: 60px; resize: vertical; }
+    .fld input:focus { outline: 2px solid var(--accent-blue); }
+    .fld .req { color: var(--accent-red); }
+    .fld .help { font-size: 10px; color: var(--text-muted); }
+
+    /* ─── DESKTOP layout: pixel-positioned (current behavior) ─── */
+    .layout-desktop {
+        position: relative;
+        height: 420px;
+        background-image:
+                linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+        background-size: 16px 16px;
+    }
+    .layout-desktop .fld { position: absolute; }
+
+    /* ─── ELASTIC layout: 12-col grid that collapses ─── */
+    .layout-grid {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        gap: 10px 12px;
+    }
+    /* Tablet: 8-col */
+    .layout-grid.cols-8 { grid-template-columns: repeat(8, 1fr); gap: 10px; }
+    /* Mobile: 4-col with auto-stack */
+    .layout-grid.cols-4 { grid-template-columns: repeat(4, 1fr); gap: 14px; }
+
+    /* Field span helpers */
+    .col-12 { grid-column: span 12; }
+    .col-8 { grid-column: span 8; }
+    .col-6 { grid-column: span 6; }
+    .col-4 { grid-column: span 4; }
+    .col-3 { grid-column: span 3; }
+
+    /* Mobile: force every field to full row & big touch target */
+    .layout-grid.cols-4 .fld { grid-column: 1 / -1 !important; }
+    .layout-grid.cols-4 .fld input,
+    .layout-grid.cols-4 .fld select,
+    .layout-grid.cols-4 .fld textarea { padding: 12px 14px; font-size: 14px; }
+    .layout-grid.cols-4 .fld label { font-size: 12px; }
+    .layout-grid.cols-4 .actions button { padding: 12px 18px; font-size: 14px; min-height: 44px; }
+
+    /* Action row */
+    .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-top: 14px;
+        flex-wrap: wrap;
+    }
+    .actions button {
+        padding: 7px 14px;
+        font-size: 12px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 5px;
+        color: var(--text-primary);
+        cursor: pointer;
+    }
+    .actions button.primary {
+        background: var(--accent-blue);
+        color: #0a0b13;
+        border-color: var(--accent-blue);
+        font-weight: 600;
+    }
+
+    /* ─── Side-by-side device row ────────────── */
+    .device-row {
+        display: flex;
+        gap: 28px;
+        justify-content: center;
+        align-items: flex-start;
+        padding: 28px 28px 50px;
+        background: var(--bg-tertiary);
+        overflow-x: auto;
+    }
+
+    /* Property inspector style "Layout settings" panel */
+    .inspector {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        padding: 16px 18px;
+        font-size: 12.5px;
+    }
+    .inspector h3 {
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 10px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .inspector .row {
+        display: grid;
+        grid-template-columns: 140px 1fr;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 0;
+        border-bottom: 1px dashed var(--border-color);
+    }
+    .inspector .row:last-of-type { border-bottom: none; }
+    .inspector .row .k { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .inspector .row .v { color: var(--text-primary); }
+    .inspector input[type=text], .inspector input[type=number], .inspector select {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        padding: 4px 8px;
+        color: var(--text-primary);
+        font-size: 12px;
+        font-family: var(--font-ui);
+        width: 100%;
+    }
+    .inspector .swatch {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .inspector .swatch i { font-size: 13px; }
+
+    .toggle {
+        position: relative;
+        width: 38px; height: 20px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 10px;
+        cursor: pointer;
+        flex-shrink: 0;
+    }
+    .toggle::after {
+        content: "";
+        position: absolute;
+        top: 1px;
+        left: 1px;
+        width: 16px; height: 16px;
+        background: var(--text-muted);
+        border-radius: 50%;
+        transition: 120ms ease;
+    }
+    .toggle.on { background: rgba(122,162,247,0.3); border-color: var(--accent-blue); }
+    .toggle.on::after { left: 19px; background: var(--accent-blue); }
+
+    .two-col {
+        display: grid;
+        grid-template-columns: 1fr 320px;
+        gap: 18px;
+    }
+
+    /* Responsive shrink */
+    @media (max-width: 1080px) {
+        .two-col { grid-template-columns: 1fr; }
+    }
+</style>
+</head>
+<body>
+<div class="page">
+
+    <div class="crumb">CSharpDB.Admin.Forms · UI proposal</div>
+    <h1>Make forms mobile-friendly with an "Elastic" layout mode</h1>
+    <p class="lede">
+        Today every form rendered by <code>FormRenderer.razor</code> uses absolute pixel coordinates
+        — controls have a fixed <code>X / Y / W / H</code> from <code>Rect</code>, and on a phone the
+        form simply scrolls horizontally. The <code>LayoutDefinition</code> model already carries a
+        <code>Breakpoints</code> list and <code>ControlDefinition</code> already has
+        <code>RendererHints</code>, so the schema is responsive-ready. This proposal adds a designer
+        switch and a runtime that uses them.
+    </p>
+
+    <!-- ════════ Section 1: Designer-side switch ════════ -->
+    <h2>1 · Designer · new "Layout mode" switch</h2>
+
+    <div class="two-col">
+        <div class="designer-shell">
+            <div class="d-toolbar">
+                <div class="grp">
+                    <span class="label">Layout mode</span>
+                    <div class="seg">
+                        <button><i class="bi bi-pin-map"></i> Fixed pixels</button>
+                        <button class="active"><i class="bi bi-aspect-ratio"></i> Elastic</button>
+                    </div>
+                </div>
+                <div class="grp">
+                    <span class="label">Preview</span>
+                    <div class="seg">
+                        <button><i class="bi bi-display"></i> Desktop</button>
+                        <button class="active"><i class="bi bi-tablet"></i> Tablet</button>
+                        <button><i class="bi bi-phone"></i> Mobile</button>
+                    </div>
+                </div>
+                <div class="grp">
+                    <span class="pill"><i class="bi bi-grid-3x3-gap"></i> 12-col grid · 8 px gutter</span>
+                </div>
+                <div style="flex: 1"></div>
+                <div class="grp">
+                    <span class="pill warn"><i class="bi bi-exclamation-triangle"></i> 2 controls overflow at Mobile</span>
+                </div>
+            </div>
+
+            <div class="canvas-area" style="padding: 28px 18px;">
+                <div class="device tablet">
+                    <div class="form-viewport">
+                        <div class="form-title">Customer · CST-00142</div>
+                        <div class="form-sub">vw_customer_form · tablet preview · 720 × auto</div>
+
+                        <div class="layout-grid cols-8">
+                            <div class="fld col-4">
+                                <label>First name <span class="req">*</span></label>
+                                <input value="Alice" />
+                            </div>
+                            <div class="fld col-4">
+                                <label>Last name <span class="req">*</span></label>
+                                <input value="Smith" />
+                            </div>
+                            <div class="fld col-8">
+                                <label>Email</label>
+                                <input value="alice@example.com" />
+                            </div>
+                            <div class="fld col-3">
+                                <label>Status</label>
+                                <select><option>active</option></select>
+                            </div>
+                            <div class="fld col-3">
+                                <label>Tier</label>
+                                <select><option>Gold</option></select>
+                            </div>
+                            <div class="fld col-2">
+                                <label>Active</label>
+                                <select><option>Yes</option></select>
+                            </div>
+                            <div class="fld col-8">
+                                <label>Notes</label>
+                                <textarea>VIP customer — handle with care.</textarea>
+                            </div>
+                        </div>
+
+                        <div class="actions">
+                            <button>Cancel</button>
+                            <button class="primary">Save</button>
+                        </div>
+                    </div>
+                    <div class="device-meta">tablet · 768 px breakpoint</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Property inspector showing the Layout settings -->
+        <div class="inspector">
+            <h3><i class="bi bi-sliders" style="color: var(--accent-blue);"></i> Layout settings</h3>
+
+            <div class="row">
+                <span class="k">Mode</span>
+                <span class="v"><b>Elastic</b> · 12-col grid</span>
+            </div>
+            <div class="row">
+                <span class="k">Auto-stack on mobile</span>
+                <span class="v"><div class="toggle on"></div></span>
+            </div>
+            <div class="row">
+                <span class="k">Touch targets</span>
+                <span class="v">≥ 44 px on mobile</span>
+            </div>
+
+            <h3 style="margin-top: 16px;"><i class="bi bi-aspect-ratio" style="color: var(--accent-blue);"></i> Breakpoints</h3>
+
+            <div class="row">
+                <span class="k swatch"><i class="bi bi-display" style="color: var(--accent-green);"></i> Desktop</span>
+                <span class="v">≥ 1024 px · 12 cols</span>
+            </div>
+            <div class="row">
+                <span class="k swatch"><i class="bi bi-tablet" style="color: var(--accent-yellow);"></i> Tablet</span>
+                <span class="v">≥ 640 px · 8 cols</span>
+            </div>
+            <div class="row">
+                <span class="k swatch"><i class="bi bi-phone" style="color: var(--accent-magenta);"></i> Mobile</span>
+                <span class="v">&lt; 640 px · stacked</span>
+            </div>
+
+            <h3 style="margin-top: 16px;"><i class="bi bi-magic" style="color: var(--accent-blue);"></i> Auto-elastic</h3>
+            <div class="row">
+                <span class="k">For legacy forms</span>
+                <span class="v"><div class="toggle on"></div></span>
+            </div>
+            <p style="font-size: 11px; color: var(--text-muted); margin-top: 8px; line-height: 1.5;">
+                When a form has no breakpoint overrides, the renderer infers a 12-col grid from the
+                pixel layout (X/W → column span, Y → row order) so existing forms get a sensible
+                mobile view without redesign.
+            </p>
+        </div>
+    </div>
+
+    <!-- ════════ Section 2: Side-by-side device preview ════════ -->
+    <h2>2 · Same form at three breakpoints</h2>
+    <p class="lede" style="margin-top: -6px;">
+        One form definition, three viewport sizes. Designer can switch between them with the toolbar
+        Preview segmented control; users see the right one based on their screen.
+    </p>
+
+    <div class="device-row">
+        <!-- Desktop -->
+        <div class="device desktop" style="max-width: 540px;">
+            <div class="form-viewport">
+                <div class="form-title">Customer · CST-00142</div>
+                <div class="form-sub">desktop · 12-col</div>
+
+                <div class="layout-grid">
+                    <div class="fld col-3">
+                        <label>First name <span class="req">*</span></label>
+                        <input value="Alice" />
+                    </div>
+                    <div class="fld col-3">
+                        <label>Last name <span class="req">*</span></label>
+                        <input value="Smith" />
+                    </div>
+                    <div class="fld col-6">
+                        <label>Email</label>
+                        <input value="alice@example.com" />
+                    </div>
+                    <div class="fld col-3">
+                        <label>Status</label>
+                        <select><option>active</option></select>
+                    </div>
+                    <div class="fld col-3">
+                        <label>Tier</label>
+                        <select><option>Gold</option></select>
+                    </div>
+                    <div class="fld col-3">
+                        <label>Active</label>
+                        <select><option>Yes</option></select>
+                    </div>
+                    <div class="fld col-3">
+                        <label>Created</label>
+                        <input type="date" value="2026-01-12" />
+                    </div>
+                    <div class="fld col-12">
+                        <label>Notes</label>
+                        <textarea>VIP — handle with care.</textarea>
+                    </div>
+                </div>
+                <div class="actions">
+                    <button>Cancel</button>
+                    <button class="primary">Save</button>
+                </div>
+            </div>
+            <div class="device-meta">desktop · ≥ 1024 px</div>
+        </div>
+
+        <!-- Tablet -->
+        <div class="device tablet" style="width: 460px;">
+            <div class="form-viewport">
+                <div class="form-title">Customer · CST-00142</div>
+                <div class="form-sub">tablet · 8-col</div>
+
+                <div class="layout-grid cols-8">
+                    <div class="fld col-4">
+                        <label>First name <span class="req">*</span></label>
+                        <input value="Alice" />
+                    </div>
+                    <div class="fld col-4">
+                        <label>Last name <span class="req">*</span></label>
+                        <input value="Smith" />
+                    </div>
+                    <div class="fld col-8">
+                        <label>Email</label>
+                        <input value="alice@example.com" />
+                    </div>
+                    <div class="fld col-3">
+                        <label>Status</label>
+                        <select><option>active</option></select>
+                    </div>
+                    <div class="fld col-3">
+                        <label>Tier</label>
+                        <select><option>Gold</option></select>
+                    </div>
+                    <div class="fld col-2">
+                        <label>Active</label>
+                        <select><option>Y</option></select>
+                    </div>
+                    <div class="fld col-8">
+                        <label>Notes</label>
+                        <textarea>VIP — handle with care.</textarea>
+                    </div>
+                </div>
+                <div class="actions">
+                    <button>Cancel</button>
+                    <button class="primary">Save</button>
+                </div>
+            </div>
+            <div class="device-meta">tablet · ≥ 640 px</div>
+        </div>
+
+        <!-- Mobile -->
+        <div class="device phone">
+            <div class="notch"></div>
+            <div class="form-viewport">
+                <div class="form-title">Customer · CST-00142</div>
+                <div class="form-sub">mobile · stacked</div>
+
+                <div class="layout-grid cols-4">
+                    <div class="fld">
+                        <label>First name <span class="req">*</span></label>
+                        <input value="Alice" />
+                    </div>
+                    <div class="fld">
+                        <label>Last name <span class="req">*</span></label>
+                        <input value="Smith" />
+                    </div>
+                    <div class="fld">
+                        <label>Email</label>
+                        <input value="alice@example.com" />
+                    </div>
+                    <div class="fld">
+                        <label>Status</label>
+                        <select><option>active</option></select>
+                    </div>
+                    <div class="fld">
+                        <label>Notes</label>
+                        <textarea>VIP — handle with care.</textarea>
+                    </div>
+                </div>
+                <div class="actions">
+                    <button class="primary" style="width:100%;">Save</button>
+                </div>
+            </div>
+            <div class="device-meta">mobile · &lt; 640 px</div>
+        </div>
+    </div>
+
+    <!-- ════════ Section 3: Today vs. Elastic on a phone ════════ -->
+    <h2>3 · Today vs. Elastic on a 380 px phone</h2>
+
+    <div class="device-row" style="background: var(--bg-secondary);">
+        <!-- Today: pixel layout, horizontal scroll -->
+        <div class="device phone" style="overflow: hidden;">
+            <div class="notch"></div>
+            <div class="form-viewport" style="padding: 0; overflow: auto;">
+                <div style="padding: 14px;">
+                    <div class="form-title">Customer · CST-00142</div>
+                    <div class="form-sub" style="color: var(--accent-red);">
+                        TODAY · pixel-positioned · 800 px wide
+                    </div>
+                </div>
+                <div class="layout-desktop" style="width: 800px; height: 360px; padding: 14px;">
+                    <div class="fld" style="left:14px; top: 4px; width: 180px;">
+                        <label>First name</label>
+                        <input value="Alice" />
+                    </div>
+                    <div class="fld" style="left: 210px; top: 4px; width: 180px;">
+                        <label>Last name</label>
+                        <input value="Smith" />
+                    </div>
+                    <div class="fld" style="left: 410px; top: 4px; width: 360px;">
+                        <label>Email</label>
+                        <input value="alice@example.com" />
+                    </div>
+                    <div class="fld" style="left: 14px; top: 80px; width: 180px;">
+                        <label>Status</label>
+                        <select><option>active</option></select>
+                    </div>
+                    <div class="fld" style="left: 210px; top: 80px; width: 180px;">
+                        <label>Tier</label>
+                        <select><option>Gold</option></select>
+                    </div>
+                    <div class="fld" style="left: 410px; top: 80px; width: 360px;">
+                        <label>Notes</label>
+                        <textarea>VIP — handle with care.</textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="device-meta" style="color: var(--accent-red);">Horizontal scroll · cramped · no save button visible</div>
+        </div>
+
+        <!-- Elastic on the same phone -->
+        <div class="device phone">
+            <div class="notch"></div>
+            <div class="form-viewport">
+                <div class="form-title">Customer · CST-00142</div>
+                <div class="form-sub" style="color: var(--accent-green);">
+                    ELASTIC · auto-stacked · 380 px
+                </div>
+
+                <div class="layout-grid cols-4">
+                    <div class="fld">
+                        <label>First name <span class="req">*</span></label>
+                        <input value="Alice" />
+                    </div>
+                    <div class="fld">
+                        <label>Last name <span class="req">*</span></label>
+                        <input value="Smith" />
+                    </div>
+                    <div class="fld">
+                        <label>Email</label>
+                        <input value="alice@example.com" />
+                    </div>
+                    <div class="fld">
+                        <label>Status</label>
+                        <select><option>active</option></select>
+                    </div>
+                    <div class="fld">
+                        <label>Tier</label>
+                        <select><option>Gold</option></select>
+                    </div>
+                </div>
+                <div class="actions">
+                    <button class="primary" style="width:100%;">Save</button>
+                </div>
+            </div>
+            <div class="device-meta" style="color: var(--accent-green);">Single-column · 44 px touch targets · primary action visible</div>
+        </div>
+    </div>
+
+    <!-- ════════ Section 4: Notes ════════ -->
+    <h2>4 · Implementation notes (no code changed)</h2>
+
+    <div class="inspector" style="padding: 18px 22px;">
+        <ul style="list-style: none; padding: 0;">
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Schema is already responsive-ready.</b>
+                <code>LayoutDefinition</code> has <code>Breakpoints</code> and
+                <code>ControlDefinition</code> has <code>RendererHints</code>. Per-breakpoint
+                geometry can ride in <code>RendererHints["breakpoint:mobile"] = { x, y, w, h, hidden }</code>
+                with no model migration. <code>DesignerState.IsVisibleAtBreakpoint</code> and
+                <code>GetEffectiveRect</code> already handle this design-side.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Add a <code>LayoutMode</code> field to <code>LayoutDefinition</code></b>
+                — values: <code>FixedPixel</code> (today's behavior) and <code>Elastic</code>.
+                Existing forms default to <code>FixedPixel</code>, so nothing changes for them.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Runtime <code>FormRenderer.razor</code> picks the layout</b> using
+                a CSS container query (or a one-time <code>window.matchMedia</code> probe) and emits
+                either:
+                <br>—  <code>position: absolute; left/top/width/height</code> (FixedPixel, today),
+                <br>—  CSS Grid with <code>grid-column: span N</code> per control (Elastic).
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Auto-elastic for legacy forms</b> — when a form is <code>FixedPixel</code> but the
+                viewport is below the tablet breakpoint, the renderer can synthesize a column span
+                from the original <code>Rect.Width / canvasWidth × 12</code> and order by
+                <code>Rect.Y</code>. Doesn't require redesigning every form.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Designer changes</b> — toolbar gains a Layout-mode segmented control and a
+                Preview-device segmented control. The existing 8 px snap-to-grid stays. Property
+                inspector grows a "Span at desktop / tablet / mobile" row per control. The "2
+                controls overflow at Mobile" pill is a lint warning that links to the offenders.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Runtime niceties</b> — touch targets ≥ 44 px on mobile, primary action sticks to
+                the bottom of the viewport, the toolbar ([DataEntry.razor toolbar](../../src/CSharpDB.Admin.Forms/Pages/DataEntry.razor)) becomes a <code>flex-wrap</code> row that
+                collapses Print/Edit-Form behind a "⋯" overflow on small screens. Print stylesheet
+                ignores breakpoints and renders the desktop layout as today.
+            </li>
+            <li style="padding: 8px 0;">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Out of scope for this proposal</b> — touch-drag in the designer (designer can
+                stay desktop-only), mobile-specific control variants (e.g. native date picker), and
+                an offline data-entry mode.
+            </li>
+        </ul>
+    </div>
+
+    <p style="font-size: 12px; color: var(--text-muted); margin-top: 28px;">
+        Back to <a href="index.html">all mockups</a>.
+    </p>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/heavy-tab.html
+++ b/www/admin-ui-mockups/heavy-tab.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Heavy tab → vertical sub-nav (Storage example) — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    .sidebar { padding: 10px; font-size: 12px; color: var(--text-secondary); }
+    .sidebar .grp { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; padding: 8px 6px 4px; }
+    .sidebar .it { padding: 4px 6px; display: flex; align-items: center; gap: 6px; border-radius: 4px; cursor: pointer; }
+    .sidebar .it:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+    .heavy {
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+    }
+
+    /* Vertical sub-nav rail */
+    .rail {
+        background: var(--bg-secondary);
+        border-right: 1px solid var(--border-color);
+        display: flex;
+        flex-direction: column;
+        overflow-y: auto;
+    }
+    .rail-head {
+        padding: 12px 14px 8px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+        color: var(--text-muted);
+        border-bottom: 1px solid var(--border-color);
+    }
+    .rail-section {
+        padding: 8px 0 4px;
+    }
+    .rail-section .label {
+        padding: 6px 14px 4px;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+        color: var(--text-muted);
+    }
+    .rail-item {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        padding: 7px 14px;
+        font-size: 12.5px;
+        color: var(--text-secondary);
+        cursor: pointer;
+        border-left: 2px solid transparent;
+    }
+    .rail-item:hover { color: var(--text-primary); background: var(--bg-hover); }
+    .rail-item.active {
+        color: var(--text-primary);
+        background: rgba(122,162,247,0.1);
+        border-left-color: var(--accent-blue);
+    }
+    .rail-item .ico { width: 16px; text-align: center; font-size: 13px; color: var(--text-muted); }
+    .rail-item.active .ico { color: var(--accent-blue); }
+    .rail-item .badge {
+        margin-left: auto;
+        font-size: 10px;
+        padding: 1px 7px;
+        border-radius: 999px;
+        background: rgba(255,255,255,0.06);
+        color: var(--text-muted);
+    }
+    .rail-item .badge.warn { color: var(--accent-yellow); background: rgba(224,175,104,0.15); }
+    .rail-item .badge.err { color: var(--accent-red); background: rgba(247,118,142,0.15); }
+
+    /* Main pane */
+    .pane {
+        overflow-y: auto;
+        padding: 22px 28px 60px;
+    }
+    .pane h1 {
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+    .pane .crumb { color: var(--text-muted); font-size: 12px; margin-bottom: 4px; }
+    .pane .lede { color: var(--text-secondary); font-size: 12.5px; margin: 6px 0 18px; max-width: 720px; }
+
+    .pane-toolbar {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 18px;
+    }
+
+    .card {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        margin-bottom: 16px;
+        overflow: hidden;
+    }
+    .card header {
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .card h3 { font-size: 13px; font-weight: 600; }
+    .card .body { padding: 14px 16px; font-size: 12.5px; color: var(--text-secondary); }
+    .card table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+    .card table th, .card table td {
+        padding: 7px 10px;
+        text-align: left;
+        font-size: 12px;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .card table th { color: var(--text-muted); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; }
+    .card table tr:last-child td { border-bottom: none; }
+    .card table td.mono { font-family: var(--font-mono); color: var(--text-primary); }
+    .card table td.num { font-family: var(--font-mono); color: var(--accent-orange); text-align: right; }
+
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+
+    .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-size: 10.5px;
+        font-weight: 600;
+    }
+    .pill.ok { background: rgba(158,206,106,0.12); color: var(--accent-green); }
+    .pill.warn { background: rgba(224,175,104,0.12); color: var(--accent-yellow); }
+    .pill.err { background: rgba(247,118,142,0.12); color: var(--accent-red); }
+
+    .bar { background: var(--bg-tertiary); border-radius: 4px; height: 8px; overflow: hidden; margin-top: 6px; }
+    .bar > span { display: block; height: 100%; background: var(--accent-yellow); border-radius: 4px; }
+
+    .meter {
+        display: flex;
+        gap: 18px;
+        align-items: center;
+        padding: 12px 16px;
+        background: var(--bg-tertiary);
+        border-radius: var(--radius-md);
+        margin-bottom: 14px;
+    }
+    .meter .value { font-size: 22px; font-weight: 700; color: var(--text-primary); }
+    .meter .label { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+</style>
+</head>
+<body>
+<div class="app">
+
+    <div class="titlebar">
+        <div class="brand">
+            <div class="logo">C#</div>
+            <span>CSharpDB Studio</span>
+            <span class="dbname">— relational.db</span>
+        </div>
+        <button class="db-switcher"><i class="bi bi-database"></i> relational.db <i class="bi bi-caret-down-fill"></i></button>
+        <button class="palette-launcher"><i class="bi bi-search"></i> Search anything… <span class="kbd">Ctrl K</span></button>
+        <div class="spacer"></div>
+        <span class="conn-pill"><span class="dot"></span> Connected</span>
+    </div>
+
+    <div class="body">
+        <aside class="sidebar">
+            <div class="grp">▾ Tables · 24</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Orders</div>
+            <div class="grp">▸ System</div>
+            <div class="grp" style="margin-top: 12px;">Admin</div>
+            <div class="it" style="background: rgba(122,162,247,0.1); color: var(--text-primary); border-left: 2px solid var(--accent-blue); padding-left: 4px;">
+                <i class="bi bi-hdd-stack icon-system"></i> Storage
+            </div>
+        </aside>
+
+        <div class="content" style="overflow: hidden;">
+            <div class="tabstrip">
+                <div class="tab"><i class="bi bi-grid-1x2 icon-table"></i> Dashboard</div>
+                <div class="tab active"><i class="bi bi-hdd-stack icon-system"></i> Storage <i class="bi bi-x"></i></div>
+                <button class="tab-new"><i class="bi bi-plus"></i></button>
+            </div>
+
+            <div class="heavy">
+                <!-- Vertical sub-nav -->
+                <aside class="rail">
+                    <div class="rail-head">Storage Inspector</div>
+
+                    <div class="rail-section">
+                        <div class="label">Overview</div>
+                        <div class="rail-item active">
+                            <i class="bi bi-speedometer2 ico"></i>
+                            <span>Summary</span>
+                        </div>
+                    </div>
+
+                    <div class="rail-section">
+                        <div class="label">Inspect</div>
+                        <div class="rail-item">
+                            <i class="bi bi-file-binary ico"></i>
+                            <span>Database header</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-journal-text ico"></i>
+                            <span>WAL</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-pie-chart ico"></i>
+                            <span>Space usage</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-bar-chart-steps ico"></i>
+                            <span>Page histogram</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-search ico"></i>
+                            <span>Page drill-down</span>
+                        </div>
+                    </div>
+
+                    <div class="rail-section">
+                        <div class="label">Health</div>
+                        <div class="rail-item">
+                            <i class="bi bi-shield-check ico"></i>
+                            <span>Index checks</span>
+                            <span class="badge ok">OK</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-exclamation-triangle ico"></i>
+                            <span>Integrity issues</span>
+                            <span class="badge warn">3</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-grid-3x2-gap ico"></i>
+                            <span>Fragmentation</span>
+                        </div>
+                    </div>
+
+                    <div class="rail-section">
+                        <div class="label">Maintenance</div>
+                        <div class="rail-item">
+                            <i class="bi bi-arrow-repeat ico"></i>
+                            <span>Reindex</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-bounding-box-circles ico"></i>
+                            <span>Vacuum</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-download ico"></i>
+                            <span>Backup &amp; Restore</span>
+                        </div>
+                        <div class="rail-item">
+                            <i class="bi bi-link-45deg ico"></i>
+                            <span>FK migration</span>
+                        </div>
+                    </div>
+                </aside>
+
+                <!-- Main pane: Summary -->
+                <div class="pane">
+                    <div class="crumb">Storage / Overview</div>
+                    <h1>Summary</h1>
+                    <p class="lede">An at-a-glance look at the database file. Pick a category from the rail on the left to drill into details.</p>
+
+                    <div class="pane-toolbar">
+                        <button class="btn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+                        <button class="btn"><i class="bi bi-shield-check"></i> Run integrity check</button>
+                        <button class="btn"><i class="bi bi-download"></i> Backup now</button>
+                    </div>
+
+                    <div class="grid-2">
+                        <div class="card">
+                            <header><h3>File</h3><span class="pill ok">healthy</span></header>
+                            <div class="body">
+                                <div class="meter">
+                                    <div>
+                                        <div class="value">2.4 GB</div>
+                                        <div class="label">Database file</div>
+                                    </div>
+                                    <div style="margin-left:auto; text-align:right;">
+                                        <div class="value" style="font-size: 14px; color: var(--text-secondary);">68%</div>
+                                        <div class="label">of 3.5 GB cap</div>
+                                    </div>
+                                </div>
+                                <div class="bar"><span style="width: 68%"></span></div>
+                                <table style="margin-top: 14px;">
+                                    <tr><td>Page size</td><td class="num">4 KB</td></tr>
+                                    <tr><td>Physical pages</td><td class="num">614,400</td></tr>
+                                    <tr><td>Freelist pages</td><td class="num">12</td></tr>
+                                    <tr><td>WAL file</td><td class="num">128 MB</td></tr>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="card">
+                            <header><h3>Health</h3><span class="pill warn">3 warnings</span></header>
+                            <div class="body">
+                                <table>
+                                    <tr><td>Index checks</td><td><span class="pill ok">all OK</span></td></tr>
+                                    <tr><td>Integrity issues</td><td><span class="pill warn">3 warnings</span></td></tr>
+                                    <tr><td>Last integrity check</td><td>2h ago</td></tr>
+                                    <tr><td>Open writer txns</td><td class="num">1</td></tr>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="card">
+                            <header><h3>Recent maintenance</h3><span style="font-size:11px; color: var(--text-muted);">last 7 days</span></header>
+                            <div class="body">
+                                <table>
+                                    <tr><td>Last backup</td><td>16h ago · <span style="color:var(--text-primary);">customers.backup.db</span></td></tr>
+                                    <tr><td>Last vacuum</td><td>4d ago · 312 MB reclaimed</td></tr>
+                                    <tr><td>Last reindex</td><td>2d ago · 38 indexes</td></tr>
+                                    <tr><td>Last FK migration</td><td>—</td></tr>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="card">
+                            <header><h3>Page type histogram</h3></header>
+                            <div class="body">
+                                <table>
+                                    <tr><td class="mono">btree-leaf</td><td class="num">412,099</td></tr>
+                                    <tr><td class="mono">btree-internal</td><td class="num">8,213</td></tr>
+                                    <tr><td class="mono">overflow</td><td class="num">194,076</td></tr>
+                                    <tr><td class="mono">freelist</td><td class="num">12</td></tr>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <header>
+                            <h3>Top integrity issues</h3>
+                            <a href="#" style="font-size: 11px;">View all 3 →</a>
+                        </header>
+                        <table>
+                            <thead>
+                            <tr>
+                                <th style="width: 90px;">Severity</th>
+                                <th style="width: 160px;">Code</th>
+                                <th>Message</th>
+                                <th style="width: 70px; text-align:right;">Page</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td><span class="pill warn">WARN</span></td>
+                                <td class="mono">WAL_TRAILING_BYTES</td>
+                                <td>WAL file has 24 trailing bytes after the last commit frame.</td>
+                                <td class="num">—</td>
+                            </tr>
+                            <tr>
+                                <td><span class="pill warn">WARN</span></td>
+                                <td class="mono">FREELIST_GAP</td>
+                                <td>Freelist contains a gap; consider running vacuum.</td>
+                                <td class="num">512</td>
+                            </tr>
+                            <tr>
+                                <td><span class="pill warn">WARN</span></td>
+                                <td class="mono">INDEX_FREE_SPACE_HIGH</td>
+                                <td>Index <code>ix_customers_email</code> has &gt;50% free space across leaf pages.</td>
+                                <td class="num">3,212</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="statusbar">
+        <span class="pill ok"><span class="dot"></span> Connected</span>
+        <span class="pill"><i class="bi bi-database"></i> relational.db</span>
+        <span class="pill warn"><i class="bi bi-exclamation-triangle"></i> 3 storage warnings</span>
+        <div style="flex:1"></div>
+        <span class="pill warn"><i class="bi bi-hdd"></i> 2.4 GB / 3.5 GB</span>
+    </div>
+</div>
+
+<!-- Annotations -->
+<div class="notes">
+    <header><i class="bi bi-lightbulb"></i> The pattern: split heavy tabs into vertical sub-nav</header>
+    <ul>
+        <li><b style="color: var(--accent-green);">ALREADY EXISTS in StorageTab</b> — Database header, WAL, Space usage, Fragmentation, Maintenance (Reindex / Vacuum), Backup &amp; Restore, FK migration, Page-type histogram, Index checks, Integrity issues, Page drill-down. Each is a fully-featured section.</li>
+        <li><b style="color: var(--accent-red);">PROBLEM</b> — all eleven sections are <i>vertically stacked</i> in one long scroll. Users have to scroll past the file header every time they want to reach maintenance, and there's no overview of where to start.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Vertical sub-nav rail</b> on the left of the tab. Categories: Overview, Inspect, Health, Maintenance. Each item is one click away — no scrolling.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Summary screen</b> as the default view — surfaces the most useful facts (file size with cap, health pills, recent maintenance, top warnings) so a user landing on Storage gets value without picking a section.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Status badges in the rail</b> (e.g. "WARN 3" on Integrity issues) so users see what needs attention without opening every section.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">SAME PATTERN APPLIES TO</b>:</li>
+        <li style="padding-left: 24px;">— <b>Pipeline tab</b> — currently stacks Designer, Run Result, Stored Pipelines, Recent Runs vertically. Rail items: Designer / Run / Stored / History / Rejects.</li>
+        <li style="padding-left: 24px;">— <b>Procedure tab</b> — currently stacks Definition, Parameters, Execution. Rail items: Definition / Parameters / Run / Results.</li>
+        <li style="padding-left: 24px;">— <b>Schema view of Data tab</b> — currently stacks Columns, Alter Table, Indexes, Triggers. Could become sub-tabs as proposed in <a href="data-tab.html">data-tab.html</a>.</li>
+        <li><span class="pin"></span> <b>Implementation note:</b> the rail items are routes within a single tab; switching them does not open a new top-level tab. State (e.g. an unsaved JSON edit in Pipeline) is preserved across rail switches.</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/index.html
+++ b/www/admin-ui-mockups/index.html
@@ -1,0 +1,539 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>CSharpDB Admin — UI Improvement Mockups</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    body { overflow: auto; }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 56px 32px 80px; }
+    h1 { font-size: 28px; font-weight: 700; margin-bottom: 6px; letter-spacing: -0.02em; }
+    .lede { color: var(--text-secondary); font-size: 14px; max-width: 760px; margin-bottom: 8px; }
+    .scope { color: var(--text-muted); font-size: 12px; margin-bottom: 36px; }
+    h2 { font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.7px; color: var(--text-muted); margin: 36px 0 14px; }
+
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: 16px;
+    }
+    .card {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        transition: border-color 120ms ease, transform 120ms ease;
+    }
+    .card:hover { border-color: var(--border-light); transform: translateY(-1px); }
+    .card-thumb {
+        height: 130px;
+        background: var(--bg-tertiary);
+        position: relative;
+        overflow: hidden;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .card-thumb .glyph {
+        position: absolute;
+        font-size: 64px;
+        color: var(--accent-blue);
+        opacity: 0.25;
+        right: 16px;
+        bottom: -8px;
+    }
+    .card-thumb .preview {
+        position: absolute;
+        inset: 14px;
+        border-radius: 6px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border-color);
+        padding: 8px;
+        font-size: 9px;
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+        overflow: hidden;
+    }
+    .card-thumb .preview .row { display: block; padding: 1px 0; }
+    .card-thumb .preview .row.head { color: var(--accent-blue); font-weight: 700; }
+    .card-thumb .preview .row.dim { color: var(--text-muted); opacity: 0.5; }
+
+    .card-body { padding: 14px 16px; flex: 1; display: flex; flex-direction: column; }
+    .card h3 { font-size: 14px; font-weight: 600; margin-bottom: 4px; }
+    .card p { font-size: 12px; color: var(--text-secondary); flex: 1; }
+    .card-footer {
+        padding: 10px 16px;
+        border-top: 1px solid var(--border-color);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 11px;
+    }
+    .badge {
+        font-size: 10px;
+        padding: 2px 7px;
+        border-radius: 999px;
+        background: rgba(122,162,247,0.12);
+        color: var(--accent-blue);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        font-weight: 600;
+    }
+    .badge.green { background: rgba(158,206,106,0.12); color: var(--accent-green); }
+    .badge.yellow { background: rgba(224,175,104,0.12); color: var(--accent-yellow); }
+    .badge.magenta { background: rgba(187,154,247,0.12); color: var(--accent-magenta); }
+    .badge.red { background: rgba(247,118,142,0.12); color: var(--accent-red); }
+
+    .summary {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        padding: 18px 22px;
+        margin-bottom: 8px;
+    }
+    .summary ul { list-style: none; }
+    .summary li { padding: 6px 0; color: var(--text-secondary); font-size: 13px; display: flex; gap: 10px; }
+    .summary li::before { content: "→"; color: var(--accent-blue); flex-shrink: 0; }
+    .summary li b { color: var(--text-primary); font-weight: 600; }
+
+    .legend {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        padding: 14px 18px;
+        margin-bottom: 26px;
+        display: flex;
+        gap: 20px;
+        font-size: 12px;
+        color: var(--text-secondary);
+        flex-wrap: wrap;
+    }
+    .legend .item { display: inline-flex; align-items: center; gap: 8px; }
+    .legend .swatch {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+    .legend .new { background: rgba(122,162,247,0.12); color: var(--accent-blue); }
+    .legend .restyle { background: rgba(187,154,247,0.12); color: var(--accent-magenta); }
+    .legend .exists { background: rgba(158,206,106,0.12); color: var(--accent-green); }
+    .legend .gap { background: rgba(247,118,142,0.12); color: var(--accent-red); }
+
+    table.delta {
+        width: 100%;
+        border-collapse: collapse;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+        font-size: 12.5px;
+    }
+    table.delta th, table.delta td {
+        padding: 10px 14px;
+        text-align: left;
+        border-bottom: 1px solid var(--border-color);
+        vertical-align: top;
+    }
+    table.delta th {
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        font-weight: 600;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+    }
+    table.delta tr:last-child td { border-bottom: none; }
+    table.delta td.area { font-weight: 600; color: var(--text-primary); white-space: nowrap; }
+
+    .tag {
+        display: inline-block;
+        padding: 1px 7px;
+        border-radius: 4px;
+        font-size: 10px;
+        font-weight: 600;
+        margin-right: 4px;
+    }
+    .tag.new { background: rgba(122,162,247,0.12); color: var(--accent-blue); }
+    .tag.restyle { background: rgba(187,154,247,0.12); color: var(--accent-magenta); }
+    .tag.exists { background: rgba(158,206,106,0.12); color: var(--accent-green); }
+    .tag.gap { background: rgba(247,118,142,0.12); color: var(--accent-red); }
+</style>
+</head>
+<body>
+<div class="wrap">
+    <h1>CSharpDB Admin · UI Improvement Mockups</h1>
+    <p class="lede">Static HTML previews of proposed enhancements to the Blazor Server admin
+        (<code>src/CSharpDB.Admin</code>). Nothing here is wired to the live app — these are visual
+        proposals for discussion, now reconciled against the actual current screens.</p>
+    <p class="scope">Open each file directly in a browser to see the mocked screen with annotations.</p>
+
+    <div class="legend">
+        <div class="item"><span class="swatch new">NEW</span> Capability that doesn't exist today</div>
+        <div class="item"><span class="swatch restyle">RESTYLE</span> Existing feature, reorganized or visually refreshed</div>
+        <div class="item"><span class="swatch exists">EXISTS</span> Already in the live admin (don't propose as new)</div>
+        <div class="item"><span class="swatch gap">GAP</span> Missing today, this mockup adds it</div>
+    </div>
+
+    <h2>The big ideas at a glance</h2>
+    <div class="summary">
+        <ul>
+            <li><b>Replace the sparse Welcome tab</b> with a real database dashboard: stat cards, top tables with sparklines, recent activity feed, pinned objects, quick actions, and a consolidated health panel.</li>
+            <li><b>Add a command palette</b> (Ctrl+K) — there is no global search today; users must navigate the sidebar tree or right-click for actions.</li>
+            <li><b>Sidebar gains Pinned + Recent + drill-down</b> under each table. The existing search/filter and right-click context menus stay; pin star and per-group "+" become discoverable.</li>
+            <li><b>Data tab refresh</b> is mostly visual — most "features" I first proposed (per-column filters, sortable headers, type badges, pagination, inline edit, row selection, save/discard) <i>already exist</i>. The genuine adds are: breadcrumb header, filter summary chips, schema sub-tabs, export/import, bulk-edit / copy-as-INSERT, status-bar table facts.</li>
+            <li><b>Query tab gains result sub-tabs</b> (Results / Plan / Messages / Stats), an Explain Plan button, a Cancel button, and a query-history rail. Run / Format / Save / Designer mode / autocomplete / completions popup all already exist.</li>
+            <li><b>Heavy tabs (Storage / Pipeline / Procedure)</b> currently stack 4–11 sections in one long scroll. Replace with a vertical sub-nav rail and a Summary screen so users land on something useful.</li>
+            <li><b>Forms reflow on mobile</b> via a new Elastic layout mode in <code>CSharpDB.Admin.Forms</code> — today every control is absolute-positioned in pixels, so phone users get horizontal scroll. Schema already has <code>Breakpoints</code> and <code>RendererHints</code>; the runtime just doesn't use them.</li>
+            <li><b>Reports get a Reader view</b> in <code>CSharpDB.Admin.Reports</code> — paper layout stays untouched (it's supposed to look like paper, and Print/PDF need it), but a derived Reader view turns bands into sections and repeated detail rows into cards. Phone defaults to Reader.</li>
+            <li><b>Report designer surfaces the Reader view</b> via a Paper / Reader / Split toolbar toggle, a live phone-sized preview pane, a Reader-hint subsection in the Selection inspector, an "Auto-derive all hints" action, and a Reader-lint panel — so the runtime view never drifts from designer intent.</li>
+            <li><b>Title bar gains a database switcher</b> (recent databases dropdown) and a search-style command-palette launcher. Today there's just an "Open Database" button that opens a path prompt.</li>
+        </ul>
+    </div>
+
+    <h2>Mockups</h2>
+    <div class="grid">
+
+        <a class="card" href="dashboard.html">
+            <div class="card-thumb">
+                <div class="preview">
+                    <span class="row head">DASHBOARD · relational.db</span>
+                    <span class="row">┌─ Tables ──┬─ Views ──┬─ Procs ──┐</span>
+                    <span class="row">│   24      │    6     │    11    │</span>
+                    <span class="row">└───────────┴──────────┴──────────┘</span>
+                    <span class="row dim">Top tables  ▮▮▮▮▮▮▮▮ Customers</span>
+                    <span class="row dim">            ▮▮▮▮▮▮   Orders</span>
+                    <span class="row dim">            ▮▮▮▮     Invoices</span>
+                </div>
+                <i class="bi bi-grid-1x2 glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Database Dashboard</h3>
+                <p>Replaces the sparse Welcome tab. Stats, top tables with sparklines, recent activity, pinned objects, quick actions, health panel. Mostly net-new content.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge">High impact · mostly new</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+        <a class="card" href="command-palette.html">
+            <div class="card-thumb">
+                <div class="preview" style="display:flex; flex-direction:column; justify-content:center; padding: 18px;">
+                    <span class="row head" style="text-align:center;">⌘  Search anything</span>
+                    <span class="row dim" style="margin: 6px 0;">────────────────────────────</span>
+                    <span class="row">▶ Open table: Customers</span>
+                    <span class="row dim">  Run: Select Top 50</span>
+                    <span class="row dim">  New Form for Customers</span>
+                </div>
+                <i class="bi bi-command glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Command Palette (Ctrl+K)</h3>
+                <p>One keystroke to fuzzy-find tables, forms, reports, procedures, or actions. There is no global search in the app today — this is purely additive.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge magenta">Fully new</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+        <a class="card" href="sidebar.html">
+            <div class="card-thumb">
+                <div class="preview">
+                    <span class="row head">★ PINNED</span>
+                    <span class="row dim">  ▦ Customers   ▦ Orders</span>
+                    <span class="row head" style="margin-top:4px;">⏱ RECENT</span>
+                    <span class="row dim">  ▦ Invoices    ◫ Customer Form</span>
+                    <span class="row head" style="margin-top:4px;">▾ TABLES <span style="color:var(--text-muted)">24</span> +</span>
+                    <span class="row dim">  ▦ Customers</span>
+                    <span class="row dim">  ▦ Orders</span>
+                </div>
+                <i class="bi bi-list-nested glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Improved Object Explorer</h3>
+                <p>Pinned + Recent sections, type filter chips, drill-down under tables (columns / indexes / triggers as nested rows). The base tree, search, and right-click menus already exist.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge green">High value · adds + restyle</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+        <a class="card" href="data-tab.html">
+            <div class="card-thumb">
+                <div class="preview">
+                    <span class="row head">tables / Customers · 1,247 rows</span>
+                    <span class="row dim">[Data] Schema  Indexes  Triggers</span>
+                    <span class="row dim">▼ status = active   ▼ created &gt; 2026-01</span>
+                    <span class="row" style="color: var(--accent-blue);">  id │ name      │ email     │ status</span>
+                    <span class="row dim">───┼───────────┼───────────┼───────</span>
+                    <span class="row dim">  1│ A. Smith  │ as@e.com  │ active</span>
+                    <span class="row dim">  2│ B. Lee    │ bl@e.com  │ active</span>
+                </div>
+                <i class="bi bi-table glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Data Tab refresh</h3>
+                <p>Most filter / sort / pagination / type-badge / inline-edit features <i>already exist</i>. Real adds: breadcrumb, filter chip summary, schema sub-tabs, export, bulk action bar.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge yellow">Mostly visual + gap-fill</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+        <a class="card" href="query-tab.html">
+            <div class="card-thumb">
+                <div class="preview">
+                    <span class="row head">▶ Run · Format · Explain · SQL</span>
+                    <span class="row" style="color: var(--accent-magenta);">SELECT</span><span class="row"> c.id, c.name, COUNT(o.id)</span>
+                    <span class="row"><span style="color: var(--accent-magenta);">FROM</span> Customers c …</span>
+                    <span class="row dim">─────────────────────────────</span>
+                    <span class="row dim">[Results · 1247] Plan  Messages</span>
+                    <span class="row dim">  id │ name        │ orders</span>
+                    <span class="row dim">  1  │ Alice Smith │ 12</span>
+                </div>
+                <i class="bi bi-terminal glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Query Tab refresh</h3>
+                <p>Result sub-tabs (Results / Plan / Messages / Stats), Explain &amp; Cancel buttons, query-history rail. Run / Format / Save / Designer / autocomplete already exist.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge">Adds + restyle</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+        <a class="card" href="forms-mobile.html">
+            <div class="card-thumb">
+                <div class="preview" style="display:flex; gap:6px; padding:10px;">
+                    <div style="flex:1; border:1px solid var(--border-color); border-radius:3px; padding:4px; font-size:8px;">
+                        <span class="row head">DESKTOP</span>
+                        <span class="row dim">[ first ][ last ][ email     ]</span>
+                        <span class="row dim">[ status ][ tier ][ created  ]</span>
+                        <span class="row dim">[ notes ────────────────────  ]</span>
+                    </div>
+                    <div style="width:60px; border:1px solid var(--border-color); border-radius:8px; padding:4px; font-size:8px;">
+                        <span class="row head" style="text-align:center;">📱</span>
+                        <span class="row dim">[first ]</span>
+                        <span class="row dim">[last  ]</span>
+                        <span class="row dim">[email ]</span>
+                        <span class="row dim">[status]</span>
+                        <span class="row dim">[ Save ]</span>
+                    </div>
+                </div>
+                <i class="bi bi-phone glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Elastic Forms (mobile-friendly)</h3>
+                <p>Forms render with absolute pixel coords today and don't reflow on phones. Add an Elastic layout mode + auto-stack so the same form works on desktop, tablet, and mobile — schema is already responsive-ready.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge magenta">Mobile · forms project</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+        <a class="card" href="reports-mobile.html">
+            <div class="card-thumb">
+                <div class="preview" style="display:flex; gap:6px; padding:10px;">
+                    <div style="flex:1; border:1px solid var(--border-color); border-radius:3px; padding:4px; font-size:8px; background:#fff; color:#222;">
+                        <span class="row" style="color:#000; font-weight:700;">PAPER · Letter</span>
+                        <span class="row" style="color:#444;">ID │ Cust │ Orders │ Total</span>
+                        <span class="row" style="color:#444;">━━━━━━━━━━━━━━━━━━━━━━</span>
+                        <span class="row" style="color:#444;">1  │ A.S. │ 12     │ 4,950</span>
+                        <span class="row" style="color:#444;">4  │ D.S. │ 7      │ 2,723</span>
+                    </div>
+                    <div style="width:60px; border:1px solid var(--border-color); border-radius:8px; padding:4px; font-size:8px;">
+                        <span class="row head" style="text-align:center;">📱 Reader</span>
+                        <span class="row dim">▾ Tier·Gold</span>
+                        <span class="row dim">▦ Alice S.</span>
+                        <span class="row dim">  12 · $4,950</span>
+                        <span class="row dim">▦ David S.</span>
+                    </div>
+                </div>
+                <i class="bi bi-file-earmark-richtext glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Mobile-friendly Reports (Reader view)</h3>
+                <p>Reports are paper-shaped and shouldn't reflow. Add a derived Reader view: bands → sections, repeated rows → cards, group footers → summary lines. Phone defaults to Reader; Print &amp; PDF stay on Paper.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge magenta">Mobile · reports project</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+        <a class="card" href="reports-designer.html">
+            <div class="card-thumb">
+                <div class="preview" style="display:flex; gap:4px; padding:8px; font-size:7px;">
+                    <div style="width:30px; border:1px solid var(--border-color); border-radius:2px; padding:3px;">
+                        <span class="row dim">Tools</span>
+                        <span class="row dim">▦</span>
+                        <span class="row dim">T</span>
+                    </div>
+                    <div style="flex:1; border:1px solid var(--border-color); border-radius:2px; padding:3px; background:#fff; color:#222;">
+                        <span class="row" style="color:#000; font-weight:700;">Detail band</span>
+                        <span class="row" style="color:#444;">{id} {name} {total}</span>
+                        <span class="row" style="color:var(--accent-blue);">    [title][field]</span>
+                    </div>
+                    <div style="width:50px; border:1px solid var(--accent-blue); border-radius:5px; padding:3px;">
+                        <span class="row head" style="font-size:6px;">📱 Reader</span>
+                        <span class="row dim">▦ Alice</span>
+                        <span class="row dim">$4,950</span>
+                    </div>
+                </div>
+                <i class="bi bi-layout-split glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Report Designer · Reader-view support</h3>
+                <p>Paper / Reader / Split toggle in the toolbar, live phone preview alongside the paper canvas, Reader-hint subsection in the Selection inspector, and a one-click "Auto-derive all hints" + lint panel.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge magenta">Designer · reports project</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+        <a class="card" href="heavy-tab.html">
+            <div class="card-thumb">
+                <div class="preview">
+                    <span class="row head">▾ Storage</span>
+                    <span class="row" style="color: var(--accent-blue);">► Summary</span>
+                    <span class="row dim">  Database header</span>
+                    <span class="row dim">  WAL</span>
+                    <span class="row dim">  Space usage</span>
+                    <span class="row dim">  Integrity issues  ⚠ 3</span>
+                    <span class="row dim">  Vacuum / Reindex</span>
+                    <span class="row dim">  Backup &amp; Restore</span>
+                </div>
+                <i class="bi bi-hdd-stack glyph"></i>
+            </div>
+            <div class="card-body">
+                <h3>Heavy tabs → vertical sub-nav</h3>
+                <p>Storage, Pipeline, and Procedure tabs each stack 4–11 long sections. Add a left rail with a Summary screen so users land on something useful and can jump without scrolling.</p>
+            </div>
+            <div class="card-footer">
+                <span class="badge green">Pattern fix · cross-cutting</span>
+                <span>Open mockup →</span>
+            </div>
+        </a>
+
+    </div>
+
+    <h2>Reality check: what's actually in the live admin today</h2>
+    <p class="lede" style="margin-bottom: 14px;">After reading the actual tab components, the picture is more mature than my first pass assumed. Here's the delta per area.</p>
+
+    <table class="delta">
+        <thead>
+        <tr>
+            <th style="width:18%;">Area</th>
+            <th style="width:42%;">Already exists in the live admin</th>
+            <th style="width:40%;">Genuinely missing / proposed here</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td class="area">Welcome / first-run</td>
+            <td>App icon, name, four shortcut hints, table-card grid with optional row counts.</td>
+            <td><span class="tag new">NEW</span> Stat cards, top tables with sparklines, recent activity, pinned grid, quick actions, health panel.</td>
+        </tr>
+        <tr>
+            <td class="area">Object Explorer</td>
+            <td>Tree of Tables / Forms / Reports / System Catalog / Views / Indexes / Triggers / Procedures with counts; text filter; right-click menus on every kind; collapse-all; resize handle; active-tab highlighting.</td>
+            <td>
+                <span class="tag new">NEW</span> Pinned &amp; Recent sections, type filter chips, drill-down under each table (columns / indexes / triggers nested), match highlighting in filter results.<br>
+                <span class="tag restyle">RESTYLE</span> per-item star + ⋯, per-group "+" on hover.
+            </td>
+        </tr>
+        <tr>
+            <td class="area">Data tab</td>
+            <td>Data ↔ Schema view switcher, Add Row / Delete (with count) / Save / Discard / Refresh, per-column filter row with Contains/StartsWith/EndsWith/Exact, sort indicators, type badges, PK badges, pagination, inline edit, row selection, NULL/BLOB rendering, modified-cell styling, right-click context menu.</td>
+            <td>
+                <span class="tag new">NEW</span> Breadcrumb header, filter summary chips, schema sub-tabs, export/import, bulk-edit + copy-as-INSERT, status-bar table facts.<br>
+                <span class="tag restyle">RESTYLE</span> column type icons (vs text badges), enum status pills, value-type cell coloring.
+            </td>
+        </tr>
+        <tr>
+            <td class="area">Query tab</td>
+            <td>Run / Analyze / Clear / Format / Save buttons, saved-query dropdown, Stats shortcuts, SQL ↔ Designer mode toggle, resizable editor with persisted height, line numbers, syntax highlighting, autocomplete popup with arrow-key nav, Ctrl+Enter, EXEC procedure parsing with named args.</td>
+            <td><span class="tag new">NEW</span> Result sub-tabs (Results / Plan / Messages / Stats), Explain Plan button, Cancel button, query-history rail per-tab and global.</td>
+        </tr>
+        <tr>
+            <td class="area">Storage tab</td>
+            <td>11 stacked sections: DB header, WAL, Space usage, Fragmentation, Maintenance (Reindex / Vacuum), Backup / Restore, FK migration, Page-type histogram, Index checks, Integrity issues, Page drill-down. Refresh, hex dump toggle.</td>
+            <td><span class="tag new">NEW</span> Vertical sub-nav rail, default Summary screen, status badges in nav, recent-maintenance recap.</td>
+        </tr>
+        <tr>
+            <td class="area">Pipeline tab</td>
+            <td>Visual designer + JSON mode, Validate / Dry Run / Run / Save / Reset, stored pipelines list with revisions, recent runs with metrics, run inspector with rejects, resume.</td>
+            <td><span class="tag new">NEW</span> Sub-nav rail to navigate Designer / Run Result / Stored / History / Rejects without scrolling. (Same pattern as Storage.)</td>
+        </tr>
+        <tr>
+            <td class="area">Procedure tab</td>
+            <td>Definition (name / desc / enabled / body SQL), parameters table (name/type/required/default/desc), execution panel with args JSON, per-statement results.</td>
+            <td><span class="tag new">NEW</span> Sub-nav rail or sub-tabs for Definition / Parameters / Run / Results so the body editor isn't competing with the args panel.</td>
+        </tr>
+        <tr>
+            <td class="area">Forms (Admin.Forms)</td>
+            <td>Visual form designer with grid + snap, toolbox, layers panel, property inspector, child tabs, validation overrides, default form generation from a table schema, undo/redo, navigation, print, child datagrids. Schema model already has <code>LayoutDefinition.Breakpoints</code> and <code>ControlDefinition.RendererHints</code>; <code>DesignerState</code> already exposes <code>IsVisibleAtBreakpoint</code> and <code>GetEffectiveRect</code>.</td>
+            <td>
+                <span class="tag new">NEW</span> <code>LayoutMode = Elastic</code> on <code>LayoutDefinition</code>; runtime <code>FormRenderer</code> that emits CSS Grid spans (instead of <code>position: absolute</code> in pixels) and picks a breakpoint based on viewport.<br>
+                <span class="tag new">NEW</span> Designer toolbar gains Layout-mode + Device-preview segmented controls; property inspector gains per-breakpoint span / hidden flags; "controls overflow at this breakpoint" lint pill.<br>
+                <span class="tag new">NEW</span> Auto-elastic fallback for legacy forms — synthesize a 12-col span from the existing <code>Rect.Width / canvasWidth</code> so old forms get a usable mobile view without a redesign.
+            </td>
+        </tr>
+        <tr>
+            <td class="area">Reports (Admin.Reports)</td>
+            <td>Visual report designer with bands (ReportHeader / PageHeader / GroupHeader / Detail / GroupFooter / PageFooter / ReportFooter); Label / BoundText / CalculatedText / Line / Box controls; pixel-positioned within bands; preview pagination at fixed Letter 816 × 1056 px page; <code>overflow-x: auto</code> on the page surface; print stylesheet that hides toolbar; Export PDF; default report generation from a source schema; <code>RendererHints</code> on <code>ReportDefinition</code> and a <code>PropertyBag</code> on each control already available for extension.</td>
+            <td>
+                <span class="tag new">NEW</span> Reader view — derived from the same <code>ReportPreviewResult</code>; bands become collapsible sections, repeated Detail rows become cards, GroupFooter becomes a summary row. Auto-pick on phones; user toggle persists per report.<br>
+                <span class="tag new">NEW</span> Per-control reader hints in <code>Props["readerHint"]</code> (role: title / subtitle / field / hidden, custom label, showOnPhone). No schema migration.<br>
+                <span class="tag new">NEW</span> Paper-view zoom controls (Fit-width / 100% / 150% / 200%) and a sticky page pager so Paper is still tolerable on a phone when the user explicitly wants it.<br>
+                <span class="tag exists">EXISTS</span> Print and Export PDF continue to use Paper unchanged.
+            </td>
+        </tr>
+        <tr>
+            <td class="area">Reports designer</td>
+            <td>3-column layout: Toolbox (Pointer / Label / BoundText / Calculated / Line / Box) + Groups + Sorts on the left; per-band paper canvas with absolute pixel positions and pointer drag-resize in the center; Page Settings (Paper / Orientation / 4 margins) + Selection inspector (X/Y/W/H, type-specific props, Bring/Send/Delete) on the right. Pointer-driven; no touch affordances.</td>
+            <td>
+                <span class="tag new">NEW</span> Toolbar Paper / Reader / Split view toggle + Reader-device toggle (Tablet / Phone). Split mode shows the live Reader projection beside the paper canvas.<br>
+                <span class="tag new">NEW</span> Selection inspector grows a Reader-view subsection (Role: title / subtitle / field / hidden, custom label, "show on phone", quick-action buttons). Stored in <code>Props["readerHint"]</code> — no schema migration.<br>
+                <span class="tag new">NEW</span> Tiny role badges on canvas controls show what the Reader pickup will be.<br>
+                <span class="tag new">NEW</span> "Auto-derive all hints" action seeds hints from inference rules; Reader-lint panel surfaces issues with one-click fixes.<br>
+                <span class="tag exists">DELIBERATE NON-GOAL</span> The designer chrome itself stays desktop-only — the 3-column pointer-driven UI is right for building paper reports; only the Reader <i>preview</i> goes mobile-sized.
+            </td>
+        </tr>
+        <tr>
+            <td class="area">Title / status bars</td>
+            <td>Logo + db name, Open Database (path prompt), New Query / Table / Form / Procedure / Pipeline / Storage buttons, theme toggle, sidebar toggle, keyboard-shortcuts modal. Status bar shows connection, db path, table/view/proc counts.</td>
+            <td><span class="tag new">NEW</span> Database switcher dropdown with recent databases, command-palette launcher, status-bar storage pressure / background-job ticker / notification counter.</td>
+        </tr>
+        <tr>
+            <td class="area">Modals / toasts</td>
+            <td>Confirm modal with danger styling, prompt modal, toast container with success / warning / error, context menu with separators and danger items.</td>
+            <td><span class="tag new">NEW</span> Side drawers for non-blocking edits (e.g. column properties); rolling notification log accessible from the status bar.</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h2>Smaller wins worth doing</h2>
+    <div class="summary">
+        <ul>
+            <li><b>Tab strip</b>: dirty-dot indicator (already mocked), middle-click to close, overflow dropdown when there are too many tabs.</li>
+            <li><b>Density toggle</b> (Compact / Comfortable) so the same screens work on a 13" laptop and a 27" monitor.</li>
+            <li><b>Empty states with calls-to-action</b> — every empty list should suggest the next step ("No saved queries yet — press Ctrl+S in any query tab").</li>
+            <li><b>Inline help</b>: a "?" button per tab that opens a side-panel cheat-sheet for the active tab, instead of a single global keyboard-shortcut modal.</li>
+            <li><b>Toast → inbox</b>: keep a rolling notification log accessible from the status bar so users can re-read what happened.</li>
+        </ul>
+    </div>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/query-tab.html
+++ b/www/admin-ui-mockups/query-tab.html
@@ -1,0 +1,602 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Query Tab — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    .sidebar { padding: 10px; font-size: 12px; color: var(--text-secondary); }
+    .sidebar .grp { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; padding: 8px 6px 4px; }
+    .sidebar .it { padding: 4px 6px; display: flex; align-items: center; gap: 6px; border-radius: 4px; cursor: pointer; }
+    .sidebar .it:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+    .qt {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
+    /* Top toolbar (mirrors current QueryTab toolbar) */
+    .qt-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 14px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        flex-shrink: 0;
+    }
+    .tb {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 5px 11px;
+        background: transparent;
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-sm);
+        color: var(--text-secondary);
+        font-size: 12px;
+        cursor: pointer;
+    }
+    .tb:hover { background: var(--bg-hover); color: var(--text-primary); }
+    .tb.primary { background: var(--accent-blue); color: #0a0b13; border-color: var(--accent-blue); font-weight: 600; }
+    .tb.danger { color: var(--accent-red); }
+    .sep { width: 1px; height: 18px; background: var(--border-color); margin: 0 4px; }
+    .qt-mode {
+        display: flex;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+    }
+    .qt-mode button {
+        background: transparent;
+        border: none;
+        color: var(--text-muted);
+        font-size: 11px;
+        padding: 5px 11px;
+        cursor: pointer;
+    }
+    .qt-mode button.active { color: var(--accent-blue); background: var(--bg-active); font-weight: 600; }
+
+    .qt-info {
+        margin-left: auto;
+        font-size: 11px;
+        color: var(--text-muted);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+    .qt-info b { color: var(--text-primary); font-weight: 600; }
+
+    /* Saved queries / stats secondary bar (already exists in app, mocked for context) */
+    .secondary-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 14px;
+        background: var(--bg-primary);
+        border-bottom: 1px solid var(--border-color);
+        font-size: 11px;
+        color: var(--text-muted);
+        flex-wrap: wrap;
+    }
+    .secondary-bar .label {
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        font-weight: 600;
+        color: var(--text-secondary);
+        margin-right: 4px;
+    }
+    .secondary-bar input[type=text], .secondary-bar select {
+        padding: 3px 8px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        color: var(--text-primary);
+        font-size: 11px;
+        font-family: var(--font-ui);
+    }
+    .secondary-bar input[type=text] { width: 160px; }
+    .secondary-bar select { width: 200px; }
+
+    /* Workspace: editor on top, results panel on bottom; right rail with history */
+    .workspace {
+        flex: 1;
+        display: grid;
+        grid-template-columns: 1fr 280px;
+        min-height: 0;
+    }
+
+    .work-main {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    /* SQL editor block (mocked) */
+    .editor {
+        flex: 0 0 220px;
+        display: flex;
+        background: var(--bg-primary);
+        border-bottom: 1px solid var(--border-color);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        line-height: 1.6;
+        overflow: hidden;
+        position: relative;
+    }
+    .editor .gutter {
+        background: var(--bg-tertiary);
+        border-right: 1px solid var(--border-color);
+        color: var(--text-muted);
+        padding: 10px 8px;
+        text-align: right;
+        user-select: none;
+        min-width: 36px;
+    }
+    .editor .gutter span { display: block; }
+    .editor pre {
+        flex: 1;
+        padding: 10px 14px;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        margin: 0;
+    }
+    .kw { color: var(--accent-magenta); }
+    .fn { color: var(--accent-cyan); }
+    .str { color: var(--accent-green); }
+    .num { color: var(--accent-orange); }
+    .com { color: var(--text-muted); font-style: italic; }
+    .op { color: var(--accent-yellow); }
+
+    /* Resize handle */
+    .splitter {
+        height: 6px;
+        background: var(--bg-secondary);
+        cursor: row-resize;
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-shrink: 0;
+    }
+    .splitter::after {
+        content: "";
+        width: 32px; height: 3px;
+        background: var(--border-light);
+        border-radius: 2px;
+    }
+
+    /* Result panel with tab strip */
+    .results {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        background: var(--bg-primary);
+    }
+    .res-tabs {
+        display: flex;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        flex-shrink: 0;
+    }
+    .res-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 8px 14px;
+        font-size: 11.5px;
+        color: var(--text-muted);
+        border-right: 1px solid var(--border-color);
+        border-top: 2px solid transparent;
+        cursor: pointer;
+        background: transparent;
+        border-bottom: none;
+        border-left: none;
+    }
+    .res-tab:hover { color: var(--text-primary); background: var(--bg-hover); }
+    .res-tab.active {
+        color: var(--text-primary);
+        background: var(--bg-primary);
+        border-top-color: var(--accent-blue);
+    }
+    .res-tab .badge {
+        font-size: 9px;
+        padding: 1px 5px;
+        border-radius: 999px;
+        background: rgba(122,162,247,0.15);
+        color: var(--accent-blue);
+    }
+    .res-tab.active .badge { background: rgba(122,162,247,0.25); }
+    .res-tabs-meta {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 0 14px;
+        font-size: 11px;
+        color: var(--text-muted);
+    }
+    .res-tabs-meta b { color: var(--text-primary); font-variant-numeric: tabular-nums; }
+    .res-tabs-meta button {
+        background: transparent;
+        border: none;
+        color: var(--text-muted);
+        cursor: pointer;
+        font-size: 14px;
+    }
+    .res-tabs-meta button:hover { color: var(--text-primary); }
+
+    /* Result body */
+    .res-body {
+        flex: 1;
+        overflow: auto;
+        position: relative;
+    }
+    table.grid {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+        font-family: var(--font-mono);
+    }
+    table.grid thead th {
+        position: sticky;
+        top: 0;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        padding: 7px 10px;
+        text-align: left;
+        color: var(--text-secondary);
+        font-family: var(--font-ui);
+        font-weight: 600;
+        font-size: 11px;
+        white-space: nowrap;
+    }
+    table.grid tbody td {
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--border-color);
+        white-space: nowrap;
+        color: var(--text-primary);
+    }
+    table.grid tbody tr:hover td { background: var(--bg-hover); }
+    table.grid td.id { color: var(--accent-blue); font-weight: 600; }
+    table.grid td.num { color: var(--accent-orange); text-align: right; }
+    table.grid td.dt { color: var(--accent-yellow); }
+
+    /* Plan view (placeholder when "Plan" tab is active — but we show Results active) */
+    .messages {
+        padding: 14px;
+        font-family: var(--font-mono);
+        font-size: 12px;
+        color: var(--text-secondary);
+    }
+    .messages .ok { color: var(--accent-green); }
+
+    /* Right rail: history */
+    .rail {
+        background: var(--bg-secondary);
+        border-left: 1px solid var(--border-color);
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+    .rail-head {
+        padding: 10px 14px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+        color: var(--text-muted);
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .rail-tabs {
+        display: flex;
+        gap: 4px;
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .rail-tab {
+        padding: 3px 9px;
+        font-size: 10.5px;
+        border-radius: 999px;
+        color: var(--text-muted);
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        cursor: pointer;
+    }
+    .rail-tab.active {
+        color: var(--accent-blue);
+        background: rgba(122,162,247,0.12);
+        border-color: transparent;
+        font-weight: 600;
+    }
+
+    .hist-list { flex: 1; overflow-y: auto; padding: 4px 0; }
+
+    .hist-item {
+        padding: 9px 12px 9px 14px;
+        border-bottom: 1px solid var(--border-color);
+        cursor: pointer;
+        font-size: 11.5px;
+    }
+    .hist-item:hover { background: var(--bg-hover); }
+    .hist-item .meta {
+        display: flex;
+        justify-content: space-between;
+        font-size: 10px;
+        color: var(--text-muted);
+        margin-bottom: 4px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+    .hist-item .meta .ok { color: var(--accent-green); }
+    .hist-item .meta .err { color: var(--accent-red); }
+    .hist-item .sql {
+        font-family: var(--font-mono);
+        color: var(--text-secondary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 11px;
+    }
+    .hist-item .sql .kw { color: var(--accent-magenta); }
+    .hist-item .actions {
+        display: none;
+        gap: 6px;
+        margin-top: 6px;
+    }
+    .hist-item:hover .actions { display: flex; }
+    .hist-action {
+        font-size: 10px;
+        padding: 2px 7px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        color: var(--text-secondary);
+        cursor: pointer;
+    }
+    .hist-action:hover { color: var(--text-primary); border-color: var(--border-light); }
+
+    /* Plan / Messages tab examples kept off-screen but visible if user wants - use details for clarity */
+
+    /* Highlight a "completion popup" in editor for visual interest */
+    .completion {
+        position: absolute;
+        left: 220px;
+        top: 92px;
+        background: var(--bg-elevated);
+        border: 1px solid var(--border-light);
+        border-radius: 6px;
+        box-shadow: var(--shadow-popup);
+        padding: 4px 0;
+        min-width: 220px;
+        z-index: 5;
+    }
+    .completion .ci {
+        display: flex;
+        justify-content: space-between;
+        padding: 5px 12px;
+        font-size: 11.5px;
+        color: var(--text-secondary);
+        font-family: var(--font-ui);
+        gap: 12px;
+    }
+    .completion .ci.active { background: rgba(122,162,247,0.15); color: var(--accent-blue); }
+    .completion .ci .det { color: var(--text-muted); font-size: 10.5px; }
+
+</style>
+</head>
+<body>
+<div class="app">
+
+    <div class="titlebar">
+        <div class="brand">
+            <div class="logo">C#</div>
+            <span>CSharpDB Studio</span>
+            <span class="dbname">— relational.db</span>
+        </div>
+        <button class="db-switcher"><i class="bi bi-database"></i> relational.db <i class="bi bi-caret-down-fill"></i></button>
+        <button class="palette-launcher"><i class="bi bi-search"></i> Search anything… <span class="kbd">Ctrl K</span></button>
+        <div class="spacer"></div>
+        <span class="conn-pill"><span class="dot"></span> Connected</span>
+    </div>
+
+    <div class="body">
+        <aside class="sidebar">
+            <div class="grp">★ Pinned</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="grp">▾ Tables · 24</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Customers</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Orders</div>
+            <div class="it"><i class="bi bi-table icon-table"></i> Invoices</div>
+        </aside>
+
+        <div class="content" style="overflow: hidden;">
+            <div class="tabstrip">
+                <div class="tab"><i class="bi bi-grid-1x2 icon-table"></i> Dashboard</div>
+                <div class="tab"><i class="bi bi-table icon-table"></i> Customers <i class="bi bi-x"></i></div>
+                <div class="tab active dirty"><i class="bi bi-terminal" style="color: var(--accent-blue);"></i> Active customers <i class="bi bi-x"></i></div>
+                <button class="tab-new"><i class="bi bi-plus"></i></button>
+            </div>
+
+            <div class="qt">
+                <!-- Top toolbar -->
+                <div class="qt-toolbar">
+                    <button class="tb primary"><i class="bi bi-play-fill"></i> Run <span class="kbd">Ctrl ↵</span></button>
+                    <button class="tb danger"><i class="bi bi-stop-fill"></i> Cancel</button>
+                    <span class="sep"></span>
+                    <button class="tb"><i class="bi bi-bar-chart-line"></i> Analyze</button>
+                    <button class="tb"><i class="bi bi-eraser"></i> Clear</button>
+                    <button class="tb"><i class="bi bi-code-slash"></i> Format</button>
+                    <button class="tb"><i class="bi bi-diagram-2"></i> Explain Plan</button>
+                    <span class="sep"></span>
+                    <div class="qt-mode">
+                        <button class="active"><i class="bi bi-terminal"></i> SQL</button>
+                        <button><i class="bi bi-diagram-3"></i> Designer</button>
+                    </div>
+                    <div class="qt-info">
+                        <span><b>1,247</b> rows · <b>18.4</b> ms · page 1</span>
+                    </div>
+                </div>
+
+                <!-- Saved bar (already exists today; included for context) -->
+                <div class="secondary-bar">
+                    <span class="label"><i class="bi bi-bookmark-star"></i> Saved</span>
+                    <input type="text" placeholder="Query name…" value="Active customers" />
+                    <button class="tb" style="padding: 3px 9px;"><i class="bi bi-save"></i> Save</button>
+                    <select>
+                        <option>Load saved query…</option>
+                    </select>
+                    <button class="tb" style="padding: 3px 8px;"><i class="bi bi-download"></i> Load</button>
+                    <span class="sep"></span>
+                    <span class="label"><i class="bi bi-bar-chart-line"></i> Stats</span>
+                    <button class="tb" style="padding: 3px 9px;"><i class="bi bi-table"></i> Table Stats</button>
+                    <button class="tb" style="padding: 3px 9px;"><i class="bi bi-list-columns"></i> Column Stats</button>
+                </div>
+
+                <!-- Workspace -->
+                <div class="workspace">
+                    <div class="work-main">
+                        <!-- Editor -->
+                        <div class="editor">
+                            <div class="gutter">
+                                <span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span>
+                            </div>
+                            <pre><span class="com">-- Pull active customers with recent orders</span>
+<span class="kw">SELECT</span>  c.id,
+        c.name,
+        c.email,
+        <span class="fn">COUNT</span>(o.id) <span class="kw">AS</span> order_count
+<span class="kw">FROM</span> Customers <span class="kw">AS</span> c
+<span class="kw">LEFT JOIN</span> Orders <span class="kw">AS</span> o <span class="kw">ON</span> o.customer_id <span class="op">=</span> c.<span class="kw">i</span></pre>
+                            <!-- Completion popup (already exists in app) -->
+                            <div class="completion">
+                                <div class="ci active"><span>id</span><span class="det">int · pk</span></div>
+                                <div class="ci"><span>image_url</span><span class="det">text</span></div>
+                                <div class="ci"><span>is_active</span><span class="det">int (bool)</span></div>
+                                <div class="ci"><span>imported_at</span><span class="det">datetime</span></div>
+                            </div>
+                        </div>
+
+                        <div class="splitter"></div>
+
+                        <!-- Results panel with sub-tabs -->
+                        <div class="results">
+                            <div class="res-tabs">
+                                <button class="res-tab active"><i class="bi bi-grid-3x3"></i> Results <span class="badge">1,247</span></button>
+                                <button class="res-tab"><i class="bi bi-diagram-2"></i> Plan</button>
+                                <button class="res-tab"><i class="bi bi-chat-left-text"></i> Messages <span class="badge">2</span></button>
+                                <button class="res-tab"><i class="bi bi-info-circle"></i> Stats</button>
+                                <div class="res-tabs-meta">
+                                    <span>Rows <b>1–25</b> of <b>1,247</b></span>
+                                    <button title="Export"><i class="bi bi-download"></i></button>
+                                    <button title="Copy as JSON"><i class="bi bi-clipboard"></i></button>
+                                    <button title="Pop out results"><i class="bi bi-box-arrow-up-right"></i></button>
+                                </div>
+                            </div>
+
+                            <div class="res-body">
+                                <table class="grid">
+                                    <thead>
+                                    <tr>
+                                        <th>id</th>
+                                        <th>name</th>
+                                        <th>email</th>
+                                        <th style="text-align:right;">order_count</th>
+                                        <th>last_order_at</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr><td class="id">1</td><td>Alice Smith</td><td>alice@example.com</td><td class="num">12</td><td class="dt">2026-04-22 09:14</td></tr>
+                                    <tr><td class="id">2</td><td>Bob Lee</td><td>bob@example.com</td><td class="num">3</td><td class="dt">2026-04-12 11:02</td></tr>
+                                    <tr><td class="id">3</td><td>Carol Smith</td><td>carol@example.com</td><td class="num">9</td><td class="dt">2026-04-19 16:48</td></tr>
+                                    <tr><td class="id">4</td><td>David Smith</td><td>dsmith@example.com</td><td class="num">7</td><td class="dt">2026-04-19 08:22</td></tr>
+                                    <tr><td class="id">5</td><td>Eve Smithers</td><td>eve@example.com</td><td class="num">22</td><td class="dt">2026-04-21 14:10</td></tr>
+                                    <tr><td class="id">6</td><td>Frank Smithy</td><td>frank@example.com</td><td class="num">1</td><td class="dt">2026-03-12 10:55</td></tr>
+                                    <tr><td class="id">7</td><td>Grace Smith-Jones</td><td>grace@example.com</td><td class="num">5</td><td class="dt">2026-04-22 09:17</td></tr>
+                                    <tr><td class="id">8</td><td>Henry Smithfield</td><td>hank@example.com</td><td class="num">0</td><td class="dt">—</td></tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Right rail: query history + scratchpad chips -->
+                    <div class="rail">
+                        <div class="rail-head">
+                            <span><i class="bi bi-clock-history"></i> History</span>
+                            <button style="background:transparent; border:none; color:var(--text-muted); cursor:pointer;"><i class="bi bi-funnel"></i></button>
+                        </div>
+                        <div class="rail-tabs">
+                            <span class="rail-tab active">This tab</span>
+                            <span class="rail-tab">All</span>
+                            <span class="rail-tab">Errors</span>
+                        </div>
+                        <div class="hist-list">
+                            <div class="hist-item">
+                                <div class="meta"><span class="ok">✓ 18 ms · 1,247 rows</span><span>just now</span></div>
+                                <div class="sql"><span class="kw">SELECT</span> c.id, c.name, c.email, <span class="kw">COUNT</span>(o.id)…</div>
+                                <div class="actions">
+                                    <span class="hist-action"><i class="bi bi-arrow-90deg-up"></i> Restore</span>
+                                    <span class="hist-action"><i class="bi bi-bookmark"></i> Save</span>
+                                    <span class="hist-action"><i class="bi bi-clipboard"></i> Copy</span>
+                                </div>
+                            </div>
+                            <div class="hist-item">
+                                <div class="meta"><span class="ok">✓ 4 ms · 1 row</span><span>2m</span></div>
+                                <div class="sql"><span class="kw">SELECT COUNT</span>(*) <span class="kw">FROM</span> Customers</div>
+                            </div>
+                            <div class="hist-item">
+                                <div class="meta"><span class="err">✗ syntax error</span><span>5m</span></div>
+                                <div class="sql"><span class="kw">SELECT</span> * <span class="kw">FROMM</span> Orders</div>
+                            </div>
+                            <div class="hist-item">
+                                <div class="meta"><span class="ok">✓ 32 ms · 8,912 rows</span><span>11m</span></div>
+                                <div class="sql"><span class="kw">SELECT</span> * <span class="kw">FROM</span> Orders <span class="kw">WHERE</span> created_at > '2026-01-01'</div>
+                            </div>
+                            <div class="hist-item">
+                                <div class="meta"><span class="ok">✓ 9 ms · 6 rows</span><span>34m</span></div>
+                                <div class="sql"><span class="kw">SELECT</span> * <span class="kw">FROM</span> sys.table_stats</div>
+                            </div>
+                            <div class="hist-item">
+                                <div class="meta"><span class="ok">✓ 145 ms · 24,310 rows</span><span>1h</span></div>
+                                <div class="sql"><span class="kw">SELECT</span> * <span class="kw">FROM</span> OrderItems <span class="kw">WHERE</span> qty > 5</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="statusbar">
+        <span class="pill ok"><span class="dot"></span> Connected</span>
+        <span class="pill"><i class="bi bi-database"></i> relational.db</span>
+        <span class="pill"><i class="bi bi-terminal" style="color: var(--accent-blue);"></i> Active customers · dirty</span>
+        <span class="pill"><i class="bi bi-clock"></i> Last run 18 ms</span>
+        <div style="flex:1"></div>
+        <span class="pill action"><i class="bi bi-clock-history"></i> 87 queries today</span>
+    </div>
+</div>
+
+<!-- Annotations -->
+<div class="notes">
+    <header><i class="bi bi-lightbulb"></i> Reality check vs. the live screen</header>
+    <ul>
+        <li><b style="color: var(--accent-green);">ALREADY EXISTS</b> — Run / Analyze / Clear / Format buttons, SQL ↔ Designer mode toggle (a Visual Designer panel exists today!), saved-query name input + Save + Load dropdown + Refresh, Stats shortcuts (Table Stats / Column Stats), per-tab SQL persistence, resizable editor splitter with persisted height, line-numbered editor with syntax highlighting, autocomplete popup with arrow-key nav (Ctrl-Space to trigger explicitly), Ctrl+Enter to run, EXEC procedure parsing with named args, paged results that over-fetch one row to avoid blocking COUNT(*).</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Result sub-tabs</b> — Results / Plan / Messages / Stats. Today the result panel only shows rows. Plan would expose the existing query plan; Messages would collect non-query notices; Stats would show the existing elapsed/rows breakdown plus per-statement timings.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Explain Plan button</b> in toolbar — runs the query in plan-only mode and switches to the Plan sub-tab.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Cancel button</b> for in-flight queries.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: History rail</b> on the right — per-tab and global recent-queries list with status (✓/✗), elapsed, and row count. Hover reveals Restore / Save / Copy. Today there's no query history.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Result toolbar</b> in the result tab strip — Export, Copy as JSON, Pop out results.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-magenta);">RESTYLE</b> — toolbar visually groups primary action (Run) + cancel + secondary tools + view mode + result summary, instead of the current single flat row.</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/reports-designer.html
+++ b/www/admin-ui-mockups/reports-designer.html
@@ -1,0 +1,973 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Report Designer · Reader-view support — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    body { overflow: auto; }
+
+    .page {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 32px 28px 80px;
+    }
+
+    h1 { font-size: 22px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
+    .crumb { color: var(--text-muted); font-size: 12px; margin-bottom: 4px; }
+    .lede { color: var(--text-secondary); font-size: 13px; max-width: 760px; margin-bottom: 8px; }
+    .lede + .lede { margin-bottom: 22px; }
+
+    h2 {
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+        color: var(--text-muted);
+        margin: 32px 0 12px;
+    }
+
+    /* ─── Designer shell ─── */
+    .shell {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+    }
+
+    .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 14px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        flex-wrap: wrap;
+    }
+    .toolbar .grp {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding-right: 12px;
+        border-right: 1px solid var(--border-color);
+    }
+    .toolbar .grp:last-child { border-right: none; }
+    .toolbar .label {
+        font-size: 11px;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+    .toolbar input[type=text] {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        padding: 5px 9px;
+        border-radius: 4px;
+        color: var(--text-primary);
+        font-size: 12px;
+        font-family: var(--font-ui);
+        min-width: 180px;
+    }
+    .toolbar select {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        padding: 5px 9px;
+        border-radius: 4px;
+        color: var(--text-primary);
+        font-size: 12px;
+        font-family: var(--font-ui);
+    }
+    .toolbar .tb {
+        background: transparent;
+        border: 1px solid var(--border-color);
+        color: var(--text-secondary);
+        padding: 5px 11px;
+        border-radius: 4px;
+        font-size: 12px;
+        cursor: pointer;
+        display: inline-flex;
+        gap: 5px;
+        align-items: center;
+    }
+    .toolbar .tb:hover { background: var(--bg-hover); color: var(--text-primary); }
+    .toolbar .tb.primary {
+        background: var(--accent-blue);
+        color: #0a0b13;
+        border-color: var(--accent-blue);
+        font-weight: 600;
+    }
+
+    .seg {
+        display: flex;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+    }
+    .seg button {
+        background: transparent;
+        border: none;
+        color: var(--text-muted);
+        font-size: 11px;
+        padding: 5px 12px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+    }
+    .seg button:hover { color: var(--text-primary); }
+    .seg button.active {
+        color: var(--accent-blue);
+        background: var(--bg-active);
+        font-weight: 600;
+    }
+    .seg button:not(:last-child) { border-right: 1px solid var(--border-color); }
+
+    .toolbar .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 3px 10px;
+        font-size: 11px;
+        background: rgba(122,162,247,0.12);
+        color: var(--accent-blue);
+        border-radius: 999px;
+        font-weight: 600;
+    }
+    .toolbar .pill.warn { background: rgba(224,175,104,0.12); color: var(--accent-yellow); }
+
+    /* ─── 3-column designer body ─── */
+    .designer-body {
+        display: grid;
+        grid-template-columns: 220px 1fr 320px;
+        min-height: 600px;
+    }
+
+    .panel {
+        background: var(--bg-secondary);
+        border-right: 1px solid var(--border-color);
+        padding: 14px;
+        overflow-y: auto;
+    }
+    .panel.right { border-right: none; border-left: 1px solid var(--border-color); }
+
+    .panel-section {
+        margin-bottom: 18px;
+    }
+    .panel-section h4 {
+        font-size: 10px;
+        font-weight: 600;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+        margin-bottom: 8px;
+        padding-bottom: 6px;
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .tool-btn {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+        padding: 6px 9px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        color: var(--text-secondary);
+        border-radius: 4px;
+        font-size: 12px;
+        cursor: pointer;
+        margin-bottom: 4px;
+    }
+    .tool-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+    .tool-btn.active {
+        background: rgba(122,162,247,0.15);
+        border-color: var(--accent-blue);
+        color: var(--accent-blue);
+    }
+    .tool-btn i { font-size: 13px; }
+
+    .list-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 6px;
+        font-size: 12px;
+        color: var(--text-primary);
+    }
+    .list-row .x {
+        margin-left: auto;
+        color: var(--text-muted);
+        cursor: pointer;
+    }
+
+    /* ─── Center: paper canvas + reader preview ─── */
+    .center {
+        background: var(--bg-tertiary);
+        padding: 16px;
+        overflow-y: auto;
+    }
+
+    .center.split {
+        display: grid;
+        grid-template-columns: 1fr 320px;
+        gap: 16px;
+    }
+
+    .band-section {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        margin-bottom: 10px;
+        overflow: hidden;
+    }
+    .band-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 6px 10px;
+        background: var(--bg-tertiary);
+        font-size: 11px;
+        color: var(--text-secondary);
+        border-bottom: 1px solid var(--border-color);
+    }
+    .band-header .name {
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        font-weight: 600;
+    }
+    .band-header input[type=number] {
+        width: 50px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        padding: 2px 5px;
+        border-radius: 3px;
+        color: var(--text-primary);
+        font-size: 11px;
+    }
+
+    .band-paper {
+        background: #ffffff;
+        position: relative;
+        background-image:
+                linear-gradient(rgba(0,0,0,0.05) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(0,0,0,0.05) 1px, transparent 1px);
+        background-size: 16px 16px;
+    }
+    .band-margin {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        background: rgba(0,0,0,0.03);
+        background-image: repeating-linear-gradient(
+                45deg, transparent 0 4px,
+                rgba(0,0,0,0.05) 4px 5px);
+    }
+
+    .ctrl {
+        position: absolute;
+        font-family: 'Times New Roman', Georgia, serif;
+        font-size: 10px;
+        color: #1a1a1a;
+        padding: 0 2px;
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+    }
+    .ctrl.bound, .ctrl.calc { font-family: Consolas, monospace; }
+    .ctrl.label { font-weight: 700; }
+    .ctrl.line {
+        background: #333;
+        height: 1px !important;
+    }
+    .ctrl.box {
+        border: 1px solid #333;
+    }
+    .ctrl.selected {
+        outline: 1.5px solid #1a73e8;
+        outline-offset: 1px;
+    }
+    .ctrl .role-badge {
+        position: absolute;
+        top: -8px;
+        right: -4px;
+        background: var(--accent-blue);
+        color: #fff;
+        font-size: 8px;
+        padding: 1px 4px;
+        border-radius: 3px;
+        font-family: var(--font-ui);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.4px;
+    }
+    .ctrl .role-badge.title { background: var(--accent-blue); }
+    .ctrl .role-badge.field { background: var(--accent-cyan); color: #0a0b13; }
+    .ctrl .role-badge.hidden { background: var(--text-muted); }
+
+    /* ─── Reader preview pane (right of split center) ─── */
+    .reader-preview {
+        background: var(--bg-primary);
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        overflow: hidden;
+        align-self: start;
+        position: sticky;
+        top: 16px;
+    }
+    .reader-preview .device-bar {
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        padding: 7px 12px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 11px;
+        color: var(--text-muted);
+    }
+    .reader-preview .device-bar .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--accent-green);
+    }
+    .reader-preview-body {
+        padding: 0;
+    }
+    .rd-head {
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .rd-head h3 { font-size: 13px; font-weight: 700; }
+    .rd-head .sub { font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+
+    .rd-section {
+        padding: 9px 14px;
+        background: var(--bg-tertiary);
+        border-bottom: 1px solid var(--border-color);
+        font-size: 12px;
+        font-weight: 600;
+        display: flex;
+        justify-content: space-between;
+    }
+    .rd-section .badge {
+        font-size: 9px;
+        background: rgba(122,162,247,0.15);
+        color: var(--accent-blue);
+        padding: 2px 7px;
+        border-radius: 999px;
+    }
+
+    .rd-card {
+        padding: 10px 14px;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .rd-card .title { font-size: 12px; font-weight: 600; }
+    .rd-card .id { font-family: var(--font-mono); font-size: 9px; color: var(--text-muted); margin-bottom: 6px; }
+    .rd-card dl {
+        display: grid;
+        grid-template-columns: 80px 1fr;
+        row-gap: 3px;
+        column-gap: 8px;
+        font-size: 11px;
+    }
+    .rd-card dt { color: var(--text-muted); }
+    .rd-card dd { color: var(--text-primary); font-family: var(--font-mono); }
+    .rd-card dd.num { color: var(--accent-orange); text-align: right; }
+
+    /* ─── Right panel: inspector ─── */
+    .insp-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 6px;
+        margin-bottom: 8px;
+    }
+    .insp-row.full { grid-template-columns: 1fr; }
+    .insp-row label {
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--text-muted);
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+    }
+    .insp-row input, .insp-row select {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        padding: 4px 7px;
+        border-radius: 3px;
+        color: var(--text-primary);
+        font-size: 12px;
+        font-family: var(--font-ui);
+    }
+
+    .control-type-badge {
+        display: inline-block;
+        padding: 2px 8px;
+        background: rgba(125,207,255,0.15);
+        color: var(--accent-cyan);
+        border-radius: 3px;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        font-weight: 600;
+        margin-bottom: 8px;
+    }
+
+    .reader-section-card {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--accent-blue);
+        border-radius: 5px;
+        padding: 10px 12px;
+        margin-top: 12px;
+    }
+    .reader-section-card .head {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--accent-blue);
+        margin-bottom: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+    .reader-section-card .quick {
+        display: flex;
+        gap: 4px;
+        margin-top: 8px;
+    }
+    .reader-section-card .quick button {
+        flex: 1;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        color: var(--text-secondary);
+        padding: 5px 6px;
+        font-size: 10px;
+        border-radius: 3px;
+        cursor: pointer;
+    }
+    .reader-section-card .quick button:hover { color: var(--text-primary); border-color: var(--border-light); }
+    .reader-section-card .quick button.active {
+        color: var(--accent-blue);
+        border-color: var(--accent-blue);
+        background: rgba(122,162,247,0.1);
+    }
+
+    .toggle-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 11px;
+        margin-top: 8px;
+    }
+    .toggle {
+        position: relative;
+        width: 32px; height: 18px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: 9px;
+        cursor: pointer;
+        flex-shrink: 0;
+    }
+    .toggle::after {
+        content: "";
+        position: absolute;
+        top: 1px;
+        left: 1px;
+        width: 14px; height: 14px;
+        background: var(--text-muted);
+        border-radius: 50%;
+        transition: 120ms;
+    }
+    .toggle.on { background: rgba(122,162,247,0.3); border-color: var(--accent-blue); }
+    .toggle.on::after { left: 15px; background: var(--accent-blue); }
+
+    /* Lint pane */
+    .lint {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        padding: 14px 18px;
+        margin-top: 14px;
+    }
+    .lint h3 {
+        font-size: 12px;
+        font-weight: 600;
+        margin-bottom: 10px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .lint-item {
+        display: flex;
+        gap: 10px;
+        padding: 7px 0;
+        font-size: 12px;
+        border-bottom: 1px dashed var(--border-color);
+    }
+    .lint-item:last-child { border-bottom: none; }
+    .lint-item .ico { width: 18px; flex-shrink: 0; }
+    .lint-item .body { flex: 1; }
+    .lint-item .body b { color: var(--text-primary); }
+    .lint-item .body .sub { color: var(--text-muted); font-size: 10px; margin-top: 2px; font-family: var(--font-mono); }
+    .lint-item .fix {
+        font-size: 10px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        color: var(--accent-blue);
+        padding: 3px 9px;
+        border-radius: 3px;
+        cursor: pointer;
+        align-self: center;
+    }
+    .lint-item .fix:hover { border-color: var(--accent-blue); }
+    .lint-item.warn .ico { color: var(--accent-yellow); }
+    .lint-item.info .ico { color: var(--accent-blue); }
+
+    .inspector-static {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        padding: 16px 18px;
+    }
+    .inspector-static h3 {
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 10px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .inspector-static ul {
+        list-style: none;
+        padding: 0;
+    }
+    .inspector-static li {
+        padding: 8px 0;
+        font-size: 12.5px;
+        color: var(--text-secondary);
+        border-bottom: 1px dashed var(--border-color);
+    }
+    .inspector-static li:last-child { border-bottom: none; }
+</style>
+</head>
+<body>
+<div class="page">
+
+    <div class="crumb">CSharpDB.Admin.Reports · Designer-side proposal</div>
+    <h1>Add Reader-view support to the report designer</h1>
+    <p class="lede">
+        The previous mockup (<a href="reports-mobile.html">reports-mobile.html</a>) added a <b>Reader
+        view</b> at runtime so phones aren't stuck side-scrolling an 816 px paper page. But if the
+        designer can't see or shape the Reader view, it's effectively invisible to the people
+        building reports — so the runtime view drifts from intent over time.
+    </p>
+    <p class="lede">
+        This proposal adds three things to <code>Pages/Designer.razor</code>: a Paper / Reader /
+        Split view toggle in the toolbar, a Reader-view subsection in the Selection inspector, and
+        a Reader-lint summary panel that catches problems before users hit them on a phone. The
+        existing 3-column layout (Toolbox / Bands / Page-settings + Selection) stays.
+    </p>
+
+    <!-- ════════ Section 1: Designer with Split mode ════════ -->
+    <h2>1 · Designer toolbar gains a view-mode switch (Paper / Reader / Split)</h2>
+
+    <div class="shell">
+        <div class="toolbar">
+            <input type="text" value="Customer Sales — Q1 2026" />
+            <select><option>vw_customer_sales</option></select>
+            <button class="tb"><i class="bi bi-save"></i> Save</button>
+            <button class="tb"><i class="bi bi-eye"></i> Preview</button>
+            <button class="tb"><i class="bi bi-arrows-fullscreen"></i> Auto Fit</button>
+
+            <div class="grp" style="margin-left: 12px;">
+                <span class="label">Designer view</span>
+                <div class="seg">
+                    <button><i class="bi bi-file-earmark"></i> Paper</button>
+                    <button><i class="bi bi-card-list"></i> Reader</button>
+                    <button class="active"><i class="bi bi-layout-split"></i> Split</button>
+                </div>
+            </div>
+
+            <div class="grp">
+                <span class="label">Reader device</span>
+                <div class="seg">
+                    <button><i class="bi bi-tablet"></i> Tablet</button>
+                    <button class="active"><i class="bi bi-phone"></i> Phone</button>
+                </div>
+            </div>
+
+            <div style="flex: 1"></div>
+            <span class="pill warn"><i class="bi bi-exclamation-triangle"></i> 3 reader hints needed</span>
+            <span class="pill"><i class="bi bi-printer"></i> Letter · Portrait</span>
+        </div>
+
+        <div class="designer-body">
+            <!-- LEFT panel: toolbox + groups + sorts (existing) -->
+            <aside class="panel">
+                <div class="panel-section">
+                    <h4><i class="bi bi-tools"></i> Toolbox</h4>
+                    <button class="tool-btn"><i class="bi bi-cursor"></i> Pointer</button>
+                    <button class="tool-btn"><i class="bi bi-tag"></i> Label</button>
+                    <button class="tool-btn active"><i class="bi bi-fonts"></i> Bound Text</button>
+                    <button class="tool-btn"><i class="bi bi-calculator"></i> Calculated</button>
+                    <button class="tool-btn"><i class="bi bi-dash-lg"></i> Line</button>
+                    <button class="tool-btn"><i class="bi bi-square"></i> Box</button>
+                </div>
+
+                <div class="panel-section">
+                    <h4><i class="bi bi-collection"></i> Groups</h4>
+                    <div class="list-row">
+                        <i class="bi bi-grip-vertical" style="color: var(--text-muted);"></i>
+                        <span>tier</span>
+                        <span class="x"><i class="bi bi-x"></i></span>
+                    </div>
+                </div>
+
+                <div class="panel-section">
+                    <h4><i class="bi bi-sort-down"></i> Sorts</h4>
+                    <div class="list-row">
+                        <span>customer_name</span>
+                        <span class="x"><i class="bi bi-x"></i></span>
+                    </div>
+                    <div class="list-row">
+                        <span>total_amount ↓</span>
+                        <span class="x"><i class="bi bi-x"></i></span>
+                    </div>
+                </div>
+            </aside>
+
+            <!-- CENTER (Split mode): paper canvas + reader preview side by side -->
+            <main class="center split">
+                <div>
+                    <!-- Page Header band -->
+                    <section class="band-section">
+                        <div class="band-header">
+                            <span class="name">Page Header</span>
+                            <input type="number" value="40" />
+                        </div>
+                        <div class="band-paper" style="height: 40px;">
+                            <div class="band-margin" style="left: 0; width: 24px;"></div>
+                            <div class="band-margin" style="right: 0; width: 24px;"></div>
+                            <div class="ctrl label" style="left: 24px; top: 4px; width: 280px; height: 18px; font-size: 14px;">
+                                Customer Sales — Q1 2026
+                            </div>
+                            <div class="ctrl line" style="left: 24px; top: 30px; width: 580px; height: 1px;"></div>
+                        </div>
+                    </section>
+
+                    <!-- Group Header band -->
+                    <section class="band-section">
+                        <div class="band-header">
+                            <span class="name">Group Header · tier</span>
+                            <input type="number" value="24" />
+                        </div>
+                        <div class="band-paper" style="height: 24px;">
+                            <div class="band-margin" style="left: 0; width: 24px;"></div>
+                            <div class="band-margin" style="right: 0; width: 24px;"></div>
+                            <div class="ctrl bound" style="left: 24px; top: 4px; width: 200px; height: 16px; font-weight: 700;">
+                                Tier · {tier}
+                                <span class="role-badge title">title</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- Detail band -->
+                    <section class="band-section">
+                        <div class="band-header">
+                            <span class="name">Detail</span>
+                            <input type="number" value="22" />
+                        </div>
+                        <div class="band-paper" style="height: 22px;">
+                            <div class="band-margin" style="left: 0; width: 24px;"></div>
+                            <div class="band-margin" style="right: 0; width: 24px;"></div>
+                            <div class="ctrl bound" style="left: 24px; top: 4px; width: 30px;">
+                                {id}
+                            </div>
+                            <div class="ctrl bound selected" style="left: 60px; top: 4px; width: 130px;">
+                                {customer_name}
+                                <span class="role-badge title">title</span>
+                            </div>
+                            <div class="ctrl bound" style="left: 200px; top: 4px; width: 80px; justify-content: flex-end;">
+                                {orders}
+                                <span class="role-badge field">field</span>
+                            </div>
+                            <div class="ctrl bound" style="left: 290px; top: 4px; width: 90px; justify-content: flex-end;">
+                                {avg_amount}
+                                <span class="role-badge field">field</span>
+                            </div>
+                            <div class="ctrl bound" style="left: 390px; top: 4px; width: 90px; justify-content: flex-end;">
+                                {total_amount}
+                                <span class="role-badge field">field</span>
+                            </div>
+                            <div class="ctrl bound" style="left: 490px; top: 4px; width: 110px;">
+                                {last_order_at}
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- Group Footer band -->
+                    <section class="band-section">
+                        <div class="band-header">
+                            <span class="name">Group Footer · tier</span>
+                            <input type="number" value="22" />
+                        </div>
+                        <div class="band-paper" style="height: 22px;">
+                            <div class="band-margin" style="left: 0; width: 24px;"></div>
+                            <div class="band-margin" style="right: 0; width: 24px;"></div>
+                            <div class="ctrl calc" style="left: 200px; top: 4px; width: 280px; justify-content: flex-end; font-weight: 700;">
+                                Subtotal · =SUM(orders) · =SUM(total_amount)
+                            </div>
+                        </div>
+                    </section>
+                </div>
+
+                <!-- Reader live preview pane (right column of split center) -->
+                <div class="reader-preview">
+                    <div class="device-bar">
+                        <span class="dot"></span>
+                        <span><b style="color: var(--text-primary);">Reader preview</b> · phone · 380 px</span>
+                        <div style="margin-left: auto; display: flex; gap: 4px;">
+                            <button class="tb" style="padding: 2px 6px; font-size: 10px;"><i class="bi bi-arrow-clockwise"></i></button>
+                            <button class="tb" style="padding: 2px 6px; font-size: 10px;"><i class="bi bi-box-arrow-up-right"></i></button>
+                        </div>
+                    </div>
+                    <div class="reader-preview-body">
+                        <div class="rd-head">
+                            <h3>Customer Sales — Q1 2026</h3>
+                            <div class="sub">vw_customer_sales · live preview</div>
+                        </div>
+                        <div class="rd-section">
+                            <span><i class="bi bi-chevron-down"></i> Tier · Gold</span>
+                            <span class="badge">3</span>
+                        </div>
+                        <div class="rd-card">
+                            <div class="title">Alice Smith</div>
+                            <div class="id">CUST-00001</div>
+                            <dl>
+                                <dt>Orders</dt><dd class="num">12</dd>
+                                <dt>Avg</dt><dd class="num">$412.50</dd>
+                                <dt>Total</dt><dd class="num">$4,950.00</dd>
+                            </dl>
+                        </div>
+                        <div class="rd-card">
+                            <div class="title">David Smith</div>
+                            <div class="id">CUST-00004</div>
+                            <dl>
+                                <dt>Orders</dt><dd class="num">7</dd>
+                                <dt>Avg</dt><dd class="num">$389.00</dd>
+                                <dt>Total</dt><dd class="num">$2,723.00</dd>
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+            </main>
+
+            <!-- RIGHT panel: Selection inspector + Reader subsection -->
+            <aside class="panel right">
+                <div class="panel-section">
+                    <h4><i class="bi bi-file-earmark"></i> Page Settings</h4>
+                    <div class="insp-row">
+                        <label>Paper <select><option>Letter</option><option>A4</option></select></label>
+                        <label>Orient. <select><option>Portrait</option></select></label>
+                    </div>
+                    <div class="insp-row">
+                        <label>L margin <input type="number" value="0.5" step="0.1" /></label>
+                        <label>T margin <input type="number" value="0.5" step="0.1" /></label>
+                        <label>R margin <input type="number" value="0.5" step="0.1" /></label>
+                        <label>B margin <input type="number" value="0.5" step="0.1" /></label>
+                    </div>
+                </div>
+
+                <div class="panel-section">
+                    <h4><i class="bi bi-bullseye"></i> Selection</h4>
+                    <div class="control-type-badge">BoundText</div>
+                    <div class="insp-row">
+                        <label>X <input type="number" value="60" step="4" /></label>
+                        <label>Y <input type="number" value="4" step="4" /></label>
+                        <label>W <input type="number" value="130" step="4" /></label>
+                        <label>H <input type="number" value="14" step="2" /></label>
+                    </div>
+                    <div class="insp-row full">
+                        <label>Field
+                            <select><option>customer_name</option></select>
+                        </label>
+                    </div>
+                    <div class="insp-row">
+                        <label>Format <input type="text" placeholder="e.g. C2" /></label>
+                        <label>Align <select><option>Left</option></select></label>
+                    </div>
+                    <div class="insp-row">
+                        <label>Font size <input type="number" value="10" /></label>
+                        <label>Weight <input type="text" value="400" /></label>
+                    </div>
+
+                    <!-- ★ NEW: Reader-view subsection ★ -->
+                    <div class="reader-section-card">
+                        <div class="head"><i class="bi bi-card-list"></i> Reader view</div>
+                        <div class="insp-row full">
+                            <label>Role
+                                <select>
+                                    <option selected>Card title</option>
+                                    <option>Card subtitle</option>
+                                    <option>Detail field</option>
+                                    <option>Hidden in reader</option>
+                                </select>
+                            </label>
+                        </div>
+                        <div class="insp-row full">
+                            <label>Reader label
+                                <input type="text" value="Customer" placeholder="(field name)" />
+                            </label>
+                        </div>
+                        <div class="toggle-row">
+                            <span style="color: var(--text-secondary);">Show on phone</span>
+                            <div class="toggle on"></div>
+                        </div>
+                        <div class="quick">
+                            <button>Title</button>
+                            <button class="active">Field</button>
+                            <button>Hide</button>
+                        </div>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </div>
+
+    <!-- ════════ Section 2: Auto-derive + lint ════════ -->
+    <h2>2 · Auto-derive Reader hints + lint warnings</h2>
+    <p class="lede" style="margin-top: -6px;">
+        For existing reports the designer can synthesize hints from the layout in one click. The
+        lint panel surfaces problems specific to Reader so they don't get discovered on a phone.
+    </p>
+
+    <div class="lint">
+        <h3 style="display: flex; justify-content: space-between;">
+            <span><i class="bi bi-exclamation-triangle" style="color: var(--accent-yellow);"></i> Reader-view lint · <code style="font-family: var(--font-mono); color: var(--text-muted); font-size: 11px;">Customer Sales — Q1 2026</code></span>
+            <button style="background: var(--accent-blue); color: #0a0b13; border: none; padding: 5px 12px; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 12px;">
+                <i class="bi bi-magic"></i> Auto-derive all hints
+            </button>
+        </h3>
+
+        <div class="lint-item warn">
+            <span class="ico"><i class="bi bi-exclamation-triangle-fill"></i></span>
+            <div class="body">
+                <b>3 BoundText controls have no Reader role assigned.</b>
+                <div class="sub">Detail band · {orders}, {avg_amount}, {last_order_at}</div>
+            </div>
+            <button class="fix">Auto-assign as fields →</button>
+        </div>
+
+        <div class="lint-item info">
+            <span class="ico"><i class="bi bi-info-circle-fill"></i></span>
+            <div class="body">
+                <b>No Card title set on Detail band.</b>
+                <div class="sub">First BoundText {id} would auto-promote at runtime — set explicitly to avoid surprises.</div>
+            </div>
+            <button class="fix">Use {customer_name} →</button>
+        </div>
+
+        <div class="lint-item info">
+            <span class="ico"><i class="bi bi-info-circle-fill"></i></span>
+            <div class="body">
+                <b>2 Line controls in Page Header will be hidden in Reader.</b>
+                <div class="sub">Decorative controls (Line, Box) auto-hide. No action needed unless you want them shown.</div>
+            </div>
+            <button class="fix">Acknowledge</button>
+        </div>
+
+        <div class="lint-item warn">
+            <span class="ico"><i class="bi bi-exclamation-triangle-fill"></i></span>
+            <div class="body">
+                <b>Group Footer formula <code style="color: var(--text-primary);">=SUM(orders)</code> renders as a single line in Reader.</b>
+                <div class="sub">Group Footer · tier · width 280 px on paper, full width on phone.</div>
+            </div>
+            <button class="fix">Preview →</button>
+        </div>
+    </div>
+
+    <!-- ════════ Section 3: Notes ════════ -->
+    <h2>3 · Implementation notes &amp; non-goals</h2>
+
+    <div class="inspector-static">
+        <ul>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Toolbar gains two segmented controls</b> — Designer view (<code>Paper</code> /
+                <code>Reader</code> / <code>Split</code>) and, when Reader or Split is active, a
+                Reader-device toggle (<code>Tablet</code> / <code>Phone</code>). State persists per
+                report in <code>localStorage</code>; default is <code>Split</code>.
+            </li>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Split mode reuses the runtime Reader projection.</b> The reader pane on the
+                right is the same <code>IReportReaderService</code> output described in
+                <a href="reports-mobile.html">reports-mobile.html</a>, rendered into an iframe-like
+                container at the chosen device width. Edits on the paper canvas trigger a debounced
+                preview rebuild.
+            </li>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Selection inspector grows a "Reader view" subsection</b> — Role dropdown
+                (<code>title / subtitle / field / hidden</code>), custom label override, "show on
+                phone" toggle, and three quick-action buttons (Title / Field / Hide) for one-click
+                changes. Stored in <code>ReportControlDefinition.Props["readerHint"]</code> via the
+                existing <code>PropertyBag</code> — no schema migration.
+            </li>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Controls on the canvas show a tiny role badge</b> (<code>title</code>,
+                <code>field</code>, <code>hidden</code>) when a Reader hint is set — quick visual
+                map of what the Reader view will pick up. Toggle-able from a View menu.
+            </li>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>"Auto-derive all hints" runs the inference rules on the whole report</b> — first
+                BoundText in Detail → title; remaining BoundText → fields with <code>BoundFieldName</code> as
+                the label; Line / Box → hidden; GroupHeader BoundText → section title; GroupFooter
+                CalculatedText → summary row. Pre-populates everything; users only refine.
+            </li>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Lint panel</b> appears below the designer (or as a collapsible footer). Each
+                item has a one-click fix. The "3 reader hints needed" pill in the toolbar is the
+                count summary; clicking it scrolls the lint panel into view.
+            </li>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Page Settings stays paper-only.</b> Reader has no concept of paper size /
+                margins — it's a continuous list. Margin/orientation controls don't move; they just
+                don't affect the reader pane.
+            </li>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Non-goal · mobile-friendly designer.</b> The 3-column desktop layout
+                (220 / flex / 320) and pointer-driven drag-resize are the right tools for building
+                a paper report. Making the designer touch-friendly would compromise it for a use
+                case that doesn't really exist (nobody designs a report on a phone). The Reader
+                <i>preview</i> pane goes mobile-sized, but the surrounding designer chrome stays
+                desktop-only.
+            </li>
+            <li>
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Out of scope</b> — drag-and-drop within the Reader preview (Reader is read-only),
+                a separate "mobile report definition" (whole point is one definition / two views),
+                Reader-specific charts (current renderer only supports text / line / box anyway).
+            </li>
+        </ul>
+    </div>
+
+    <p style="font-size: 12px; color: var(--text-muted); margin-top: 28px;">
+        Pairs with: <a href="reports-mobile.html">reports-mobile.html</a> (the runtime Reader view).
+        Back to <a href="index.html">all mockups</a>.
+    </p>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/reports-mobile.html
+++ b/www/admin-ui-mockups/reports-mobile.html
@@ -1,0 +1,817 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Mobile-friendly Reports — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    body { overflow: auto; }
+
+    .page {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 32px 28px 80px;
+    }
+
+    h1 { font-size: 22px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
+    .crumb { color: var(--text-muted); font-size: 12px; margin-bottom: 4px; }
+    .lede { color: var(--text-secondary); font-size: 13px; max-width: 760px; margin-bottom: 8px; }
+    .lede + .lede { margin-bottom: 22px; }
+
+    h2 {
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+        color: var(--text-muted);
+        margin: 32px 0 12px;
+    }
+
+    /* ─── Toolbar / view mode switch ───────────────────────── */
+    .shell {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+    }
+    .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 14px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        flex-wrap: wrap;
+    }
+    .toolbar .grp {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding-right: 12px;
+        border-right: 1px solid var(--border-color);
+    }
+    .toolbar .grp:last-child { border-right: none; }
+    .toolbar .label {
+        font-size: 11px;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+
+    .seg {
+        display: flex;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+    }
+    .seg button {
+        background: transparent;
+        border: none;
+        color: var(--text-muted);
+        font-size: 11px;
+        padding: 5px 12px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+    }
+    .seg button:hover { color: var(--text-primary); }
+    .seg button.active {
+        color: var(--accent-blue);
+        background: var(--bg-active);
+        font-weight: 600;
+    }
+    .seg button:not(:last-child) { border-right: 1px solid var(--border-color); }
+
+    .toolbar .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 3px 10px;
+        font-size: 11px;
+        background: rgba(122,162,247,0.12);
+        color: var(--accent-blue);
+        border-radius: 999px;
+        font-weight: 600;
+    }
+    .toolbar .pill.green { background: rgba(158,206,106,0.12); color: var(--accent-green); }
+
+    /* ─── Stage with device frames ─────────────────────────── */
+    .stage {
+        background: var(--bg-tertiary);
+        padding: 28px;
+        display: flex;
+        gap: 28px;
+        justify-content: center;
+        align-items: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .device {
+        background: var(--bg-primary);
+        border: 1px solid var(--border-color);
+        border-radius: 18px;
+        padding: 18px 14px;
+        position: relative;
+        flex-shrink: 0;
+        box-shadow: 0 24px 48px rgba(0,0,0,0.35);
+    }
+    .device .notch {
+        position: absolute;
+        top: 6px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 50px;
+        height: 4px;
+        background: var(--border-light);
+        border-radius: 4px;
+    }
+    .device.phone { width: 380px; }
+    .device.tablet { width: 720px; }
+    .device.desktop {
+        width: 100%;
+        max-width: 980px;
+        border-radius: 8px;
+        padding: 20px;
+    }
+    .device-meta {
+        position: absolute;
+        bottom: -22px;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: 10px;
+        color: var(--text-muted);
+        white-space: nowrap;
+    }
+
+    /* ─── PAPER view — fixed-width report page ─────────────── */
+    .paper {
+        background: #ffffff;
+        color: #1a1a1a;
+        border: 1px solid #b0b0b0;
+        box-shadow: 0 2px 12px rgba(0,0,0,0.18);
+        font-family: 'Times New Roman', Georgia, serif;
+        position: relative;
+        overflow: hidden;
+        margin: 0 auto;
+    }
+    .paper.letter-portrait {
+        width: 408px;          /* 816 / 2 = scaled half-letter */
+        min-height: 528px;     /* 1056 / 2 */
+        padding: 14px 18px;
+    }
+    /* Sized to demonstrate the "side-scroll on a phone" problem */
+    .paper.full-width {
+        width: 816px;
+        min-height: 0;
+        padding: 24px;
+    }
+    .paper h2 { color: #000; font-size: 14px; font-weight: 700; margin-bottom: 4px; text-transform: none; letter-spacing: 0; }
+    .paper .meta { font-size: 9px; color: #555; margin-bottom: 10px; }
+    .paper .col-headers, .paper .row {
+        display: grid;
+        grid-template-columns: 50px 1fr 90px 70px 80px;
+        gap: 6px;
+        font-size: 10px;
+    }
+    .paper .col-headers {
+        font-weight: 700;
+        border-bottom: 1.5px solid #000;
+        padding-bottom: 3px;
+        margin-bottom: 5px;
+    }
+    .paper .row {
+        padding: 3px 0;
+        border-bottom: 0.5px solid #ddd;
+        font-family: Consolas, "SFMono-Regular", monospace;
+    }
+    .paper .row .num { text-align: right; }
+    .paper .group-hdr {
+        font-weight: 700;
+        font-size: 11px;
+        margin: 8px 0 4px;
+        padding: 3px 0;
+        border-top: 0.5px solid #000;
+        border-bottom: 0.5px solid #000;
+        background: #f4f4f4;
+        padding-left: 4px;
+    }
+    .paper .group-ftr {
+        font-weight: 700;
+        font-size: 10px;
+        text-align: right;
+        padding: 3px 0;
+        margin-bottom: 6px;
+        border-top: 0.5px solid #555;
+    }
+    .paper .footer {
+        position: absolute;
+        bottom: 8px;
+        left: 18px;
+        right: 18px;
+        display: flex;
+        justify-content: space-between;
+        font-size: 9px;
+        color: #777;
+        font-style: italic;
+        border-top: 0.5px solid #999;
+        padding-top: 3px;
+    }
+
+    /* ─── READER view — reflowed cards/list ────────────────── */
+    .reader {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        font-family: var(--font-ui);
+    }
+    .reader-head {
+        padding: 14px 16px 10px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+    }
+    .reader-head h3 {
+        font-size: 14px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+    .reader-head .sub { color: var(--text-muted); font-size: 11px; margin-top: 4px; }
+
+    .reader-section {
+        padding: 12px 16px 6px;
+        background: var(--bg-tertiary);
+        border-bottom: 1px solid var(--border-color);
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--text-primary);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .reader-section .badge {
+        font-size: 10px;
+        background: rgba(122,162,247,0.15);
+        color: var(--accent-blue);
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-weight: 600;
+    }
+    .reader-section i.collapse {
+        color: var(--text-muted);
+        font-size: 11px;
+    }
+
+    .reader-card {
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .reader-card .title {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 2px;
+    }
+    .reader-card .id {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        color: var(--text-muted);
+        margin-bottom: 8px;
+    }
+    .reader-card dl {
+        display: grid;
+        grid-template-columns: 100px 1fr;
+        row-gap: 4px;
+        column-gap: 10px;
+        font-size: 11.5px;
+    }
+    .reader-card dt { color: var(--text-muted); }
+    .reader-card dd { color: var(--text-primary); font-family: var(--font-mono); }
+    .reader-card dd.num { color: var(--accent-orange); font-variant-numeric: tabular-nums; text-align: right; }
+
+    .reader-group-foot {
+        padding: 10px 16px;
+        font-size: 11.5px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        justify-content: space-between;
+    }
+    .reader-group-foot .lbl { color: var(--text-muted); }
+    .reader-group-foot .val { color: var(--accent-blue); font-weight: 600; font-variant-numeric: tabular-nums; }
+
+    .reader-foot {
+        padding: 10px 16px;
+        font-size: 10px;
+        color: var(--text-muted);
+        background: var(--bg-secondary);
+        text-align: center;
+    }
+
+    /* Mini bottom toolbar inside the device */
+    .reader-bottom {
+        padding: 10px 14px;
+        background: var(--bg-secondary);
+        border-top: 1px solid var(--border-color);
+        display: flex;
+        gap: 8px;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .reader-bottom .btn-mini {
+        flex: 1;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        color: var(--text-primary);
+        padding: 8px;
+        border-radius: 5px;
+        font-size: 11px;
+        cursor: pointer;
+    }
+    .reader-bottom .btn-mini.primary {
+        background: var(--accent-blue);
+        color: #0a0b13;
+        border-color: var(--accent-blue);
+        font-weight: 600;
+    }
+
+    /* ─── Page navigator (paper view on phone) ─────────────── */
+    .pager {
+        margin-top: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-size: 11px;
+        color: var(--text-secondary);
+        background: var(--bg-secondary);
+        padding: 8px 12px;
+        border-radius: 5px;
+        border: 1px solid var(--border-color);
+    }
+    .pager button {
+        background: transparent;
+        border: 1px solid var(--border-color);
+        color: var(--text-primary);
+        width: 28px; height: 28px;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+    .pager button:hover { background: var(--bg-hover); }
+
+    /* ─── Property inspector for Reader hints ──────────────── */
+    .inspector {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--radius-lg);
+        padding: 16px 18px;
+        font-size: 12.5px;
+    }
+    .inspector h3 {
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 10px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .inspector .row {
+        display: grid;
+        grid-template-columns: 140px 1fr;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 0;
+        border-bottom: 1px dashed var(--border-color);
+    }
+    .inspector .row:last-of-type { border-bottom: none; }
+    .inspector .row .k { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .inspector .row .v { color: var(--text-primary); }
+    .inspector input[type=text], .inspector select {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        padding: 4px 8px;
+        color: var(--text-primary);
+        font-size: 12px;
+        font-family: var(--font-ui);
+        width: 100%;
+    }
+
+    .toggle {
+        position: relative;
+        width: 38px; height: 20px;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 10px;
+        cursor: pointer;
+        flex-shrink: 0;
+    }
+    .toggle::after {
+        content: "";
+        position: absolute;
+        top: 1px;
+        left: 1px;
+        width: 16px; height: 16px;
+        background: var(--text-muted);
+        border-radius: 50%;
+        transition: 120ms ease;
+    }
+    .toggle.on { background: rgba(122,162,247,0.3); border-color: var(--accent-blue); }
+    .toggle.on::after { left: 19px; background: var(--accent-blue); }
+
+    .two-col {
+        display: grid;
+        grid-template-columns: 1fr 320px;
+        gap: 18px;
+    }
+
+    @media (max-width: 1080px) {
+        .two-col { grid-template-columns: 1fr; }
+    }
+</style>
+</head>
+<body>
+<div class="page">
+
+    <div class="crumb">CSharpDB.Admin.Reports · UI proposal</div>
+    <h1>Mobile-friendly reports — keep paper, add a Reader view</h1>
+    <p class="lede">
+        Reports are different from forms: a report is supposed to look like paper. The current
+        renderer fixes an 816 × 1056 page surface and absolutely-positions every band's controls in
+        pixels (<code>Pages/Preview.razor</code>, <code>reports.css</code>). On a phone the page
+        side-scrolls. That's painful to read but right for print fidelity.
+    </p>
+    <p class="lede">
+        The proposal: <b>do not</b> reflow the paper. Add a <b>Reader view</b> that the same
+        <code>ReportDefinition</code> produces — bands become sections, repeated detail rows become
+        cards, group footers become summary lines. Phone visitors get Reader by default, desktop
+        gets Paper, and the toolbar lets the user swap. Print &amp; Export PDF always use Paper.
+    </p>
+
+    <!-- ════════ Section 1: Designer / preview toolbar ════════ -->
+    <h2>1 · Preview toolbar gains a View-mode switch</h2>
+
+    <div class="two-col">
+        <div class="shell">
+            <div class="toolbar">
+                <div class="grp">
+                    <span class="label">View</span>
+                    <div class="seg">
+                        <button class="active"><i class="bi bi-file-earmark"></i> Paper</button>
+                        <button><i class="bi bi-card-list"></i> Reader</button>
+                    </div>
+                </div>
+                <div class="grp">
+                    <span class="label">Page</span>
+                    <div class="seg">
+                        <button><i class="bi bi-arrows-fullscreen"></i> Fit width</button>
+                        <button class="active">100%</button>
+                        <button>150%</button>
+                        <button>200%</button>
+                    </div>
+                </div>
+                <div class="grp">
+                    <span class="pill green"><i class="bi bi-printer"></i> Print uses Paper</span>
+                </div>
+                <div style="flex: 1"></div>
+                <div class="grp">
+                    <button class="tb-btn"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+                    <button class="tb-btn"><i class="bi bi-printer"></i> Print</button>
+                    <button class="tb-btn"><i class="bi bi-download"></i> Export PDF</button>
+                </div>
+            </div>
+
+            <div class="stage" style="padding: 28px 18px;">
+                <div class="device tablet">
+                    <div class="paper letter-portrait" style="width: 100%;">
+                        <h2>Customer Sales — Q1 2026</h2>
+                        <div class="meta">vw_customer_sales · 2026-04-26 · Letter · Portrait</div>
+
+                        <div class="col-headers">
+                            <span>ID</span><span>Customer</span><span class="num">Orders</span><span class="num">Avg ($)</span><span class="num">Total ($)</span>
+                        </div>
+
+                        <div class="group-hdr">Tier · Gold</div>
+                        <div class="row"><span>1</span><span>Alice Smith</span><span class="num">12</span><span class="num">412.50</span><span class="num">4,950.00</span></div>
+                        <div class="row"><span>4</span><span>David Smith</span><span class="num">7</span><span class="num">389.00</span><span class="num">2,723.00</span></div>
+                        <div class="row"><span>5</span><span>Eve Smithers</span><span class="num">22</span><span class="num">221.00</span><span class="num">4,862.00</span></div>
+                        <div class="group-ftr">Subtotal · 41 orders · $12,535.00</div>
+
+                        <div class="group-hdr">Tier · Silver</div>
+                        <div class="row"><span>2</span><span>Bob Lee</span><span class="num">3</span><span class="num">102.00</span><span class="num">306.00</span></div>
+                        <div class="row"><span>7</span><span>Grace Smith</span><span class="num">5</span><span class="num">88.00</span><span class="num">440.00</span></div>
+                        <div class="group-ftr">Subtotal · 8 orders · $746.00</div>
+
+                        <div class="footer"><span>Customer Sales</span><span>Page 1 of 4</span></div>
+                    </div>
+                    <div class="device-meta">tablet preview · Paper view · Letter portrait</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Inspector: Reader hints per control -->
+        <div class="inspector">
+            <h3><i class="bi bi-card-list" style="color: var(--accent-blue);"></i> Reader-view settings</h3>
+
+            <div class="row">
+                <span class="k">Reader enabled</span>
+                <span class="v"><div class="toggle on"></div></span>
+            </div>
+            <div class="row">
+                <span class="k">Auto on phone</span>
+                <span class="v"><div class="toggle on"></div></span>
+            </div>
+            <div class="row">
+                <span class="k">Group cards</span>
+                <span class="v">Collapsible</span>
+            </div>
+            <div class="row">
+                <span class="k">Card sort</span>
+                <span class="v">Match Paper order</span>
+            </div>
+
+            <h3 style="margin-top: 16px;"><i class="bi bi-collection" style="color: var(--accent-blue);"></i> Selected control</h3>
+
+            <div class="row">
+                <span class="k">Field</span>
+                <span class="v"><code>customer_name</code></span>
+            </div>
+            <div class="row">
+                <span class="k">Reader role</span>
+                <span class="v">
+                    <select>
+                        <option>Card title</option>
+                        <option>Card subtitle</option>
+                        <option>Detail field</option>
+                        <option>Hidden in reader</option>
+                    </select>
+                </span>
+            </div>
+            <div class="row">
+                <span class="k">Reader label</span>
+                <span class="v"><input type="text" value="Customer" /></span>
+            </div>
+            <div class="row">
+                <span class="k">Show on phone</span>
+                <span class="v"><div class="toggle on"></div></span>
+            </div>
+
+            <p style="font-size: 11px; color: var(--text-muted); margin-top: 12px; line-height: 1.5;">
+                Stored in <code>ControlDefinition.Props["readerHint"]</code>. Decorative
+                Line / Box controls auto-hide in Reader. BoundText controls auto-promote: first
+                in the Detail band → card title, others → labelled fields.
+            </p>
+        </div>
+    </div>
+
+    <!-- ════════ Section 2: Same report at three breakpoints ════════ -->
+    <h2>2 · Same report on desktop, tablet, and phone</h2>
+    <p class="lede" style="margin-top: -6px;">
+        Desktop &amp; tablet stay on Paper for fidelity. Phone defaults to Reader.
+    </p>
+
+    <div class="stage">
+        <!-- Desktop · Paper -->
+        <div class="device desktop" style="max-width: 460px;">
+            <div class="paper letter-portrait" style="width: 100%; min-height: 460px; padding: 18px;">
+                <h2>Customer Sales — Q1 2026</h2>
+                <div class="meta">vw_customer_sales · Letter · Portrait</div>
+                <div class="col-headers">
+                    <span>ID</span><span>Customer</span><span class="num">Orders</span><span class="num">Avg ($)</span><span class="num">Total ($)</span>
+                </div>
+                <div class="group-hdr">Tier · Gold</div>
+                <div class="row"><span>1</span><span>Alice Smith</span><span class="num">12</span><span class="num">412.50</span><span class="num">4,950.00</span></div>
+                <div class="row"><span>4</span><span>David Smith</span><span class="num">7</span><span class="num">389.00</span><span class="num">2,723.00</span></div>
+                <div class="row"><span>5</span><span>Eve Smithers</span><span class="num">22</span><span class="num">221.00</span><span class="num">4,862.00</span></div>
+                <div class="group-ftr">Subtotal · 41 · $12,535.00</div>
+                <div class="group-hdr">Tier · Silver</div>
+                <div class="row"><span>2</span><span>Bob Lee</span><span class="num">3</span><span class="num">102.00</span><span class="num">306.00</span></div>
+                <div class="row"><span>7</span><span>Grace S.</span><span class="num">5</span><span class="num">88.00</span><span class="num">440.00</span></div>
+                <div class="group-ftr">Subtotal · 8 · $746.00</div>
+            </div>
+            <div class="device-meta">desktop · Paper · ≥ 1024 px</div>
+        </div>
+
+        <!-- Tablet · Paper at 75% Fit-width -->
+        <div class="device tablet" style="width: 460px;">
+            <div class="paper letter-portrait" style="width: 100%; min-height: 460px; padding: 16px;">
+                <h2>Customer Sales — Q1 2026</h2>
+                <div class="meta">Fit-width · 75%</div>
+                <div class="col-headers">
+                    <span>ID</span><span>Customer</span><span class="num">Orders</span><span class="num">Avg</span><span class="num">Total</span>
+                </div>
+                <div class="group-hdr">Tier · Gold</div>
+                <div class="row"><span>1</span><span>Alice Smith</span><span class="num">12</span><span class="num">412</span><span class="num">4,950</span></div>
+                <div class="row"><span>4</span><span>David Smith</span><span class="num">7</span><span class="num">389</span><span class="num">2,723</span></div>
+                <div class="row"><span>5</span><span>Eve Smithers</span><span class="num">22</span><span class="num">221</span><span class="num">4,862</span></div>
+                <div class="group-ftr">Subtotal · $12,535</div>
+                <div class="group-hdr">Tier · Silver</div>
+                <div class="row"><span>2</span><span>Bob Lee</span><span class="num">3</span><span class="num">102</span><span class="num">306</span></div>
+                <div class="row"><span>7</span><span>Grace S.</span><span class="num">5</span><span class="num">88</span><span class="num">440</span></div>
+                <div class="group-ftr">Subtotal · $746</div>
+            </div>
+            <div class="device-meta">tablet · Paper @ Fit-width · ≥ 640 px</div>
+        </div>
+
+        <!-- Phone · Reader -->
+        <div class="device phone">
+            <div class="notch"></div>
+            <div class="reader" style="border: 1px solid var(--border-color); border-radius: 6px; overflow: hidden;">
+                <div class="reader-head">
+                    <h3>Customer Sales — Q1 2026</h3>
+                    <div class="sub">vw_customer_sales · 41 rows · 2 groups</div>
+                </div>
+
+                <div class="reader-section">
+                    <span><i class="bi bi-chevron-down collapse"></i> Tier · Gold</span>
+                    <span class="badge">3 customers</span>
+                </div>
+
+                <div class="reader-card">
+                    <div class="title">Alice Smith</div>
+                    <div class="id">CUST-00001</div>
+                    <dl>
+                        <dt>Orders</dt><dd class="num">12</dd>
+                        <dt>Avg</dt><dd class="num">$412.50</dd>
+                        <dt>Total</dt><dd class="num">$4,950.00</dd>
+                    </dl>
+                </div>
+                <div class="reader-card">
+                    <div class="title">David Smith</div>
+                    <div class="id">CUST-00004</div>
+                    <dl>
+                        <dt>Orders</dt><dd class="num">7</dd>
+                        <dt>Avg</dt><dd class="num">$389.00</dd>
+                        <dt>Total</dt><dd class="num">$2,723.00</dd>
+                    </dl>
+                </div>
+
+                <div class="reader-group-foot">
+                    <span class="lbl">Subtotal · 41 orders</span>
+                    <span class="val">$12,535.00</span>
+                </div>
+
+                <div class="reader-section">
+                    <span><i class="bi bi-chevron-right collapse"></i> Tier · Silver</span>
+                    <span class="badge">2 customers</span>
+                </div>
+
+                <div class="reader-foot">Customer Sales · 1–5 of 41 · scroll for more</div>
+            </div>
+            <div class="device-meta">phone · Reader (default) · &lt; 640 px</div>
+        </div>
+    </div>
+
+    <!-- ════════ Section 3: Today vs. Reader on a 380 px phone ════════ -->
+    <h2>3 · Today vs. Reader on a 380 px phone</h2>
+
+    <div class="stage" style="background: var(--bg-secondary);">
+        <!-- Today: paper with side-scroll -->
+        <div class="device phone">
+            <div class="notch"></div>
+            <div style="border: 1px solid var(--border-color); border-radius: 6px; overflow-x: auto; overflow-y: hidden; max-width: 100%;">
+                <div class="paper full-width" style="margin: 0;">
+                    <h2>Customer Sales — Q1 2026</h2>
+                    <div class="meta">vw_customer_sales · 2026-04-26 · Letter</div>
+                    <div class="col-headers">
+                        <span>ID</span><span>Customer</span><span class="num">Orders</span><span class="num">Avg ($)</span><span class="num">Total ($)</span>
+                    </div>
+                    <div class="group-hdr">Tier · Gold</div>
+                    <div class="row"><span>1</span><span>Alice Smith</span><span class="num">12</span><span class="num">412.50</span><span class="num">4,950.00</span></div>
+                    <div class="row"><span>4</span><span>David Smith</span><span class="num">7</span><span class="num">389.00</span><span class="num">2,723.00</span></div>
+                    <div class="row"><span>5</span><span>Eve Smithers</span><span class="num">22</span><span class="num">221.00</span><span class="num">4,862.00</span></div>
+                    <div class="group-ftr">Subtotal · 41 orders · $12,535.00</div>
+                </div>
+            </div>
+            <div class="pager">
+                <button>‹</button>
+                <span>Page 1 of 4 · pinch to zoom</span>
+                <button>›</button>
+            </div>
+            <div class="device-meta" style="color: var(--accent-red);">TODAY · Paper side-scrolls · text tiny · headers off-screen</div>
+        </div>
+
+        <!-- Reader on the same phone -->
+        <div class="device phone">
+            <div class="notch"></div>
+            <div class="reader" style="border: 1px solid var(--border-color); border-radius: 6px; overflow: hidden;">
+                <div class="reader-head">
+                    <h3>Customer Sales — Q1 2026</h3>
+                    <div class="sub">vw_customer_sales · 41 rows · 2 groups</div>
+                </div>
+
+                <div class="reader-section">
+                    <span><i class="bi bi-chevron-down collapse"></i> Tier · Gold</span>
+                    <span class="badge">3 customers</span>
+                </div>
+
+                <div class="reader-card">
+                    <div class="title">Alice Smith</div>
+                    <div class="id">CUST-00001</div>
+                    <dl>
+                        <dt>Orders</dt><dd class="num">12</dd>
+                        <dt>Avg</dt><dd class="num">$412.50</dd>
+                        <dt>Total</dt><dd class="num">$4,950.00</dd>
+                    </dl>
+                </div>
+                <div class="reader-card">
+                    <div class="title">David Smith</div>
+                    <div class="id">CUST-00004</div>
+                    <dl>
+                        <dt>Orders</dt><dd class="num">7</dd>
+                        <dt>Avg</dt><dd class="num">$389.00</dd>
+                        <dt>Total</dt><dd class="num">$2,723.00</dd>
+                    </dl>
+                </div>
+                <div class="reader-card">
+                    <div class="title">Eve Smithers</div>
+                    <div class="id">CUST-00005</div>
+                    <dl>
+                        <dt>Orders</dt><dd class="num">22</dd>
+                        <dt>Avg</dt><dd class="num">$221.00</dd>
+                        <dt>Total</dt><dd class="num">$4,862.00</dd>
+                    </dl>
+                </div>
+
+                <div class="reader-group-foot">
+                    <span class="lbl">Gold subtotal · 41</span>
+                    <span class="val">$12,535.00</span>
+                </div>
+
+                <div class="reader-bottom">
+                    <button class="btn-mini"><i class="bi bi-file-earmark"></i> Paper view</button>
+                    <button class="btn-mini primary"><i class="bi bi-download"></i> Export PDF</button>
+                </div>
+            </div>
+            <div class="device-meta" style="color: var(--accent-green);">READER · readable · cards · footer summary · paper still one tap away</div>
+        </div>
+    </div>
+
+    <!-- ════════ Section 4: Notes ════════ -->
+    <h2>4 · Implementation notes (no code changed)</h2>
+
+    <div class="inspector" style="padding: 18px 22px;">
+        <ul style="list-style: none; padding: 0;">
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Don't touch Paper.</b> The existing band-based, pixel-positioned layout from
+                <code>Pages/Preview.razor</code> stays exactly as-is for fidelity. Print and Export
+                PDF route through Paper unconditionally.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Add a <code>ViewMode</code> selector</b> to the preview toolbar:
+                <code>Paper</code> ↔ <code>Reader</code>. Auto-pick on first render based on
+                viewport (<code>Reader</code> below ~640 px, <code>Paper</code> above) — a single
+                <code>matchMedia</code> probe in JS interop is enough. User toggle persists per
+                report in <code>localStorage</code>.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Reader is a derived view, not a second layout.</b> A new
+                <code>IReportReaderService</code> takes the same <code>ReportPreviewResult</code>
+                that <code>DefaultReportPreviewService</code> already produces and walks the bands
+                semantically:
+                <br>—  <code>ReportHeader</code> / <code>PageHeader</code> → page intro (rendered once).
+                <br>—  <code>GroupHeader</code> → collapsible <code>&lt;section&gt;</code>.
+                <br>—  <code>Detail</code> band repeated → list of cards. First
+                <code>BoundText</code> in the band becomes the card title; others become
+                <code>&lt;dt&gt;/&lt;dd&gt;</code> pairs labelled with <code>BoundFieldName</code>.
+                <br>—  <code>GroupFooter</code> → summary row at the end of the section.
+                <br>—  <code>Line</code> / <code>Box</code> controls → hidden in reader.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Per-control overrides via <code>Props["readerHint"]</code></b> —
+                <code>{ "role": "title" | "subtitle" | "field" | "hidden", "label": "Customer",
+                "showOnPhone": true }</code>. Property inspector grows a Reader-view sub-section.
+                Schema unchanged; this is just data inside the existing <code>PropertyBag</code>.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Auto-reader for legacy reports</b> — the inference rules above mean any existing
+                <code>ReportDefinition</code> gets a usable Reader view with zero edits. Hints only
+                exist to refine it.
+            </li>
+            <li style="padding: 8px 0; border-bottom: 1px dashed var(--border-color);">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Paper view on phone gets quality-of-life fixes too</b> — toolbar gains
+                Fit-width / 100% / 150% / 200% zoom, and a sticky page pager (today the preview
+                stacks all pages vertically and lets each page surface side-scroll, see
+                <code>reports.css</code> <code>.report-page-surface { overflow-x: auto; }</code>).
+            </li>
+            <li style="padding: 8px 0;">
+                <span style="color: var(--accent-blue);">●</span>
+                <b>Out of scope:</b> rich charts in Reader (current renderer only supports text /
+                line / box), interactive drill-down (Reader is read-only), and a separate "mobile
+                report definition" — the whole point is one definition, two views.
+            </li>
+        </ul>
+    </div>
+
+    <p style="font-size: 12px; color: var(--text-muted); margin-top: 28px;">
+        Compare with the forms equivalent: <a href="forms-mobile.html">forms-mobile.html</a>. Back
+        to <a href="index.html">all mockups</a>.
+    </p>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/sidebar.html
+++ b/www/admin-ui-mockups/sidebar.html
@@ -1,0 +1,474 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Object Explorer — CSharpDB Studio Mockup</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="styles.css">
+<style>
+    .body { grid-template-columns: 320px 1fr; }
+
+    /* New sidebar */
+    .sidebar { display: flex; flex-direction: column; }
+
+    .sb-head {
+        padding: 10px 14px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+        color: var(--text-muted);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .sb-head .actions { display: flex; gap: 2px; }
+    .sb-mini-btn {
+        width: 24px; height: 22px;
+        border: none;
+        background: transparent;
+        color: var(--text-muted);
+        cursor: pointer;
+        border-radius: 4px;
+        display: grid;
+        place-items: center;
+    }
+    .sb-mini-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+    .sb-search {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .sb-search input {
+        flex: 1;
+        background: transparent;
+        border: none;
+        outline: none;
+        color: var(--text-primary);
+        font-size: 12px;
+    }
+    .sb-search .clear {
+        color: var(--text-muted);
+        cursor: pointer;
+        font-size: 11px;
+    }
+
+    .sb-toolbar {
+        display: flex;
+        gap: 4px;
+        padding: 6px 12px;
+        border-bottom: 1px solid var(--border-color);
+        align-items: center;
+    }
+    .sb-tool-chip {
+        padding: 2px 8px;
+        font-size: 10px;
+        border-radius: 999px;
+        color: var(--text-muted);
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+    }
+    .sb-tool-chip:hover { color: var(--text-primary); }
+    .sb-tool-chip.active { background: rgba(122,162,247,0.15); color: var(--accent-blue); border-color: transparent; }
+
+    .sb-tree {
+        flex: 1;
+        overflow-y: auto;
+        padding: 4px 0 24px;
+    }
+
+    .group {
+        margin-bottom: 2px;
+    }
+    .group-hdr {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-secondary);
+        cursor: pointer;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+    }
+    .group-hdr:hover { background: var(--bg-hover); }
+    .group-hdr .chev { font-size: 9px; width: 12px; color: var(--text-muted); }
+    .group-hdr .label { display: flex; align-items: center; gap: 6px; }
+    .group-hdr .count {
+        margin-left: auto;
+        font-size: 10px;
+        background: rgba(255,255,255,0.06);
+        padding: 1px 6px;
+        border-radius: 999px;
+        color: var(--text-muted);
+        font-weight: 500;
+    }
+    .group-hdr .add {
+        margin-left: 4px;
+        opacity: 0;
+        width: 18px; height: 18px;
+        display: grid; place-items: center;
+        border-radius: 4px;
+        color: var(--text-muted);
+    }
+    .group-hdr:hover .add { opacity: 1; }
+    .group-hdr .add:hover { color: var(--accent-blue); background: var(--bg-active); }
+
+    .item {
+        display: grid;
+        grid-template-columns: 18px 18px 1fr 18px 18px;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 12px 5px 30px;
+        font-size: 12.5px;
+        color: var(--text-secondary);
+        cursor: pointer;
+        border-left: 2px solid transparent;
+    }
+    .item:hover { color: var(--text-primary); background: var(--bg-hover); }
+    .item.active { color: var(--text-primary); background: rgba(122,162,247,0.1); border-left-color: var(--accent-blue); }
+    .item .star, .item .more { opacity: 0; color: var(--text-muted); font-size: 12px; text-align: center; }
+    .item:hover .star, .item:hover .more { opacity: 1; }
+    .item .star.on { opacity: 1; color: var(--accent-yellow); }
+    .item .star:hover { color: var(--accent-yellow); }
+    .item .lbl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .item .hint { color: var(--text-muted); font-size: 10.5px; margin-left: auto; padding-right: 4px; opacity: 0.65; }
+
+    /* nested children: columns under a table */
+    .item.nested {
+        padding-left: 50px;
+        font-size: 11.5px;
+        color: var(--text-muted);
+        grid-template-columns: 14px 1fr 38px;
+    }
+    .item.nested .lbl { color: var(--text-secondary); }
+    .item.nested .type {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        color: var(--accent-cyan);
+        text-align: right;
+    }
+    .child-group { padding: 2px 0 4px; background: rgba(255,255,255,0.015); border-left: 2px solid var(--bg-tertiary); margin-left: 22px; }
+
+    /* small headers inside table drill-down */
+    .child-head {
+        padding: 4px 12px 2px 38px;
+        color: var(--text-muted);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+    }
+
+    /* main content placeholder */
+    .placeholder {
+        flex: 1;
+        display: grid;
+        place-items: center;
+        color: var(--text-muted);
+        font-size: 13px;
+    }
+    .placeholder div { text-align: center; }
+    .placeholder .bi { font-size: 48px; opacity: 0.3; margin-bottom: 12px; display: block; }
+</style>
+</head>
+<body>
+<div class="app">
+
+    <div class="titlebar">
+        <div class="brand">
+            <div class="logo">C#</div>
+            <span>CSharpDB Studio</span>
+            <span class="dbname">— relational.db</span>
+        </div>
+        <button class="db-switcher"><i class="bi bi-database"></i> relational.db <i class="bi bi-caret-down-fill"></i></button>
+        <button class="palette-launcher"><i class="bi bi-search"></i> Search anything… <span class="kbd">Ctrl K</span></button>
+        <div class="spacer"></div>
+        <span class="conn-pill"><span class="dot"></span> Connected</span>
+        <button class="tb-btn icon-only"><i class="bi bi-moon-stars"></i></button>
+        <button class="tb-btn icon-only"><i class="bi bi-layout-sidebar-inset"></i></button>
+    </div>
+
+    <div class="body">
+        <aside class="sidebar">
+            <div class="sb-head">
+                <span>Object Explorer</span>
+                <div class="actions">
+                    <button class="sb-mini-btn" title="Sort"><i class="bi bi-sort-alpha-down"></i></button>
+                    <button class="sb-mini-btn" title="Collapse all"><i class="bi bi-arrows-collapse"></i></button>
+                    <button class="sb-mini-btn" title="Refresh"><i class="bi bi-arrow-clockwise"></i></button>
+                </div>
+            </div>
+
+            <div class="sb-search">
+                <i class="bi bi-search" style="color: var(--text-muted); font-size: 12px;"></i>
+                <input value="cust" placeholder="Filter objects…" />
+                <span class="clear"><i class="bi bi-x-lg"></i></span>
+            </div>
+
+            <div class="sb-toolbar">
+                <span class="sb-tool-chip active">All</span>
+                <span class="sb-tool-chip">Tables</span>
+                <span class="sb-tool-chip">Forms</span>
+                <span class="sb-tool-chip">Reports</span>
+                <span class="sb-tool-chip">More <i class="bi bi-three-dots"></i></span>
+            </div>
+
+            <div class="sb-tree">
+
+                <!-- Pinned -->
+                <div class="group">
+                    <div class="group-hdr">
+                        <i class="bi bi-chevron-down chev"></i>
+                        <span class="label"><i class="bi bi-pin-angle-fill" style="color: var(--accent-yellow);"></i> Pinned</span>
+                        <span class="count">3</span>
+                    </div>
+                    <div class="item active">
+                        <i class="bi bi-table icon-table"></i>
+                        <i class="bi bi-star-fill star on"></i>
+                        <span class="lbl">Customers</span>
+                        <i class="bi bi-three-dots more"></i>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-table icon-table"></i>
+                        <i class="bi bi-star-fill star on"></i>
+                        <span class="lbl">Orders</span>
+                        <i class="bi bi-three-dots more"></i>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-ui-checks-grid icon-form"></i>
+                        <i class="bi bi-star-fill star on"></i>
+                        <span class="lbl">Customer Form</span>
+                        <i class="bi bi-three-dots more"></i>
+                    </div>
+                </div>
+
+                <!-- Recent -->
+                <div class="group">
+                    <div class="group-hdr">
+                        <i class="bi bi-chevron-down chev"></i>
+                        <span class="label"><i class="bi bi-clock-history" style="color: var(--accent-cyan);"></i> Recent</span>
+                        <span class="count">5</span>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-table icon-table"></i>
+                        <i class="bi bi-star star"></i>
+                        <span class="lbl">Invoices</span>
+                        <span class="hint">2m</span>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-terminal" style="color: var(--accent-blue);"></i>
+                        <i class="bi bi-star star"></i>
+                        <span class="lbl">Query 1 — Active customers</span>
+                        <span class="hint">14m</span>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-gear-wide-connected icon-trigger"></i>
+                        <i class="bi bi-star star"></i>
+                        <span class="lbl">recalc_invoices</span>
+                        <span class="hint">1h</span>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-eye icon-view"></i>
+                        <i class="bi bi-star star"></i>
+                        <span class="lbl">vw_active_customers</span>
+                        <span class="hint">3h</span>
+                    </div>
+                </div>
+
+                <!-- Tables (with drill-down) -->
+                <div class="group">
+                    <div class="group-hdr">
+                        <i class="bi bi-chevron-down chev"></i>
+                        <span class="label"><i class="bi bi-table icon-table"></i> Tables</span>
+                        <span class="count">24</span>
+                        <span class="add" title="New table"><i class="bi bi-plus-lg"></i></span>
+                    </div>
+
+                    <div class="item">
+                        <i class="bi bi-chevron-down chev" style="font-size:9px;"></i>
+                        <i class="bi bi-table icon-table"></i>
+                        <span class="lbl"><b>Cust</b>omers</span>
+                        <i class="bi bi-star-fill star on"></i>
+                        <i class="bi bi-three-dots more"></i>
+                    </div>
+                    <div class="child-group">
+                        <div class="child-head">Columns · 8</div>
+                        <div class="item nested">
+                            <i class="bi bi-key" style="color: var(--accent-yellow);"></i>
+                            <span class="lbl">id</span>
+                            <span class="type">int</span>
+                        </div>
+                        <div class="item nested">
+                            <i class="bi bi-fonts" style="color: var(--accent-cyan);"></i>
+                            <span class="lbl">name</span>
+                            <span class="type">text(120)</span>
+                        </div>
+                        <div class="item nested">
+                            <i class="bi bi-fonts" style="color: var(--accent-cyan);"></i>
+                            <span class="lbl">email</span>
+                            <span class="type">text(255)</span>
+                        </div>
+                        <div class="item nested">
+                            <i class="bi bi-toggle-on" style="color: var(--accent-magenta);"></i>
+                            <span class="lbl">status</span>
+                            <span class="type">enum</span>
+                        </div>
+                        <div class="item nested">
+                            <i class="bi bi-calendar3" style="color: var(--accent-orange);"></i>
+                            <span class="lbl">created_at</span>
+                            <span class="type">datetime</span>
+                        </div>
+                        <div class="child-head">Indexes · 2</div>
+                        <div class="item nested">
+                            <i class="bi bi-lightning icon-index"></i>
+                            <span class="lbl">ix_customers_email</span>
+                            <span class="type">unique</span>
+                        </div>
+                        <div class="item nested">
+                            <i class="bi bi-lightning icon-index"></i>
+                            <span class="lbl">ix_customers_status</span>
+                            <span class="type"></span>
+                        </div>
+                        <div class="child-head">Triggers · 1</div>
+                        <div class="item nested">
+                            <i class="bi bi-lightning-charge icon-trigger"></i>
+                            <span class="lbl">trg_customers_audit</span>
+                            <span class="type">AFTER</span>
+                        </div>
+                    </div>
+
+                    <div class="item">
+                        <i class="bi bi-chevron-right chev" style="font-size:9px;"></i>
+                        <i class="bi bi-table icon-table"></i>
+                        <span class="lbl"><b>Cust</b>omerAddresses</span>
+                        <i class="bi bi-star star"></i>
+                        <i class="bi bi-three-dots more"></i>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-chevron-right chev" style="font-size:9px;"></i>
+                        <i class="bi bi-table icon-table"></i>
+                        <span class="lbl"><b>Cust</b>omerNotes</span>
+                        <i class="bi bi-star star"></i>
+                        <i class="bi bi-three-dots more"></i>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-chevron-right chev" style="font-size:9px;"></i>
+                        <i class="bi bi-table icon-table"></i>
+                        <span class="lbl">Orders</span>
+                        <i class="bi bi-star-fill star on"></i>
+                        <i class="bi bi-three-dots more"></i>
+                    </div>
+                </div>
+
+                <!-- Forms -->
+                <div class="group">
+                    <div class="group-hdr">
+                        <i class="bi bi-chevron-down chev"></i>
+                        <span class="label"><i class="bi bi-ui-checks-grid icon-form"></i> Forms</span>
+                        <span class="count">8</span>
+                        <span class="add" title="New form"><i class="bi bi-plus-lg"></i></span>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-chevron-right chev" style="font-size:9px;"></i>
+                        <i class="bi bi-ui-checks-grid icon-form"></i>
+                        <span class="lbl"><b>Cust</b>omer Form</span>
+                        <span class="hint">Customers</span>
+                    </div>
+                </div>
+
+                <!-- Reports -->
+                <div class="group">
+                    <div class="group-hdr">
+                        <i class="bi bi-chevron-down chev"></i>
+                        <span class="label"><i class="bi bi-file-earmark-richtext icon-report"></i> Reports</span>
+                        <span class="count">5</span>
+                        <span class="add" title="New report"><i class="bi bi-plus-lg"></i></span>
+                    </div>
+                    <div class="item">
+                        <i class="bi bi-chevron-right chev" style="font-size:9px;"></i>
+                        <i class="bi bi-file-earmark-richtext icon-report"></i>
+                        <span class="lbl"><b>Cust</b>omer Sales</span>
+                        <span class="hint">vw_customer…</span>
+                    </div>
+                </div>
+
+                <!-- Procedures -->
+                <div class="group">
+                    <div class="group-hdr">
+                        <i class="bi bi-chevron-right chev"></i>
+                        <span class="label"><i class="bi bi-gear-wide-connected icon-trigger"></i> Procedures</span>
+                        <span class="count">11</span>
+                        <span class="add" title="New procedure"><i class="bi bi-plus-lg"></i></span>
+                    </div>
+                </div>
+
+                <!-- Views -->
+                <div class="group">
+                    <div class="group-hdr">
+                        <i class="bi bi-chevron-right chev"></i>
+                        <span class="label"><i class="bi bi-eye icon-view"></i> Views</span>
+                        <span class="count">6</span>
+                    </div>
+                </div>
+
+                <!-- System -->
+                <div class="group">
+                    <div class="group-hdr">
+                        <i class="bi bi-chevron-right chev"></i>
+                        <span class="label"><i class="bi bi-hdd-stack icon-system"></i> System</span>
+                        <span class="count">17</span>
+                    </div>
+                </div>
+
+            </div>
+        </aside>
+
+        <div class="content">
+            <div class="tabstrip">
+                <div class="tab active"><i class="bi bi-table icon-table"></i> Customers <i class="bi bi-x"></i></div>
+            </div>
+            <div class="placeholder">
+                <div>
+                    <i class="bi bi-list-nested"></i>
+                    <p>Hover items in the sidebar to see star &amp; "more" actions.</p>
+                    <p style="margin-top: 4px; font-size: 11px;">Click a chevron next to a table to drill into its columns, indexes, and triggers.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="statusbar">
+        <span class="pill ok"><span class="dot"></span> Connected</span>
+        <span class="pill"><i class="bi bi-database"></i> relational.db</span>
+        <span class="pill">24 tables · 6 views · 11 procs</span>
+        <div style="flex:1"></div>
+        <span class="pill warn"><i class="bi bi-hdd"></i> 2.4 GB / 3.5 GB</span>
+    </div>
+</div>
+
+<!-- Annotations -->
+<div class="notes">
+    <header><i class="bi bi-lightbulb"></i> Reality check vs. the live screen</header>
+    <ul>
+        <li><b style="color: var(--accent-green);">ALREADY EXISTS</b> — Object Explorer header with Collapse-All button, search/filter input, expandable groups (User Tables, System Tables, Forms, Reports, System Catalog, Views, Indexes, Triggers, Procedures), per-item count badges, active-tab highlight, right-click context menus for tables / forms / reports / views / indexes / triggers / procedures, drag-resize handle.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Pinned section</b> — any item can be starred and persists at the top across sessions. Today there's no concept of pinning.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Recent section</b> — last few opened objects with relative timestamps.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Type filter chips</b> (All / Tables / Forms / Reports / More) for quick narrowing.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Drill-down under each table</b> — a chevron expands columns (with type icons), indexes, and triggers as nested rows. Today indexes/triggers are scattered across separate top-level groups; columns require switching to the Schema view.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-magenta);">RESTYLE: Per-item hover actions</b> — star + "⋯" appear on hover. The same operations are available today but only via right-click, which is undiscoverable for new users.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-magenta);">RESTYLE: Per-group "+" quick-add</b> on hover (New Table, New Form, etc.) — same as the existing right-click "New …" items.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-magenta);">RESTYLE: Compact sort &amp; refresh icons</b> next to Collapse-All in the header. Refresh exists today but only on context menus.</li>
+        <li><span class="pin"></span> <b style="color: var(--accent-blue);">NEW: Match highlighting</b> in filter results (bold "<b>Cust</b>omers"). Today filter is text-substring match without highlighting.</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/www/admin-ui-mockups/styles.css
+++ b/www/admin-ui-mockups/styles.css
@@ -1,0 +1,355 @@
+/* ─────────────────────────────────────────────────────────
+   Shared design tokens & frame styles for mockups.
+   Tokens mirror src/CSharpDB.Admin/wwwroot/css/app.css so
+   the mockups feel like real previews of the admin shell.
+   ───────────────────────────────────────────────────────── */
+
+:root {
+    /* Tokyo-Night-inspired dark palette (matches the live admin) */
+    --bg-primary: #1a1b26;
+    --bg-secondary: #16171f;
+    --bg-tertiary: #1f2029;
+    --bg-elevated: #24253a;
+    --bg-hover: #292a3e;
+    --bg-active: #33345a;
+    --border-color: #2a2b3d;
+    --border-light: #363750;
+    --text-primary: #c0caf5;
+    --text-secondary: #7982a9;
+    --text-muted: #565f89;
+    --accent-blue: #7aa2f7;
+    --accent-cyan: #7dcfff;
+    --accent-green: #9ece6a;
+    --accent-yellow: #e0af68;
+    --accent-orange: #ff9e64;
+    --accent-red: #f7768e;
+    --accent-magenta: #bb9af7;
+    --accent-teal: #2ac3de;
+    --shadow-popup: 0 16px 48px rgba(0,0,0,0.55);
+
+    --radius-sm: 4px;
+    --radius-md: 6px;
+    --radius-lg: 10px;
+
+    --font-ui: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-mono: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { height: 100%; }
+
+body {
+    font-family: var(--font-ui);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent-blue); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ─── App frame ─── */
+.app {
+    display: grid;
+    grid-template-rows: 38px 1fr 26px;
+    height: 100vh;
+}
+
+.titlebar {
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 12px;
+    user-select: none;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+}
+
+.brand .logo {
+    width: 24px; height: 24px;
+    background: linear-gradient(135deg, var(--accent-blue), var(--accent-magenta));
+    border-radius: 5px;
+    display: grid;
+    place-items: center;
+    font-size: 12px;
+    color: white;
+    font-weight: 700;
+}
+
+.brand .dbname { color: var(--text-muted); font-weight: 400; font-size: 12px; }
+
+.tb-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding-left: 12px;
+    margin-left: 0;
+    border-left: 1px solid var(--border-color);
+}
+
+.tb-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-size: 11px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.tb-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+
+.tb-btn.icon-only {
+    width: 30px; height: 26px;
+    padding: 0;
+    justify-content: center;
+}
+
+.spacer { flex: 1; }
+
+/* Database switcher dropdown trigger */
+.db-switcher {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.db-switcher:hover { border-color: var(--border-light); }
+
+.db-switcher .bi-caret-down-fill { font-size: 9px; color: var(--text-muted); }
+
+/* Command palette launcher in titlebar */
+.palette-launcher {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    color: var(--text-muted);
+    font-size: 12px;
+    min-width: 240px;
+    cursor: pointer;
+}
+
+.palette-launcher:hover { border-color: var(--border-light); color: var(--text-secondary); }
+
+.palette-launcher .kbd { margin-left: auto; }
+
+.titlebar .conn-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 9px;
+    background: rgba(158,206,106,0.1);
+    border: 1px solid rgba(158,206,106,0.3);
+    color: var(--accent-green);
+    border-radius: 999px;
+    font-size: 11px;
+}
+
+.dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent-green); }
+
+/* ─── Main split ─── */
+.body {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    overflow: hidden;
+    min-height: 0;
+}
+
+.sidebar {
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border-color);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.content {
+    background: var(--bg-primary);
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+/* ─── Tab strip (lightweight) ─── */
+.tabstrip {
+    display: flex;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    height: 36px;
+    flex-shrink: 0;
+}
+
+.tabstrip .tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 14px;
+    color: var(--text-muted);
+    font-size: 12px;
+    border-right: 1px solid var(--border-color);
+    border-top: 2px solid transparent;
+    cursor: pointer;
+}
+
+.tabstrip .tab.active {
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    border-top-color: var(--accent-blue);
+}
+
+.tabstrip .tab .bi-x { color: var(--text-muted); margin-left: 4px; opacity: 0; }
+.tabstrip .tab:hover .bi-x { opacity: 0.6; }
+.tabstrip .tab.dirty::after { content: ""; width: 6px; height: 6px; background: var(--accent-blue); border-radius: 50%; margin-left: 4px; }
+
+.tabstrip .tab-new {
+    width: 32px;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+}
+
+.tabstrip .tab-new:hover { color: var(--text-primary); background: var(--bg-hover); }
+
+/* ─── Status bar ─── */
+.statusbar {
+    background: var(--bg-secondary);
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 0 12px;
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.statusbar .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.statusbar .pill.warn { color: var(--accent-yellow); }
+.statusbar .pill.ok { color: var(--accent-green); }
+.statusbar .pill.action { color: var(--accent-blue); cursor: pointer; }
+.statusbar .pill.action:hover { color: var(--accent-cyan); }
+
+/* ─── Reusable bits ─── */
+.kbd {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-bottom-color: rgba(255,255,255,0.04);
+    border-radius: 4px;
+    color: var(--text-secondary);
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.btn:hover { background: var(--bg-hover); }
+
+.btn.primary { background: var(--accent-blue); color: #0a0b13; border-color: var(--accent-blue); font-weight: 600; }
+.btn.primary:hover { filter: brightness(1.08); }
+.btn.ghost { background: transparent; }
+
+.icon-table { color: var(--accent-blue); }
+.icon-system { color: var(--accent-cyan); }
+.icon-view { color: var(--accent-magenta); }
+.icon-trigger { color: var(--accent-orange); }
+.icon-index { color: var(--accent-green); }
+.icon-form { color: var(--accent-magenta); }
+.icon-report { color: var(--accent-cyan); }
+
+/* ─── Annotations panel ─── */
+.notes {
+    position: fixed;
+    right: 18px;
+    bottom: 44px;
+    width: 320px;
+    max-height: 60vh;
+    overflow: auto;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-popup);
+    z-index: 50;
+}
+
+.notes header {
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.notes header .bi { color: var(--accent-yellow); }
+
+.notes ul {
+    list-style: none;
+    padding: 8px 0;
+}
+
+.notes li {
+    padding: 8px 14px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.notes li:last-child { border-bottom: none; }
+
+.notes li b { color: var(--text-primary); font-weight: 600; }
+
+.notes .pin {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent-blue);
+    margin-right: 6px;
+    vertical-align: middle;
+}


### PR DESCRIPTION
## Summary

This `v3.5.0` release prepares the collection binary payload fast path, the
release benchmark refresh, and the confirmed CSharpDB Studio admin UI mockup
docs that are included on the branch.

The collection work completes the opt-in source-generated collection fast path
around fixed generated field order, compact type/null metadata, and raw value
payloads. Existing non-generated collection paths continue to use their current
JSON and binary document behavior. The runtime path now avoids duplicated direct
payload header parsing, adds single-segment `ReadOnlySpan<byte>` top-level field
lookups, and uses targeted UTF-8 span plumbing for text index/read/compare
paths.

The benchmark work adds generated collection codec coverage, records the
collection payload investigation, and refreshes the published benchmark README
from the April 26, 2026 release-core artifacts. The final release guardrail
compare passed with `PASS=185, WARN=0, SKIP=0, FAIL=0`.

The admin UI work adds forms/reports access-parity notes plus static CSharpDB
Studio admin UI mockups under `www/admin-ui-mockups`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

No issue numbers were linked for this branch. Included work in this release:

- Completed the roadmap item for source-generated collection fast path
  completion.
- Added generated collection binary payload encode/decode around fixed field
  order, compact type/null metadata, and raw values.
- Kept non-generated collection paths unchanged.
- Added direct binary payload decode improvements and top-level span lookup
  support.
- Added targeted UTF-8 span plumbing for collection text index/read/compare
  paths.
- Added generated collection codec benchmarks and expanded collection binary
  codec/generator tests.
- Refreshed release-core benchmark documentation and history.
- Added CSharpDB Studio admin UI access-parity docs and static mockups.

## Testing

- [x] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Validation performed:

- `dotnet build CSharpDB.slnx -c Release --no-restore`
- `dotnet test CSharpDB.slnx -c Release --no-build -m:1 -- RunConfiguration.DisableParallelization=true`
- Non-parallel unit test run passed with `1,652` tests.
- `dotnet run -c Release --project .\tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --release-core --repeat 3 --repro`
- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Run-Perf-Guardrails.ps1 -Mode release`
- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Compare-Baseline.ps1 -ThresholdsPath .\tests\CSharpDB.Benchmarks\perf-thresholds.json -CurrentMicroResultsDir .\tests\CSharpDB.Benchmarks\results\.tmp-current-micro-run -ReportPath .\tests\CSharpDB.Benchmarks\results\perf-guardrails-last.md`
- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Update-BenchmarkReadme.ps1 -RunManifest .\tests\CSharpDB.Benchmarks\release-core-manifest.json`
- `Get-Content -Raw .\tests\CSharpDB.Benchmarks\release-core-manifest.json | ConvertFrom-Json`
- `pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Update-BenchmarkReadme.ps1 -RunManifest .\tests\CSharpDB.Benchmarks\release-core-manifest.json -DryRun`
- `git diff --check -- tests\CSharpDB.Benchmarks\README.md tests\CSharpDB.Benchmarks\HISTORY.md tests\CSharpDB.Benchmarks\release-core-manifest.json`

Benchmark validation details:

- Initial release guardrail wrapper completed benchmark collection but failed
  compare with volatile samples:
  `PASS=174, WARN=0, SKIP=0, FAIL=11`.
- Focused retry refreshed the volatile `CollationIndexBenchmarks`,
  `CollectionIndexBenchmarks`, and `CompositeIndexBenchmarks` micro CSVs.
- Final official compare passed:
  `PASS=185, WARN=0, SKIP=0, FAIL=0`.

Focused collection investigation:

| Metric | Result |
|--------|-------:|
| Matched rows vs same-machine HEAD baseline | `60` |
| Faster matched rows | `50` |
| Slower matched rows | `10` |
| Median matched speedup | `+4.1%` |
| Mean matched speedup | `+4.8%` |

Focused recovery highlights:

| Benchmark | Before | After | Change |
|-----------|-------:|------:|-------:|
| Collection field read, missing field | `223.22 ns` | `136.73 ns` | `+38.7%` |
| Collection decode, direct payload | `333.80 ns` | `155.20 ns` | `+53.5%` |
| Collection field read, early field | `108.60 ns` | `49.77 ns` | `+54.2%` |
| Collection field compare, late text field | `159.55 ns` | `97.60 ns` | `+38.8%` |
| Collection field compare, bound accessor | `128.03 ns` | `92.83 ns` | `+27.5%` |

Path-index follow-up highlights:

| Benchmark | Final vs same-machine HEAD baseline |
|-----------|------------------------------------:|
| Nested path equality via `FindByIndex` | `+53.6%` |
| Nested path equality via `FindByPath` | `+55.9%` |
| Array path equality via `FindByIndex` | `+52.1%` |
| Text range path lookup | `+42.7%` |
| Guid equality path lookup | `+59.4%` |

Published scorecard examples from the refreshed benchmark README:

| Area | Result |
|------|-------:|
| SQL file-backed single insert | `450.4 ops/sec` |
| SQL file-backed batch x100 | `41.88K rows/sec` |
| Collection file-backed put | `447.3 ops/sec` |
| Collection file-backed batch x100 | `42.28K docs/sec` |
| Collection hot point get | `1.60M ops/sec` |
| CSharpDB InsertBatch B1000 | `233.06K rows/sec` |

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- The highest-risk runtime changes are in the generated collection model and
  collection payload codec paths:
  `CollectionModelGenerator`, `CollectionPayloadCodec`,
  `CollectionBinaryDocumentCodec`, `CollectionDocumentCodec<T>`,
  `CollectionIndexedFieldReader`, and collection index binding.
- The generator diff is intentionally large because generated code now owns the
  binary record encode/decode shape for opt-in generated models.
- Existing non-generated collection document behavior should remain on the
  existing JSON and binary document paths.
- The benchmark README generated region should be edited through
  `release-core-manifest.json` plus `scripts/Update-BenchmarkReadme.ps1`, not
  manually.
- The release-core source artifacts were not replaced by targeted micro runs.
  The targeted retry only refreshed volatile guardrail micro CSVs before
  rerunning the official compare.
- The admin UI mockup commit is included because the branch owner confirmed it
  should be part of this PR.
