### PR TITLE
Fix full-text index storage failure for hot terms (v4.0.1)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,64 +1,11 @@
 # What's New
 
-## version4.0.0
+## version4.0.1
 
-version4.0.0 introduces API-level sharding for CSharpDB. It adds explicit route-key routing, master-catalog-backed shard maps, Admin route selection, shard administration APIs, manifest-driven resharding workflows, diagnostic read-only fan-out, and metadata for future replica and failover workflows. It also completes the NuGet package dependency closure and moves release publishing to NuGet Trusted Publishing.
+version4.0.1 fixes a full-text index storage failure for hot terms.
 
-### API-Level Sharding
+### Fixed
 
-- Added route contexts, stable virtual-bucket shard maps, exact route-key pins, route-bound clients, shard status helpers, and shard-prefixed transaction ids.
-- Added `CSharpDbShardedClient` and helpers for resolving route keys to shard-specific direct, HTTP, gRPC, daemon, and ADO.NET client operations.
-- Added master-catalog mode so the master database owns active sharding metadata while application data remains in shard databases.
-- Added route propagation through REST, gRPC, daemon registration, and connection-string based clients.
-- Added an e-commerce order-history sample that demonstrates month-based route keys, exact route access, and application-controlled cross-month page fill.
-- Defined the v4 sharding boundary clearly: routing is explicit and API-level. CSharpDB does not infer routes from SQL predicates, and v4.0.0 does not add distributed joins, distributed writes, or distributed transactions.
+- Full-text internal index stores (postings, term stats, doc stats, meta) now spill oversized payloads into overflow-page chains, the same way duplicate-heavy Collection and SQL index buckets already did. Previously a term appearing in a few thousand indexed rows grew its postings blob past a single 4 KB B-tree leaf cell, and because a cell larger than a page can never be split, inserts failed with `Unable to split leaf page N: no byte-balanced redistribution fits within page capacity` and the document was left out of the index. Existing databases are read-compatible: inline payloads keep decoding as-is, and an oversized postings blob spills on its next write.
+- Added a full-text regression test that indexes 3,000 documents sharing a token with `StorePositions` enabled, covering search, delete, and reopen round-trips through the overflow chain.
 
-### Shard Administration and Catalog Management
-
-- Added `ICSharpDbShardAdminClient` for shard map snapshots, route resolution previews, shard status checks, and explicit all-shards operations.
-- Exposed shard administration through direct clients, REST endpoints, gRPC services, and daemon-hosted workflows.
-- Added catalog-backed shard map validation and apply flows, including pending map changes that are activated by recreating or restarting route-bound clients.
-- Added shard catalog history and migration history so operators can inspect route moves and catalog changes.
-- Added read-only all-shards SQL fan-out with mutating SQL rejection, per-shard result reporting, and per-shard error reporting.
-
-### Resharding and Migration Workflows
-
-- Added manifest-driven exact route-key migration for moving individual route keys between shards.
-- Added bucket-range migration for moving virtual bucket ranges between shards.
-- Added write fencing, route-owned object manifests, copy and verification steps, counts, checksums, pending catalog updates, and recovery metadata for operator-managed moves.
-- Added shard directory workflows and metadata so master-catalog deployments can track shards, roles, and route ownership consistently.
-- Added guidance for moving an existing database into a sharded deployment. v4.0.0 does not automatically split a monolithic database or infer a shard key from existing tables.
-
-### Admin Sharding Experience
-
-- Added the Admin Sharding workspace for topology, status, catalog inspection, catalog draft validation and apply, history, and route simulation.
-- Added per-tab route context and route selection for sharded Admin workflows, including query, table data, collection data, and shared grid operations.
-- Added route-bound Admin client leases for direct and remote transports.
-- Preserved unsharded Admin behavior for databases that do not enable sharding.
-
-### Replica Metadata
-
-- Added primary and replica shard role metadata, primary links, promotion eligibility, and operator-reported lag fields.
-- Exposed replica metadata through shard snapshots and status APIs.
-- v4.0.0 stores replica metadata only. Automated replication, catch-up, promotion, and failover are not included in this release.
-
-### NuGet and Release Publishing
-
-- Added NuGet packages for the dependency closure required by the published artifacts, including `CSharpDB.ImportExport`, `CSharpDB.CodeModules`, and `CSharpDB.Generators`.
-- Added a package closure verification script and workflow integration so published packages do not depend on unpublished CSharpDB packages.
-- Switched the release workflow from a long-lived NuGet API key to NuGet Trusted Publishing.
-
-### Documentation, Samples, and Tests
-
-- Added public API-level sharding documentation and updated the docs index and sample pages.
-- Added sharding migration, master-catalog, roadmap, and remaining-work guidance for operators and maintainers.
-- Added the `samples/api-level-sharding` sample project and README.
-- Added and expanded tests for sharded clients, daemon and gRPC routing, ADO.NET route connections, shard admin workflows, catalog validation, migration workflows, and Admin sharding services.
-
-### Review Notes and Known Limits
-
-- Applications must provide a route key, or Admin users must choose a route context. SQL predicates do not choose the route automatically.
-- The master database stores sharding metadata and catalog state. It is not used as a data shard or implicit fan-out participant.
-- Catalog changes and migration workflows write pending map changes; active clients must be recreated or restarted to pick them up.
-- Read-only fan-out is a diagnostic and operator helper, not a distributed query planner.
-- Existing monolithic database splitting remains a manual backfill and cutover process.

--- a/src/CSharpDB.Storage/Catalog/CatalogService.cs
+++ b/src/CSharpDB.Storage/Catalog/CatalogService.cs
@@ -1547,7 +1547,13 @@ internal sealed class CatalogService
 
     private static bool ShouldUseOverflowingIndexStore(IndexSchema schema)
     {
-        return schema.Kind is IndexKind.Collection or IndexKind.Sql;
+        // FullTextInternal stores keep one postings blob per term, and a hot
+        // term (one that appears in thousands of rows) grows that blob past a
+        // single leaf cell. A cell larger than a page can never be split
+        // ("Unable to split leaf page N: no byte-balanced redistribution fits
+        // within page capacity"), so these stores must spill to overflow
+        // pages like duplicate-heavy Collection/Sql buckets do.
+        return schema.Kind is IndexKind.Collection or IndexKind.Sql or IndexKind.FullTextInternal;
     }
 
     // ============ VIEW operations ============

--- a/tests/CSharpDB.Tests/FullTextIndexTests.cs
+++ b/tests/CSharpDB.Tests/FullTextIndexTests.cs
@@ -152,6 +152,51 @@ public sealed class FullTextIndexTests : IAsyncLifetime
         }
     }
 
+    [Fact]
+    public async Task FullTextIndex_HotTermPostingsGrowPastOneLeafCell()
+    {
+        // Regression: a term shared by thousands of rows grows its postings
+        // blob past one 4 KB leaf cell. FullTextInternal stores must spill to
+        // overflow pages; without that the insert dies inside the B-tree with
+        // "Unable to split leaf page N: no byte-balanced redistribution fits
+        // within page capacity" (a single cell larger than a page can never
+        // be split). Positions storage makes the blob grow fastest.
+        await _db.ExecuteAsync("CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)", Ct);
+        await _db.EnsureFullTextIndexAsync(
+            "fts_docs",
+            "docs",
+            ["body"],
+            new FullTextIndexOptions { StorePositions = true },
+            Ct);
+
+        const int DocumentCount = 3000;
+        for (int i = 0; i < DocumentCount; i++)
+        {
+            await _db.ExecuteAsync(
+                FormattableString.Invariant($"INSERT INTO docs VALUES ({i}, 'needle_{i:D4} line')"),
+                Ct);
+        }
+
+        IReadOnlyList<FullTextSearchHit> hits = await _db.SearchAsync("fts_docs", "line", Ct);
+        Assert.Equal(DocumentCount, hits.Count);
+
+        AssertHitRowIds(await _db.SearchAsync("fts_docs", "needle_1500", Ct), 1500);
+
+        // Deleting a document must survive the overflow round-trip too.
+        await _db.ExecuteAsync("DELETE FROM docs WHERE id = 1500", Ct);
+        Assert.Empty(await _db.SearchAsync("fts_docs", "needle_1500", Ct));
+        hits = await _db.SearchAsync("fts_docs", "line", Ct);
+        Assert.Equal(DocumentCount - 1, hits.Count);
+
+        // Reopen: the spilled postings must be durable and readable.
+        await _db.DisposeAsync();
+        _db = await Database.OpenAsync(_dbPath, Ct);
+
+        hits = await _db.SearchAsync("fts_docs", "line", Ct);
+        Assert.Equal(DocumentCount - 1, hits.Count);
+        AssertHitRowIds(await _db.SearchAsync("fts_docs", "needle_2999", Ct), 2999);
+    }
+
     private static void AssertHitRowIds(IReadOnlyList<FullTextSearchHit> hits, params long[] expectedRowIds)
     {
         Assert.Equal(expectedRowIds, hits.Select(static hit => hit.RowId).ToArray());


### PR DESCRIPTION
## Summary

Fixes a full-text index storage failure for hot terms.

Full-text internal index stores (postings, term stats, doc stats, meta) keep one payload blob per term. A term that appears in a few thousand indexed rows grows its postings blob past a single 4 KB B-tree leaf cell. Because a cell larger than a page can never be split, inserts failed inside the B-tree with `Unable to split leaf page N: no byte-balanced redistribution fits within page capacity`, and the affected document was silently left out of the index.

The fix adds `IndexKind.FullTextInternal` to `ShouldUseOverflowingIndexStore`, so these stores spill oversized payloads into overflow-page chains exactly like duplicate-heavy `Collection` and `Sql` index buckets already did. Existing databases remain read-compatible: inline payloads keep decoding as-is, and an oversized postings blob spills on its next write.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance
- [ ] Tests only

## Related Issues

N/A — no tracking issue.

## Testing

Describe validation performed.

- [x] `dotnet build CSharpDB.slnx` — succeeded, 0 warnings / 0 errors.
- [x] Relevant tests executed — `FullTextIndexTests` (6 passed, 0 failed).
- [x] Failure-path tests executed — new regression test reproduces the previously-failing insert path (3,000 docs sharing a token with `StorePositions` enabled) and covers delete + reopen round-trips through the overflow chain.
- [ ] Manual verification performed (if applicable)

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes. (RELEASE_NOTES.md)
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- The behavioral change is a single predicate: `ShouldUseOverflowingIndexStore` now returns `true` for `IndexKind.FullTextInternal` in addition to `Collection`/`Sql`.
- Backward compatibility: existing databases do not need migration. Previously-inlined payloads keep decoding as-is; an oversized blob only spills the next time it is written.
- The regression test uses `StorePositions = true` because positions storage makes the postings blob grow fastest, giving the tightest reproduction of the pre-fix leaf-split failure.
