### PR TITLE
Prepare version4.0.2 full-text indexing release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,17 @@
 # What's New
 
-## version4.0.1
+## version4.0.2
 
-version4.0.1 fixes a full-text index storage failure for hot terms.
+version4.0.2 improves full-text indexing scalability for large corpora and makes indexed mutations avoid unnecessary full-table scans.
 
-### Fixed
+### Changed
 
-- Full-text internal index stores (postings, term stats, doc stats, meta) now spill oversized payloads into overflow-page chains, the same way duplicate-heavy Collection and SQL index buckets already did. Previously a term appearing in a few thousand indexed rows grew its postings blob past a single 4 KB B-tree leaf cell, and because a cell larger than a page can never be split, inserts failed with `Unable to split leaf page N: no byte-balanced redistribution fits within page capacity` and the document was left out of the index. Existing databases are read-compatible: inline payloads keep decoding as-is, and an oversized postings blob spills on its next write.
-- Added a full-text regression test that indexes 3,000 documents sharing a token with `StorePositions` enabled, covering search, delete, and reopen round-trips through the overflow chain.
+- Full-text postings are now stored in bounded posting chunks instead of rewriting one growing postings blob for every hot-token insert. This keeps repeated-token indexing scalable for large corpora.
+- Existing full-text posting blobs remain readable. Databases with the previous full-text storage layout get the new chunk store on open, and legacy posting blobs migrate to chunked postings on the next write for that term.
+- Full-text deletes and updates rewrite only the affected posting chunk while preserving existing search result ordering and transaction rollback behavior.
+- `DELETE` and `UPDATE` statements can now collect target row IDs through available secondary indexes instead of scanning the full table for indexed predicates.
 
+### Validation
+
+- Added focused hot-token before/after benchmark coverage for insert, query, delete, and update paths.
+- Added FileSearcher NuGet before/after benchmark automation that validates real package consumption against local baseline and patched CSharpDB packages.

--- a/docs/releases/v4.0.2-pr-notes.md
+++ b/docs/releases/v4.0.2-pr-notes.md
@@ -1,0 +1,67 @@
+## Summary
+
+Prepare the version4.0.2 release for review.
+
+This release makes CSharpDB full-text indexing scale better for large corpora by storing hot-token postings in bounded chunks instead of one rewritten postings blob. It also improves `DELETE` and `UPDATE` planning so indexed predicates collect target row IDs through available secondary indexes instead of falling back to full-table scans.
+
+The full-text storage change is backward compatible: legacy posting blobs remain readable, old full-text indexes get the new chunk store on open, and legacy posting blobs migrate to chunked postings on the next write for that term.
+
+## Type of Change
+
+- [x] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [x] Documentation update
+- [x] Refactor / maintenance
+- [ ] Tests only
+
+## Related Issues
+
+None linked.
+
+## Testing
+
+Validation performed for the version4.0.2 branch:
+
+- [x] `dotnet build CSharpDB.slnx`
+- [x] Relevant tests executed
+- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
+- [x] Manual verification performed (if applicable)
+
+Commands and benchmarks run successfully during this work:
+
+```powershell
+dotnet build CSharpDB.slnx -c Release
+dotnet test tests\CSharpDB.Tests\CSharpDB.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~FullTextIndexTests|FullyQualifiedName~MutationPlannerTests" --verbosity minimal
+dotnet test CSharpDB.slnx -c Release --no-build --verbosity minimal
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FullTextHotTokenBeforeAfter.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FileSearchNuGetBeforeAfter.ps1 -Profile smoke -TimeoutSeconds 1200 -OutputDir .\artifacts\filesearch-nuget-before-after\smoke-before-after
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FileSearchNuGetBeforeAfter.ps1 -Profile standard -TimeoutSeconds 7200 -OutputDir .\artifacts\filesearch-nuget-before-after\standard-before-after
+```
+
+Latest validation:
+
+- `dotnet build CSharpDB.slnx -c Release` passed with existing NU1903 dependency vulnerability warnings.
+- Focused full-text and mutation planner tests passed: 11 passed, 0 failed.
+
+Observed benchmark results:
+
+- Hot-token 20k postings improved from 44.7s to 4.31s.
+- Hot-token 100k and 500k baseline runs timed out at 180s; patched runs completed in 18.85s and 124.35s.
+- FileSearcher standard NuGet before/after completed with baseline 2,153.8s and patched 1,867.4s wall clock.
+
+## Checklist
+
+- [x] I followed the project style and conventions.
+- [x] I added or updated tests for behavior changes.
+- [x] I covered both success and failure paths for changed behavior.
+- [x] I updated docs for user-facing changes.
+- [x] I verified no sensitive data was added.
+
+## Notes for Reviewers
+
+The new full-text layout keeps the existing postings index as the term manifest store and adds an owned posting-chunks internal store. Legacy posting blobs are not eagerly rewritten on open; they are read as-is and migrated lazily when a write touches the term.
+
+Deletes and updates use the simplest correct chunk rewrite model for now: only the chunk containing the affected row is decoded, rewritten, and persisted. Tombstones and background compaction were intentionally left out until workload data shows they are needed.
+
+The FileSearcher `full` profile was not run in this branch because it is intended for a dedicated release-machine run. Smoke and standard FileSearcher profiles were run through local NuGet package feeds so FileSearcher consumed packaged CSharpDB builds rather than project references.

--- a/src/CSharpDB.Engine/Database.cs
+++ b/src/CSharpDB.Engine/Database.cs
@@ -29,6 +29,10 @@ internal readonly record struct AdaptiveQueryReoptimizationDiagnosticsSnapshot(
     long UnsupportedFallbackCount,
     long ReoptimizationLimitFallbackCount);
 
+internal readonly record struct MutationTargetCollectionDiagnosticsSnapshot(
+    long IndexedCollectionCount,
+    long ScannedCollectionCount);
+
 /// <summary>
 /// Top-level entry point for the CSharpDB embedded database engine.
 /// </summary>
@@ -64,6 +68,8 @@ public sealed class Database : IAsyncDisposable
     private readonly SemaphoreSlim _sharedStateGate = new(1, 1);
     private long _rowIdReservationCount;
     private long _rowIdReservedRowCount;
+    private long _transactionIndexedMutationTargetCollectionCount;
+    private long _transactionScannedMutationTargetCollectionCount;
     private long _observedSchemaVersion;
     private ImplicitInsertExecutionMode _implicitInsertExecutionMode;
     private bool _inTransaction;
@@ -129,6 +135,29 @@ public sealed class Database : IAsyncDisposable
 
     internal void ResetAdaptiveQueryReoptimizationDiagnostics() =>
         _planner.ResetAdaptiveQueryReoptimizationDiagnostics();
+
+    internal MutationTargetCollectionDiagnosticsSnapshot GetMutationTargetCollectionDiagnosticsSnapshot()
+    {
+        var snapshot = _planner.GetMutationTargetCollectionDiagnosticsSnapshot();
+        return new MutationTargetCollectionDiagnosticsSnapshot(
+            snapshot.IndexedCollectionCount + Interlocked.Read(ref _transactionIndexedMutationTargetCollectionCount),
+            snapshot.ScannedCollectionCount + Interlocked.Read(ref _transactionScannedMutationTargetCollectionCount));
+    }
+
+    internal void ResetMutationTargetCollectionDiagnostics()
+    {
+        _planner.ResetMutationTargetCollectionDiagnostics();
+        Interlocked.Exchange(ref _transactionIndexedMutationTargetCollectionCount, 0);
+        Interlocked.Exchange(ref _transactionScannedMutationTargetCollectionCount, 0);
+    }
+
+    internal void RecordMutationTargetCollectionDiagnostics(MutationTargetCollectionDiagnosticsSnapshot snapshot)
+    {
+        if (snapshot.IndexedCollectionCount != 0)
+            Interlocked.Add(ref _transactionIndexedMutationTargetCollectionCount, snapshot.IndexedCollectionCount);
+        if (snapshot.ScannedCollectionCount != 0)
+            Interlocked.Add(ref _transactionScannedMutationTargetCollectionCount, snapshot.ScannedCollectionCount);
+    }
 
     private Database(
         Pager pager,
@@ -400,8 +429,11 @@ public sealed class Database : IAsyncDisposable
         IReadOnlyCollection<KeyValuePair<string, long>> committedTableRowCountDeltas,
         IReadOnlyCollection<TableStatistics> committedTableStatistics,
         IReadOnlyCollection<ColumnStatistics> committedColumnStatistics,
+        MutationTargetCollectionDiagnosticsSnapshot mutationTargetCollectionDiagnostics,
         CancellationToken ct)
     {
+        RecordMutationTargetCollectionDiagnostics(mutationTargetCollectionDiagnostics);
+
         bool applyAdvisoryStats = committedTableStatistics.Count > 0 || committedColumnStatistics.Count > 0;
         bool applyTableMetadata = committedNextRowIds.Count > 0;
         bool applyTableRowCountDeltas = committedTableRowCountDeltas.Count > 0;
@@ -546,7 +578,7 @@ public sealed class Database : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(options);
 
         var context = await InMemoryStorageEngineFactory.OpenAsync(options.StorageEngineOptions, ct: ct);
-        return new Database(
+        return await CompleteOpenAsync(new Database(
             context.Pager,
             context.Catalog,
             context.RecordSerializer,
@@ -557,7 +589,8 @@ public sealed class Database : IAsyncDisposable
             options.ImplicitInsertExecutionMode,
             options.AdaptiveQueryReoptimization,
             options.Functions,
-            temporaryStorageOptions: options.StorageEngineOptions);
+            temporaryStorageOptions: options.StorageEngineOptions),
+            ct);
     }
 
     /// <summary>
@@ -625,7 +658,7 @@ public sealed class Database : IAsyncDisposable
                 new HybridDatabasePersistenceCoordinator(fullPath, hybridOptions.PersistenceTriggers),
                 fullPath,
                 temporaryStorageOptions: options.StorageEngineOptions);
-            return snapshotDatabase;
+            return await CompleteOpenAsync(snapshotDatabase, ct);
         }
 
         var context = await HybridStorageEngineFactory.OpenAsync(fullPath, options.StorageEngineOptions, ct);
@@ -644,6 +677,7 @@ public sealed class Database : IAsyncDisposable
             temporaryStorageOptions: options.StorageEngineOptions);
         try
         {
+            await database.EnsureFullTextInternalStoresOnOpenAsync(ct);
             await database.WarmHybridHotSetAsync(hybridOptions, ct);
             return database;
         }
@@ -691,7 +725,7 @@ public sealed class Database : IAsyncDisposable
             walBytes,
             ct);
 
-        return new Database(
+        return await CompleteOpenAsync(new Database(
             context.Pager,
             context.Catalog,
             context.RecordSerializer,
@@ -703,7 +737,8 @@ public sealed class Database : IAsyncDisposable
             options.AdaptiveQueryReoptimization,
             options.Functions,
             databasePath: fullPath,
-            temporaryStorageOptions: options.StorageEngineOptions);
+            temporaryStorageOptions: options.StorageEngineOptions),
+            ct);
     }
 
     /// <summary>
@@ -718,7 +753,7 @@ public sealed class Database : IAsyncDisposable
 
         string fullPath = Path.GetFullPath(filePath);
         var context = await options.StorageEngineFactory.OpenAsync(fullPath, options.StorageEngineOptions, ct);
-        return new Database(
+        return await CompleteOpenAsync(new Database(
             context.Pager,
             context.Catalog,
             context.RecordSerializer,
@@ -730,7 +765,22 @@ public sealed class Database : IAsyncDisposable
             options.AdaptiveQueryReoptimization,
             options.Functions,
             databasePath: fullPath,
-            temporaryStorageOptions: options.StorageEngineOptions);
+            temporaryStorageOptions: options.StorageEngineOptions),
+            ct);
+    }
+
+    private static async ValueTask<Database> CompleteOpenAsync(Database database, CancellationToken ct)
+    {
+        try
+        {
+            await database.EnsureFullTextInternalStoresOnOpenAsync(ct);
+            return database;
+        }
+        catch
+        {
+            await database.DisposeAsync();
+            throw;
+        }
     }
 
     /// <summary>
@@ -1219,7 +1269,10 @@ public sealed class Database : IAsyncDisposable
             if (existing.Kind == IndexKind.FullText)
             {
                 if (FullTextIndexCatalog.MatchesDefinition(existing, tableName, normalizedColumns, resolvedOptions))
+                {
+                    await EnsureFullTextInternalStoresAsync(existing, ct);
                     return;
+                }
 
                 throw new CSharpDbException(
                     ErrorCode.TableAlreadyExists,
@@ -1288,6 +1341,81 @@ public sealed class Database : IAsyncDisposable
                 }
             }
 
+            try
+            {
+                await _pager.RollbackAsync(ct);
+                await _catalog.ReloadAsync(ct);
+            }
+            catch
+            {
+                // Preserve the original failure.
+            }
+
+            throw;
+        }
+    }
+
+    private async ValueTask EnsureFullTextInternalStoresAsync(IndexSchema logicalIndex, CancellationToken ct)
+    {
+        IndexSchema[] missingStores = FullTextIndexCatalog.CreateInternalSchemas(logicalIndex)
+            .Where(schema => _catalog.GetIndex(schema.IndexName) == null)
+            .ToArray();
+        if (missingStores.Length == 0)
+            return;
+
+        if (_inTransaction)
+        {
+            throw new InvalidOperationException(
+                "Full-text index storage cannot be upgraded while an explicit transaction is active.");
+        }
+
+        try
+        {
+            await _pager.BeginTransactionAsync(ct);
+            for (int i = 0; i < missingStores.Length; i++)
+                await _catalog.CreateIndexAsync(missingStores[i], ct);
+
+            PagerCommitResult commit = await BeginCommitForTableWithCatalogSyncAsync(logicalIndex.TableName, ct);
+            await commit.WaitAsync(ct);
+        }
+        catch
+        {
+            try
+            {
+                await _pager.RollbackAsync(ct);
+                await _catalog.ReloadAsync(ct);
+            }
+            catch
+            {
+                // Preserve the original failure.
+            }
+
+            throw;
+        }
+    }
+
+    private async ValueTask EnsureFullTextInternalStoresOnOpenAsync(CancellationToken ct)
+    {
+        IndexSchema[] missingStores = _catalog.GetIndexes()
+            .Where(static index => index.Kind == IndexKind.FullText)
+            .SelectMany(FullTextIndexCatalog.CreateInternalSchemas)
+            .Where(schema => _catalog.GetIndex(schema.IndexName) == null)
+            .ToArray();
+        if (missingStores.Length == 0)
+            return;
+
+        try
+        {
+            await _pager.BeginTransactionAsync(ct);
+            for (int i = 0; i < missingStores.Length; i++)
+                await _catalog.CreateIndexAsync(missingStores[i], ct);
+
+            PagerCommitResult commit = await BeginCommitWithCatalogSyncAsync(ct);
+            await commit.WaitAsync(ct);
+            _observedSchemaVersion = _catalog.SchemaVersion;
+        }
+        catch
+        {
             try
             {
                 await _pager.RollbackAsync(ct);

--- a/src/CSharpDB.Engine/FullTextIndexCatalog.cs
+++ b/src/CSharpDB.Engine/FullTextIndexCatalog.cs
@@ -52,6 +52,7 @@ internal static class FullTextIndexCatalog
             CreateInternalSchema(logicalIndex, FullTextIndexNaming.GetMetaIndexName(logicalIndex.IndexName)),
             CreateInternalSchema(logicalIndex, FullTextIndexNaming.GetTermsIndexName(logicalIndex.IndexName)),
             CreateInternalSchema(logicalIndex, FullTextIndexNaming.GetPostingsIndexName(logicalIndex.IndexName)),
+            CreateInternalSchema(logicalIndex, FullTextIndexNaming.GetPostingChunksIndexName(logicalIndex.IndexName)),
             CreateInternalSchema(logicalIndex, FullTextIndexNaming.GetDocStatsIndexName(logicalIndex.IndexName)),
         };
 

--- a/src/CSharpDB.Engine/FullTextIndexReader.cs
+++ b/src/CSharpDB.Engine/FullTextIndexReader.cs
@@ -22,13 +22,29 @@ internal static class FullTextIndexReader
             return Array.Empty<FullTextSearchHit>();
 
         IIndexStore postingsStore = catalog.GetIndexStore(FullTextIndexNaming.GetPostingsIndexName(logicalIndex.IndexName));
+        IIndexStore? postingChunksStore = TryGetPostingChunksStore(catalog, logicalIndex);
         var postingsByTerm = new List<List<FullTextPosting>>(terms.Length);
         for (int i = 0; i < terms.Length; i++)
         {
             long key = FullTextTermKeyCodec.ComputeKey(terms[i]);
             byte[]? bucketPayload = await postingsStore.FindAsync(key, ct);
-            if (bucketPayload == null ||
-                !FullTextPostingsPayloadCodec.TryGetMatchingPostings(bucketPayload, terms[i], out byte[] postingsPayload) ||
+            if (bucketPayload == null)
+            {
+                return Array.Empty<FullTextSearchHit>();
+            }
+
+            if (postingChunksStore != null &&
+                FullTextPostingChunkManifestCodec.IsEncoded(bucketPayload))
+            {
+                var chunkedPostings = await TryReadChunkedPostingsAsync(postingChunksStore, bucketPayload, terms[i], ct);
+                if (chunkedPostings == null)
+                    return Array.Empty<FullTextSearchHit>();
+
+                postingsByTerm.Add(chunkedPostings);
+                continue;
+            }
+
+            if (!FullTextPostingsPayloadCodec.TryGetMatchingPostings(bucketPayload, terms[i], out byte[] postingsPayload) ||
                 !FullTextPostingsListCodec.TryDecode(postingsPayload, out var postings))
             {
                 return Array.Empty<FullTextSearchHit>();
@@ -60,5 +76,45 @@ internal static class FullTextIndexReader
             hits[i] = new FullTextSearchHit(ordered[i], terms.Length);
 
         return hits;
+    }
+
+    private static IIndexStore? TryGetPostingChunksStore(SchemaCatalog catalog, IndexSchema logicalIndex)
+    {
+        string chunkIndexName = FullTextIndexNaming.GetPostingChunksIndexName(logicalIndex.IndexName);
+        return catalog.GetIndex(chunkIndexName) == null
+            ? null
+            : catalog.GetIndexStore(chunkIndexName);
+    }
+
+    private static async ValueTask<List<FullTextPosting>?> TryReadChunkedPostingsAsync(
+        IIndexStore postingChunksStore,
+        byte[] manifestPayload,
+        string term,
+        CancellationToken ct)
+    {
+        if (!FullTextPostingChunkManifestCodec.TryGetChunks(manifestPayload, term, out var chunks))
+            return null;
+
+        int totalCount = 0;
+        for (int i = 0; i < chunks.Length; i++)
+            totalCount += chunks[i].PostingCount;
+
+        var postings = new List<FullTextPosting>(totalCount);
+        for (int i = 0; i < chunks.Length; i++)
+        {
+            FullTextPostingChunkDescriptor chunk = chunks[i];
+            long chunkKey = FullTextPostingChunkKeyCodec.ComputeKey(term, chunk.FirstDocId);
+            byte[]? chunkPayload = await postingChunksStore.FindAsync(chunkKey, ct);
+            if (chunkPayload == null ||
+                !FullTextPostingChunkPayloadCodec.TryGetPostings(chunkPayload, term, chunk.FirstDocId, out byte[] postingsPayload) ||
+                !FullTextPostingsListCodec.TryDecode(postingsPayload, out var chunkPostings))
+            {
+                return null;
+            }
+
+            postings.AddRange(chunkPostings);
+        }
+
+        return postings;
     }
 }

--- a/src/CSharpDB.Engine/WriteTransaction.cs
+++ b/src/CSharpDB.Engine/WriteTransaction.cs
@@ -115,6 +115,7 @@ public sealed class WriteTransaction : IAsyncDisposable
         KeyValuePair<string, long>[] committedTableRowCountDeltas;
         TableStatistics[] committedTableStatistics;
         ColumnStatistics[] committedColumnStatistics;
+        MutationTargetCollectionDiagnosticsSnapshot mutationTargetCollectionDiagnostics;
         bool schemaChanged;
         bool rootPagesChanged;
         bool advisoryCatalogContentChanged;
@@ -127,6 +128,10 @@ public sealed class WriteTransaction : IAsyncDisposable
             committedTableRowCountDeltas = _catalog.GetPendingTableRowCountDeltas().ToArray();
             committedTableStatistics = _catalog.GetDirtyTableStatistics().ToArray();
             committedColumnStatistics = _catalog.GetDirtyColumnStatistics().ToArray();
+            var plannerMutationDiagnostics = _planner.GetMutationTargetCollectionDiagnosticsSnapshot();
+            mutationTargetCollectionDiagnostics = new MutationTargetCollectionDiagnosticsSnapshot(
+                plannerMutationDiagnostics.IndexedCollectionCount,
+                plannerMutationDiagnostics.ScannedCollectionCount);
             if (advisoryCatalogContentChanged)
             {
                 committedColumnStatistics = [];
@@ -159,6 +164,7 @@ public sealed class WriteTransaction : IAsyncDisposable
             committedTableRowCountDeltas,
             committedTableStatistics,
             committedColumnStatistics,
+            mutationTargetCollectionDiagnostics,
             ct);
     }
 

--- a/src/CSharpDB.Execution/QueryPlanner.cs
+++ b/src/CSharpDB.Execution/QueryPlanner.cs
@@ -38,6 +38,10 @@ public sealed class QueryPlanner
         long UnsupportedFallbackCount,
         long ReoptimizationLimitFallbackCount);
 
+    internal readonly record struct MutationTargetCollectionDiagnosticsSnapshot(
+        long IndexedCollectionCount,
+        long ScannedCollectionCount);
+
     private sealed record PlannerEstimateDiagnostic(
         int NodeId,
         int? ParentNodeId,
@@ -521,6 +525,8 @@ public sealed class QueryPlanner
     private long _adaptiveMaxBufferedFallbackCount;
     private long _adaptiveUnsupportedFallbackCount;
     private long _adaptiveReoptimizationLimitFallbackCount;
+    private long _indexedMutationTargetCollectionCount;
+    private long _scannedMutationTargetCollectionCount;
 
     private readonly record struct CorrelationScope(DbValue[] Row, TableSchema Schema);
     private long _observedSchemaVersion;
@@ -928,6 +934,17 @@ public sealed class QueryPlanner
         Interlocked.Exchange(ref _adaptiveMaxBufferedFallbackCount, 0);
         Interlocked.Exchange(ref _adaptiveUnsupportedFallbackCount, 0);
         Interlocked.Exchange(ref _adaptiveReoptimizationLimitFallbackCount, 0);
+    }
+
+    internal MutationTargetCollectionDiagnosticsSnapshot GetMutationTargetCollectionDiagnosticsSnapshot()
+        => new(
+            Interlocked.Read(ref _indexedMutationTargetCollectionCount),
+            Interlocked.Read(ref _scannedMutationTargetCollectionCount));
+
+    internal void ResetMutationTargetCollectionDiagnostics()
+    {
+        Interlocked.Exchange(ref _indexedMutationTargetCollectionCount, 0);
+        Interlocked.Exchange(ref _scannedMutationTargetCollectionCount, 0);
     }
 
     private static AdaptiveQueryReoptimizationOptions NormalizeAdaptiveQueryReoptimizationOptions(
@@ -8258,29 +8275,13 @@ public sealed class QueryPlanner
         var indexes = _catalog.GetIndexesForTable(stmt.TableName);
 
         // Collect rows to delete (can't modify tree while iterating)
-        int? deleteCapacityHint = TryGetCachedTreeRowCountCapacityHint(tree);
-        var rowsToDelete = deleteCapacityHint.HasValue
-            ? new List<(long rowId, DbValue[] row)>(deleteCapacityHint.Value)
-            : new List<(long rowId, DbValue[] row)>();
-        var scan = new TableScanOperator(tree, schema, GetReadSerializer(schema), deleteCapacityHint);
-        ApplyLogicalPredicateReadScope(stmt.TableName, stmt.Where, schema, scan);
-        await scan.OpenAsync(ct);
-        while (await scan.MoveNextAsync(ct))
-        {
-            if (stmt.Where != null)
-            {
-                var result = hasRemainingSubqueries && ContainsSubqueries(stmt.Where)
-                    ? await EvaluateExpressionWithSubqueriesAsync(
-                        stmt.Where,
-                        scan.Current,
-                        schema,
-                        Array.Empty<CorrelationScope>(),
-                        ct)
-                    : ExpressionEvaluator.Evaluate(stmt.Where, scan.Current, schema, _functions);
-                if (!result.IsTruthy) continue;
-            }
-            rowsToDelete.Add((scan.CurrentRowId, (DbValue[])scan.Current.Clone()));
-        }
+        var rowsToDelete = await CollectMutationTargetRowsAsync(
+            stmt.TableName,
+            schema,
+            tree,
+            stmt.Where,
+            hasRemainingSubqueries,
+            ct);
 
         bool hasIncomingForeignKeys = _catalog.GetReferencingForeignKeys(stmt.TableName).Count > 0;
         if (!hasIncomingForeignKeys)
@@ -8351,30 +8352,20 @@ public sealed class QueryPlanner
         bool hasIncomingForeignKeys = _catalog.GetReferencingForeignKeys(stmt.TableName).Count > 0;
 
         // Collect rows to update
-        int? updateCapacityHint = TryGetCachedTreeRowCountCapacityHint(tree);
-        var updates = updateCapacityHint.HasValue
-            ? new List<(long rowId, DbValue[] oldRow, DbValue[] newRow)>(updateCapacityHint.Value)
+        var targetRows = await CollectMutationTargetRowsAsync(
+            stmt.TableName,
+            schema,
+            tree,
+            stmt.Where,
+            hasRemainingSubqueries,
+            ct);
+        var updates = targetRows.Count > 0
+            ? new List<(long rowId, DbValue[] oldRow, DbValue[] newRow)>(targetRows.Count)
             : new List<(long rowId, DbValue[] oldRow, DbValue[] newRow)>();
-        var scan = new TableScanOperator(tree, schema, GetReadSerializer(schema), updateCapacityHint);
-        ApplyLogicalPredicateReadScope(stmt.TableName, stmt.Where, schema, scan);
-        await scan.OpenAsync(ct);
-        while (await scan.MoveNextAsync(ct))
+        foreach (var (rowId, row) in targetRows)
         {
-            if (stmt.Where != null)
-            {
-                var result = hasRemainingSubqueries && ContainsSubqueries(stmt.Where)
-                    ? await EvaluateExpressionWithSubqueriesAsync(
-                        stmt.Where,
-                        scan.Current,
-                        schema,
-                        Array.Empty<CorrelationScope>(),
-                        ct)
-                    : ExpressionEvaluator.Evaluate(stmt.Where, scan.Current, schema, _functions);
-                if (!result.IsTruthy) continue;
-            }
-
-            var oldRow = (DbValue[])scan.Current.Clone();
-            var newRow = (DbValue[])scan.Current.Clone();
+            var oldRow = row;
+            var newRow = (DbValue[])row.Clone();
             foreach (var set in stmt.SetClauses)
             {
                 int colIdx = schema.GetColumnIndex(set.ColumnName);
@@ -8383,13 +8374,13 @@ public sealed class QueryPlanner
                 newRow[colIdx] = hasRemainingSubqueries && ContainsSubqueries(set.Value)
                     ? await EvaluateExpressionWithSubqueriesAsync(
                         set.Value,
-                        scan.Current,
+                        row,
                         schema,
                         Array.Empty<CorrelationScope>(),
                         ct)
-                    : ExpressionEvaluator.Evaluate(set.Value, scan.Current, schema, _functions);
+                    : ExpressionEvaluator.Evaluate(set.Value, row, schema, _functions);
             }
-            updates.Add((scan.CurrentRowId, oldRow, newRow));
+            updates.Add((rowId, oldRow, newRow));
         }
 
         if (!hasOutgoingForeignKeys && !hasIncomingForeignKeys)
@@ -8473,6 +8464,127 @@ public sealed class QueryPlanner
         await PersistForeignKeyMutationContextAsync(mutationContext, stmt.TableName, updates.Count > 0, persistRootChanges: true, ct);
 
         return new QueryResult(updates.Count);
+    }
+
+    private async ValueTask<List<(long rowId, DbValue[] row)>> CollectMutationTargetRowsAsync(
+        string tableName,
+        TableSchema schema,
+        BTree tree,
+        Expression? where,
+        bool hasRemainingSubqueries,
+        CancellationToken ct)
+    {
+        IOperator? indexedSource = null;
+        Expression? remainingWhere = where;
+        if (where != null && !hasRemainingSubqueries)
+        {
+            indexedSource = TryBuildIndexScan(tableName, where, schema, out remainingWhere)
+                ?? TryBuildIntegerIndexRangeScan(tableName, where, schema, out remainingWhere)
+                ?? TryBuildOrderedTextIndexRangeScan(tableName, where, schema, out remainingWhere);
+        }
+
+        if (indexedSource != null)
+        {
+            Interlocked.Increment(ref _indexedMutationTargetCollectionCount);
+
+            int? capacityHint = indexedSource is IEstimatedRowCountProvider estimated &&
+                                estimated.EstimatedRowCount is int estimatedRowCount
+                ? ToCapacityHint(estimatedRowCount)
+                : null;
+            var indexedRows = capacityHint.HasValue
+                ? new List<(long rowId, DbValue[] row)>(capacityHint.Value)
+                : new List<(long rowId, DbValue[] row)>();
+
+            Action? logicalReadScope = TryCreateLogicalPredicateReadScope(tableName, where, schema);
+            logicalReadScope?.Invoke();
+
+            await indexedSource.OpenAsync(ct);
+            try
+            {
+                while (await indexedSource.MoveNextAsync(ct))
+                {
+                    if (remainingWhere != null)
+                    {
+                        var result = ExpressionEvaluator.Evaluate(remainingWhere, indexedSource.Current, schema, _functions);
+                        if (!result.IsTruthy)
+                            continue;
+                    }
+
+                    if (!TryGetCurrentRowId(indexedSource, out long rowId))
+                        throw new InvalidOperationException("Indexed mutation source did not expose a current row id.");
+
+                    indexedRows.Add((rowId, (DbValue[])indexedSource.Current.Clone()));
+                }
+            }
+            finally
+            {
+                await indexedSource.DisposeAsync();
+            }
+
+            return indexedRows;
+        }
+
+        Interlocked.Increment(ref _scannedMutationTargetCollectionCount);
+
+        int? scanCapacityHint = TryGetCachedTreeRowCountCapacityHint(tree);
+        var scannedRows = scanCapacityHint.HasValue
+            ? new List<(long rowId, DbValue[] row)>(scanCapacityHint.Value)
+            : new List<(long rowId, DbValue[] row)>();
+        var scan = new TableScanOperator(tree, schema, GetReadSerializer(schema), scanCapacityHint);
+        ApplyLogicalPredicateReadScope(tableName, where, schema, scan);
+        await scan.OpenAsync(ct);
+        try
+        {
+            while (await scan.MoveNextAsync(ct))
+            {
+                if (where != null)
+                {
+                    var result = hasRemainingSubqueries && ContainsSubqueries(where)
+                        ? await EvaluateExpressionWithSubqueriesAsync(
+                            where,
+                            scan.Current,
+                            schema,
+                            Array.Empty<CorrelationScope>(),
+                            ct)
+                        : ExpressionEvaluator.Evaluate(where, scan.Current, schema, _functions);
+                    if (!result.IsTruthy)
+                        continue;
+                }
+
+                scannedRows.Add((scan.CurrentRowId, (DbValue[])scan.Current.Clone()));
+            }
+        }
+        finally
+        {
+            await scan.DisposeAsync();
+        }
+
+        return scannedRows;
+    }
+
+    private static bool TryGetCurrentRowId(IOperator source, out long rowId)
+    {
+        switch (source)
+        {
+            case TableScanOperator tableScan:
+                rowId = tableScan.CurrentRowId;
+                return true;
+            case PrimaryKeyLookupOperator primaryKeyLookup:
+                rowId = primaryKeyLookup.CurrentRowId;
+                return true;
+            case IndexScanOperator indexScan:
+                rowId = indexScan.CurrentRowId;
+                return true;
+            case UniqueIndexLookupOperator uniqueIndexLookup:
+                rowId = uniqueIndexLookup.CurrentRowId;
+                return true;
+            case IndexOrderedScanOperator orderedScan:
+                rowId = orderedScan.CurrentRowId;
+                return true;
+            default:
+                rowId = 0;
+                return false;
+        }
     }
 
     private async ValueTask<QueryResult> ExecuteTemporaryDeleteAsync(DeleteStatement stmt, CancellationToken ct)

--- a/src/CSharpDB.Storage/Indexing/FullTextIndexMaintenance.cs
+++ b/src/CSharpDB.Storage/Indexing/FullTextIndexMaintenance.cs
@@ -7,6 +7,7 @@ namespace CSharpDB.Storage.Indexing;
 internal static class FullTextIndexMaintenance
 {
     private const long MetaKey = 0;
+    internal const int MaxPostingsPerChunk = 1024;
 
     public static bool TryResolveColumnIndices(
         IndexSchema indexSchema,
@@ -121,6 +122,7 @@ internal static class FullTextIndexMaintenance
         IIndexStore metaStore = catalog.GetIndexStore(FullTextIndexNaming.GetMetaIndexName(logicalIndex.IndexName));
         IIndexStore termsStore = catalog.GetIndexStore(FullTextIndexNaming.GetTermsIndexName(logicalIndex.IndexName));
         IIndexStore postingsStore = catalog.GetIndexStore(FullTextIndexNaming.GetPostingsIndexName(logicalIndex.IndexName));
+        IIndexStore? postingChunksStore = TryGetPostingChunksStore(catalog, logicalIndex);
         IIndexStore docStatsStore = catalog.GetIndexStore(FullTextIndexNaming.GetDocStatsIndexName(logicalIndex.IndexName));
 
         await UpdateMetaAsync(metaStore, +1, docLength, ct);
@@ -137,10 +139,17 @@ internal static class FullTextIndexMaintenance
             await WritePayloadAsync(termsStore, key, updatedTermStats, ct);
 
             byte[]? postingsPayload = await postingsStore.FindAsync(key, ct);
-            byte[] updatedPostings = postingsPayload == null
-                ? FullTextPostingsPayloadCodec.CreateSingle(term, [new FullTextPosting(rowId, positions)])
-                : FullTextPostingsPayloadCodec.Insert(postingsPayload, term, rowId, positions, out _);
-            await WritePayloadAsync(postingsStore, key, updatedPostings, ct);
+            if (postingChunksStore != null)
+            {
+                await InsertPostingAsync(postingsStore, postingChunksStore, key, term, rowId, positions, postingsPayload, ct);
+            }
+            else
+            {
+                byte[] updatedPostings = postingsPayload == null
+                    ? FullTextPostingsPayloadCodec.CreateSingle(term, [new FullTextPosting(rowId, positions)])
+                    : FullTextPostingsPayloadCodec.Insert(postingsPayload, term, rowId, positions, out _);
+                await WritePayloadAsync(postingsStore, key, updatedPostings, ct);
+            }
         }
     }
 
@@ -160,6 +169,7 @@ internal static class FullTextIndexMaintenance
         IIndexStore metaStore = catalog.GetIndexStore(FullTextIndexNaming.GetMetaIndexName(logicalIndex.IndexName));
         IIndexStore termsStore = catalog.GetIndexStore(FullTextIndexNaming.GetTermsIndexName(logicalIndex.IndexName));
         IIndexStore postingsStore = catalog.GetIndexStore(FullTextIndexNaming.GetPostingsIndexName(logicalIndex.IndexName));
+        IIndexStore? postingChunksStore = TryGetPostingChunksStore(catalog, logicalIndex);
         IIndexStore docStatsStore = catalog.GetIndexStore(FullTextIndexNaming.GetDocStatsIndexName(logicalIndex.IndexName));
 
         await UpdateMetaAsync(metaStore, -1, -docLength, ct);
@@ -179,11 +189,308 @@ internal static class FullTextIndexMaintenance
             byte[]? postingsPayload = await postingsStore.FindAsync(key, ct);
             if (postingsPayload != null)
             {
-                byte[]? updatedPostings = FullTextPostingsPayloadCodec.Remove(postingsPayload, term, rowId, out bool changed);
-                if (changed)
-                    await WritePayloadAsync(postingsStore, key, updatedPostings, ct);
+                if (postingChunksStore != null)
+                {
+                    await DeletePostingAsync(postingsStore, postingChunksStore, key, term, rowId, postingsPayload, ct);
+                }
+                else
+                {
+                    byte[]? updatedPostings = FullTextPostingsPayloadCodec.Remove(postingsPayload, term, rowId, out bool changed);
+                    if (changed)
+                        await WritePayloadAsync(postingsStore, key, updatedPostings, ct);
+                }
             }
         }
+    }
+
+    private static IIndexStore? TryGetPostingChunksStore(SchemaCatalog catalog, IndexSchema logicalIndex)
+    {
+        string chunkIndexName = FullTextIndexNaming.GetPostingChunksIndexName(logicalIndex.IndexName);
+        return catalog.GetIndex(chunkIndexName) == null
+            ? null
+            : catalog.GetIndexStore(chunkIndexName);
+    }
+
+    private static async ValueTask InsertPostingAsync(
+        IIndexStore postingsStore,
+        IIndexStore postingChunksStore,
+        long termKey,
+        string term,
+        long rowId,
+        IReadOnlyList<int> positions,
+        byte[]? manifestPayload,
+        CancellationToken ct)
+    {
+        if (manifestPayload == null)
+        {
+            var posting = new FullTextPosting(rowId, positions.ToArray());
+            var initialChunks = await WriteChunksForTermAsync(postingChunksStore, term, [posting], ct);
+            await WritePayloadAsync(
+                postingsStore,
+                termKey,
+                FullTextPostingChunkManifestCodec.CreateSingle(term, initialChunks),
+                ct);
+            return;
+        }
+
+        if (FullTextPostingsPayloadCodec.IsEncoded(manifestPayload))
+            manifestPayload = await MigrateLegacyPostingsPayloadAsync(postingsStore, postingChunksStore, termKey, manifestPayload, ct);
+
+        if (!FullTextPostingChunkManifestCodec.IsEncoded(manifestPayload))
+            throw new InvalidOperationException("Full-text postings manifest is not in a supported format.");
+
+        FullTextPostingChunkDescriptor[] chunks = FullTextPostingChunkManifestCodec.TryGetChunks(manifestPayload, term, out var existingChunks)
+            ? existingChunks
+            : [];
+
+        if (chunks.Length == 0)
+        {
+            var posting = new FullTextPosting(rowId, positions.ToArray());
+            var newChunks = await WriteChunksForTermAsync(postingChunksStore, term, [posting], ct);
+            byte[]? updatedManifest = FullTextPostingChunkManifestCodec.Upsert(manifestPayload, term, newChunks);
+            await WritePayloadAsync(postingsStore, termKey, updatedManifest, ct);
+            return;
+        }
+
+        int chunkIndex = FindChunkIndex(chunks, rowId);
+        FullTextPostingChunkDescriptor oldDescriptor = chunks[chunkIndex];
+        List<FullTextPosting> postings = await ReadChunkPostingsAsync(postingChunksStore, term, oldDescriptor.FirstDocId, ct);
+
+        int postingIndex = FindPostingIndex(postings, rowId);
+        if (postingIndex >= 0)
+            postings[postingIndex] = new FullTextPosting(rowId, positions.ToArray());
+        else
+            postings.Insert(~postingIndex, new FullTextPosting(rowId, positions.ToArray()));
+
+        var updatedChunks = new List<FullTextPostingChunkDescriptor>(chunks.Length + 1);
+        for (int i = 0; i < chunks.Length; i++)
+        {
+            if (i != chunkIndex)
+            {
+                updatedChunks.Add(chunks[i]);
+                continue;
+            }
+
+            await RemoveChunkAsync(postingChunksStore, term, oldDescriptor.FirstDocId, ct);
+            updatedChunks.AddRange(await WriteChunksForTermAsync(postingChunksStore, term, postings, ct));
+        }
+
+        byte[]? updatedPayload = FullTextPostingChunkManifestCodec.Upsert(manifestPayload, term, updatedChunks);
+        await WritePayloadAsync(postingsStore, termKey, updatedPayload, ct);
+    }
+
+    private static async ValueTask DeletePostingAsync(
+        IIndexStore postingsStore,
+        IIndexStore postingChunksStore,
+        long termKey,
+        string term,
+        long rowId,
+        byte[] manifestPayload,
+        CancellationToken ct)
+    {
+        if (FullTextPostingsPayloadCodec.IsEncoded(manifestPayload))
+            manifestPayload = await MigrateLegacyPostingsPayloadAsync(postingsStore, postingChunksStore, termKey, manifestPayload, ct);
+
+        if (!FullTextPostingChunkManifestCodec.IsEncoded(manifestPayload) ||
+            !FullTextPostingChunkManifestCodec.TryGetChunks(manifestPayload, term, out var chunks) ||
+            chunks.Length == 0)
+        {
+            return;
+        }
+
+        int chunkIndex = FindChunkIndex(chunks, rowId);
+        FullTextPostingChunkDescriptor oldDescriptor = chunks[chunkIndex];
+        if (rowId < oldDescriptor.FirstDocId || rowId > oldDescriptor.LastDocId)
+            return;
+
+        List<FullTextPosting> postings = await ReadChunkPostingsAsync(postingChunksStore, term, oldDescriptor.FirstDocId, ct);
+        int postingIndex = FindPostingIndex(postings, rowId);
+        if (postingIndex < 0)
+            return;
+
+        postings.RemoveAt(postingIndex);
+        await RemoveChunkAsync(postingChunksStore, term, oldDescriptor.FirstDocId, ct);
+
+        var updatedChunks = new List<FullTextPostingChunkDescriptor>(Math.Max(0, chunks.Length - 1));
+        for (int i = 0; i < chunks.Length; i++)
+        {
+            if (i != chunkIndex)
+            {
+                updatedChunks.Add(chunks[i]);
+                continue;
+            }
+
+            if (postings.Count > 0)
+                updatedChunks.AddRange(await WriteChunksForTermAsync(postingChunksStore, term, postings, ct));
+        }
+
+        byte[]? updatedPayload = updatedChunks.Count == 0
+            ? FullTextPostingChunkManifestCodec.Remove(manifestPayload, term)
+            : FullTextPostingChunkManifestCodec.Upsert(manifestPayload, term, updatedChunks);
+        await WritePayloadAsync(postingsStore, termKey, updatedPayload, ct);
+    }
+
+    private static async ValueTask<byte[]> MigrateLegacyPostingsPayloadAsync(
+        IIndexStore postingsStore,
+        IIndexStore postingChunksStore,
+        long termKey,
+        byte[] legacyPayload,
+        CancellationToken ct)
+    {
+        if (!FullTextPostingsPayloadCodec.TryDecodeBuckets(legacyPayload, out var buckets))
+            throw new InvalidOperationException("Legacy full-text postings payload is invalid.");
+
+        var manifests = new List<FullTextPostingChunkManifestBucket>(buckets.Count);
+        foreach (FullTextPostingsBucket bucket in buckets)
+        {
+            if (!FullTextPostingsListCodec.TryDecode(bucket.PostingsPayload, out var postings))
+                throw new InvalidOperationException("Legacy full-text postings list is invalid.");
+
+            FullTextPostingChunkDescriptor[] chunks = await WriteChunksForTermAsync(
+                postingChunksStore,
+                bucket.Term,
+                postings,
+                ct);
+            if (chunks.Length > 0)
+                manifests.Add(new FullTextPostingChunkManifestBucket(bucket.Term, chunks));
+        }
+
+        byte[]? manifestPayload = null;
+        foreach (FullTextPostingChunkManifestBucket manifest in manifests)
+        {
+            manifestPayload = manifestPayload == null
+                ? FullTextPostingChunkManifestCodec.CreateSingle(manifest.Term, manifest.Chunks)
+                : FullTextPostingChunkManifestCodec.Upsert(manifestPayload, manifest.Term, manifest.Chunks);
+        }
+
+        await WritePayloadAsync(postingsStore, termKey, manifestPayload, ct);
+        return manifestPayload ?? [];
+    }
+
+    private static async ValueTask<FullTextPostingChunkDescriptor[]> WriteChunksForTermAsync(
+        IIndexStore postingChunksStore,
+        string term,
+        IReadOnlyList<FullTextPosting> postings,
+        CancellationToken ct)
+    {
+        if (postings.Count == 0)
+            return [];
+
+        var descriptors = new List<FullTextPostingChunkDescriptor>((postings.Count / MaxPostingsPerChunk) + 1);
+        for (int offset = 0; offset < postings.Count; offset += MaxPostingsPerChunk)
+        {
+            int count = Math.Min(MaxPostingsPerChunk, postings.Count - offset);
+            FullTextPosting[] chunkPostings = new FullTextPosting[count];
+            for (int i = 0; i < count; i++)
+                chunkPostings[i] = postings[offset + i];
+
+            FullTextPostingChunkDescriptor descriptor = CreateDescriptor(chunkPostings);
+            await WriteChunkAsync(postingChunksStore, term, descriptor.FirstDocId, chunkPostings, ct);
+            descriptors.Add(descriptor);
+        }
+
+        return descriptors.ToArray();
+    }
+
+    private static async ValueTask<List<FullTextPosting>> ReadChunkPostingsAsync(
+        IIndexStore postingChunksStore,
+        string term,
+        long firstDocId,
+        CancellationToken ct)
+    {
+        long chunkKey = FullTextPostingChunkKeyCodec.ComputeKey(term, firstDocId);
+        byte[]? chunkPayload = await postingChunksStore.FindAsync(chunkKey, ct);
+        if (chunkPayload == null ||
+            !FullTextPostingChunkPayloadCodec.TryGetPostings(chunkPayload, term, firstDocId, out byte[] postingsPayload) ||
+            !FullTextPostingsListCodec.TryDecode(postingsPayload, out var postings))
+        {
+            throw new InvalidOperationException("Full-text posting chunk is missing or corrupt.");
+        }
+
+        return postings;
+    }
+
+    private static async ValueTask WriteChunkAsync(
+        IIndexStore postingChunksStore,
+        string term,
+        long firstDocId,
+        IReadOnlyList<FullTextPosting> postings,
+        CancellationToken ct)
+    {
+        long chunkKey = FullTextPostingChunkKeyCodec.ComputeKey(term, firstDocId);
+        byte[]? existing = await postingChunksStore.FindAsync(chunkKey, ct);
+        byte[] payload = existing == null
+            ? FullTextPostingChunkPayloadCodec.CreateSingle(term, firstDocId, postings)
+            : FullTextPostingChunkPayloadCodec.Upsert(existing, term, firstDocId, postings);
+        await WritePayloadAsync(postingChunksStore, chunkKey, payload, ct);
+    }
+
+    private static async ValueTask RemoveChunkAsync(
+        IIndexStore postingChunksStore,
+        string term,
+        long firstDocId,
+        CancellationToken ct)
+    {
+        long chunkKey = FullTextPostingChunkKeyCodec.ComputeKey(term, firstDocId);
+        byte[]? existing = await postingChunksStore.FindAsync(chunkKey, ct);
+        if (existing == null)
+            return;
+
+        byte[]? updated = FullTextPostingChunkPayloadCodec.Remove(existing, term, firstDocId);
+        await WritePayloadAsync(postingChunksStore, chunkKey, updated, ct);
+    }
+
+    private static FullTextPostingChunkDescriptor CreateDescriptor(IReadOnlyList<FullTextPosting> postings)
+    {
+        if (postings.Count == 0)
+            throw new ArgumentException("Posting chunk must contain at least one posting.", nameof(postings));
+
+        return new FullTextPostingChunkDescriptor(
+            postings[0].DocId,
+            postings[^1].DocId,
+            postings.Count);
+    }
+
+    private static int FindChunkIndex(IReadOnlyList<FullTextPostingChunkDescriptor> chunks, long rowId)
+    {
+        int low = 0;
+        int high = chunks.Count - 1;
+        while (low <= high)
+        {
+            int mid = low + ((high - low) / 2);
+            FullTextPostingChunkDescriptor chunk = chunks[mid];
+            if (rowId < chunk.FirstDocId)
+                high = mid - 1;
+            else if (rowId > chunk.LastDocId)
+                low = mid + 1;
+            else
+                return mid;
+        }
+
+        if (low >= chunks.Count)
+            return chunks.Count - 1;
+
+        return low;
+    }
+
+    private static int FindPostingIndex(IReadOnlyList<FullTextPosting> postings, long docId)
+    {
+        int low = 0;
+        int high = postings.Count - 1;
+        while (low <= high)
+        {
+            int mid = low + ((high - low) / 2);
+            long current = postings[mid].DocId;
+            if (current == docId)
+                return mid;
+
+            if (current < docId)
+                low = mid + 1;
+            else
+                high = mid - 1;
+        }
+
+        return ~low;
     }
 
     private static async ValueTask UpdateMetaAsync(

--- a/src/CSharpDB.Storage/Indexing/FullTextIndexNaming.cs
+++ b/src/CSharpDB.Storage/Indexing/FullTextIndexNaming.cs
@@ -5,6 +5,7 @@ internal static class FullTextIndexNaming
     internal const string MetaSuffix = "__meta";
     internal const string TermsSuffix = "__terms";
     internal const string PostingsSuffix = "__postings";
+    internal const string PostingChunksSuffix = "__postingchunks";
     internal const string DocStatsSuffix = "__docstats";
     internal const string KGramsSuffix = "__kgrams";
 
@@ -13,6 +14,8 @@ internal static class FullTextIndexNaming
     public static string GetTermsIndexName(string indexName) => indexName + TermsSuffix;
 
     public static string GetPostingsIndexName(string indexName) => indexName + PostingsSuffix;
+
+    public static string GetPostingChunksIndexName(string indexName) => indexName + PostingChunksSuffix;
 
     public static string GetDocStatsIndexName(string indexName) => indexName + DocStatsSuffix;
 
@@ -23,6 +26,7 @@ internal static class FullTextIndexNaming
         GetMetaIndexName(indexName),
         GetTermsIndexName(indexName),
         GetPostingsIndexName(indexName),
+        GetPostingChunksIndexName(indexName),
         GetDocStatsIndexName(indexName),
     ];
 }

--- a/src/CSharpDB.Storage/Indexing/FullTextPostingsPayloadCodec.cs
+++ b/src/CSharpDB.Storage/Indexing/FullTextPostingsPayloadCodec.cs
@@ -137,6 +137,9 @@ internal static class FullTextPostingsPayloadCodec
         return true;
     }
 
+    public static bool TryDecodeBuckets(ReadOnlySpan<byte> payload, out List<FullTextPostingsBucket> entries)
+        => TryDecodeEntries(payload, out entries);
+
     public static byte[] Insert(ReadOnlySpan<byte> payload, string term, long docId, IReadOnlyList<int> positions, out bool changed)
     {
         if (!TryDecodeEntries(payload, out var entries))
@@ -335,5 +338,433 @@ internal static class FullTextPostingsPayloadCodec
         }
 
         return ~low;
+    }
+}
+
+internal readonly record struct FullTextPostingChunkDescriptor(long FirstDocId, long LastDocId, int PostingCount);
+
+internal static class FullTextPostingChunkKeyCodec
+{
+    public static long ComputeKey(string term, long firstDocId)
+    {
+        ArgumentNullException.ThrowIfNull(term);
+
+        const ulong offsetBasis = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+
+        ulong hash = offsetBasis;
+        foreach (byte b in Encoding.UTF8.GetBytes(term))
+        {
+            hash ^= b;
+            hash *= prime;
+        }
+
+        unchecked
+        {
+            ulong docBits = (ulong)firstDocId;
+            for (int i = 0; i < sizeof(long); i++)
+            {
+                hash ^= (byte)(docBits >> (i * 8));
+                hash *= prime;
+            }
+        }
+
+        return unchecked((long)hash);
+    }
+}
+
+internal readonly record struct FullTextPostingChunkManifestBucket(
+    string Term,
+    FullTextPostingChunkDescriptor[] Chunks);
+
+internal static class FullTextPostingChunkManifestCodec
+{
+    private static readonly byte[] MagicBytes = [(byte)'F', (byte)'T', (byte)'M', (byte)'1'];
+
+    public static bool IsEncoded(ReadOnlySpan<byte> payload)
+        => payload.Length >= MagicBytes.Length && payload[..MagicBytes.Length].SequenceEqual(MagicBytes);
+
+    public static byte[] CreateSingle(string term, IReadOnlyList<FullTextPostingChunkDescriptor> chunks)
+        => EncodeEntries([new FullTextPostingChunkManifestBucket(term, chunks.ToArray())]);
+
+    public static bool TryGetChunks(ReadOnlySpan<byte> payload, string term, out FullTextPostingChunkDescriptor[] chunks)
+    {
+        chunks = [];
+        if (!TryDecodeEntries(payload, out var entries))
+            return false;
+
+        int index = FindEntryIndex(entries, term);
+        if (index < 0)
+            return false;
+
+        chunks = entries[index].Chunks;
+        return true;
+    }
+
+    public static byte[]? Upsert(
+        ReadOnlySpan<byte> payload,
+        string term,
+        IReadOnlyList<FullTextPostingChunkDescriptor> chunks)
+    {
+        if (chunks.Count == 0)
+            return Remove(payload, term);
+
+        if (!TryDecodeEntries(payload, out var entries))
+            throw new InvalidOperationException("Payload is not in full-text posting chunk manifest format.");
+
+        int index = FindInsertIndex(entries, term, out bool exists);
+        var bucket = new FullTextPostingChunkManifestBucket(term, chunks.ToArray());
+        if (exists)
+            entries[index] = bucket;
+        else
+            entries.Insert(index, bucket);
+
+        return EncodeEntries(entries);
+    }
+
+    public static byte[]? Remove(ReadOnlySpan<byte> payload, string term)
+    {
+        if (!TryDecodeEntries(payload, out var entries))
+            throw new InvalidOperationException("Payload is not in full-text posting chunk manifest format.");
+
+        int index = FindEntryIndex(entries, term);
+        if (index < 0)
+            return payload.ToArray();
+
+        entries.RemoveAt(index);
+        return entries.Count == 0 ? null : EncodeEntries(entries);
+    }
+
+    private static bool TryDecodeEntries(ReadOnlySpan<byte> payload, out List<FullTextPostingChunkManifestBucket> entries)
+    {
+        entries = [];
+        if (!IsEncoded(payload))
+            return false;
+
+        int offset = MagicBytes.Length;
+        int count = checked((int)Varint.Read(payload[offset..], out int countBytes));
+        offset += countBytes;
+        if (count < 0)
+            return false;
+
+        entries = new List<FullTextPostingChunkManifestBucket>(count);
+        for (int i = 0; i < count; i++)
+        {
+            int encodedLength = checked((int)Varint.Read(payload[offset..], out int termLengthBytes));
+            offset += termLengthBytes;
+            if (encodedLength <= 0)
+                return false;
+
+            int termLength = encodedLength - 1;
+            if (offset + termLength > payload.Length)
+                return false;
+
+            string term = Encoding.UTF8.GetString(payload.Slice(offset, termLength));
+            offset += termLength;
+
+            int chunkCount = checked((int)Varint.Read(payload[offset..], out int chunkCountBytes));
+            offset += chunkCountBytes;
+            if (chunkCount < 0)
+                return false;
+
+            var chunks = new FullTextPostingChunkDescriptor[chunkCount];
+            for (int j = 0; j < chunkCount; j++)
+            {
+                long firstDocId = checked((long)Varint.Read(payload[offset..], out int firstBytes));
+                offset += firstBytes;
+                long lastDocId = checked((long)Varint.Read(payload[offset..], out int lastBytes));
+                offset += lastBytes;
+                int postingCount = checked((int)Varint.Read(payload[offset..], out int postingCountBytes));
+                offset += postingCountBytes;
+                if (postingCount <= 0 || lastDocId < firstDocId)
+                    return false;
+
+                chunks[j] = new FullTextPostingChunkDescriptor(firstDocId, lastDocId, postingCount);
+            }
+
+            entries.Add(new FullTextPostingChunkManifestBucket(term, chunks));
+        }
+
+        return offset == payload.Length;
+    }
+
+    private static byte[] EncodeEntries(IReadOnlyList<FullTextPostingChunkManifestBucket> entries)
+    {
+        int size = MagicBytes.Length + Varint.SizeOf(entries.Count);
+        for (int i = 0; i < entries.Count; i++)
+        {
+            int termByteLength = Encoding.UTF8.GetByteCount(entries[i].Term);
+            size += Varint.SizeOf(termByteLength + 1) + termByteLength;
+            size += Varint.SizeOf(entries[i].Chunks.Length);
+            for (int j = 0; j < entries[i].Chunks.Length; j++)
+            {
+                FullTextPostingChunkDescriptor chunk = entries[i].Chunks[j];
+                size += Varint.SizeOf(chunk.FirstDocId);
+                size += Varint.SizeOf(chunk.LastDocId);
+                size += Varint.SizeOf(chunk.PostingCount);
+            }
+        }
+
+        byte[] payload = GC.AllocateUninitializedArray<byte>(size);
+        MagicBytes.CopyTo(payload, 0);
+        int offset = MagicBytes.Length;
+        offset += Varint.Write(payload.AsSpan(offset), entries.Count);
+
+        for (int i = 0; i < entries.Count; i++)
+        {
+            FullTextPostingChunkManifestBucket entry = entries[i];
+            int termByteLength = Encoding.UTF8.GetByteCount(entry.Term);
+            offset += Varint.Write(payload.AsSpan(offset), termByteLength + 1);
+            offset += Encoding.UTF8.GetBytes(entry.Term, payload.AsSpan(offset, termByteLength));
+            offset += Varint.Write(payload.AsSpan(offset), entry.Chunks.Length);
+            for (int j = 0; j < entry.Chunks.Length; j++)
+            {
+                FullTextPostingChunkDescriptor chunk = entry.Chunks[j];
+                offset += Varint.Write(payload.AsSpan(offset), chunk.FirstDocId);
+                offset += Varint.Write(payload.AsSpan(offset), chunk.LastDocId);
+                offset += Varint.Write(payload.AsSpan(offset), chunk.PostingCount);
+            }
+        }
+
+        return payload;
+    }
+
+    private static int FindInsertIndex(
+        IReadOnlyList<FullTextPostingChunkManifestBucket> entries,
+        string term,
+        out bool exists)
+    {
+        int low = 0;
+        int high = entries.Count - 1;
+        while (low <= high)
+        {
+            int mid = low + ((high - low) / 2);
+            int comparison = string.Compare(entries[mid].Term, term, StringComparison.Ordinal);
+            if (comparison == 0)
+            {
+                exists = true;
+                return mid;
+            }
+
+            if (comparison < 0)
+                low = mid + 1;
+            else
+                high = mid - 1;
+        }
+
+        exists = false;
+        return low;
+    }
+
+    private static int FindEntryIndex(IReadOnlyList<FullTextPostingChunkManifestBucket> entries, string term)
+    {
+        int low = 0;
+        int high = entries.Count - 1;
+        while (low <= high)
+        {
+            int mid = low + ((high - low) / 2);
+            int comparison = string.Compare(entries[mid].Term, term, StringComparison.Ordinal);
+            if (comparison == 0)
+                return mid;
+
+            if (comparison < 0)
+                low = mid + 1;
+            else
+                high = mid - 1;
+        }
+
+        return -1;
+    }
+}
+
+internal readonly record struct FullTextPostingChunkBucket(string Term, long FirstDocId, byte[] PostingsPayload);
+
+internal static class FullTextPostingChunkPayloadCodec
+{
+    private static readonly byte[] MagicBytes = [(byte)'F', (byte)'T', (byte)'C', (byte)'1'];
+
+    public static byte[] CreateSingle(string term, long firstDocId, IReadOnlyList<FullTextPosting> postings)
+        => EncodeEntries([new FullTextPostingChunkBucket(term, firstDocId, FullTextPostingsListCodec.EncodeSorted(postings))]);
+
+    public static bool TryGetPostings(
+        ReadOnlySpan<byte> payload,
+        string term,
+        long firstDocId,
+        out byte[] postingsPayload)
+    {
+        postingsPayload = [];
+        if (!TryDecodeEntries(payload, out var entries))
+            return false;
+
+        int index = FindEntryIndex(entries, term, firstDocId);
+        if (index < 0)
+            return false;
+
+        postingsPayload = entries[index].PostingsPayload;
+        return true;
+    }
+
+    public static byte[] Upsert(
+        ReadOnlySpan<byte> payload,
+        string term,
+        long firstDocId,
+        IReadOnlyList<FullTextPosting> postings)
+    {
+        if (!TryDecodeEntries(payload, out var entries))
+            throw new InvalidOperationException("Payload is not in full-text posting chunk format.");
+
+        int index = FindInsertIndex(entries, term, firstDocId, out bool exists);
+        var bucket = new FullTextPostingChunkBucket(term, firstDocId, FullTextPostingsListCodec.EncodeSorted(postings));
+        if (exists)
+            entries[index] = bucket;
+        else
+            entries.Insert(index, bucket);
+
+        return EncodeEntries(entries);
+    }
+
+    public static byte[]? Remove(ReadOnlySpan<byte> payload, string term, long firstDocId)
+    {
+        if (!TryDecodeEntries(payload, out var entries))
+            throw new InvalidOperationException("Payload is not in full-text posting chunk format.");
+
+        int index = FindEntryIndex(entries, term, firstDocId);
+        if (index < 0)
+            return payload.ToArray();
+
+        entries.RemoveAt(index);
+        return entries.Count == 0 ? null : EncodeEntries(entries);
+    }
+
+    private static bool TryDecodeEntries(ReadOnlySpan<byte> payload, out List<FullTextPostingChunkBucket> entries)
+    {
+        entries = [];
+        if (payload.Length < MagicBytes.Length || !payload[..MagicBytes.Length].SequenceEqual(MagicBytes))
+            return false;
+
+        int offset = MagicBytes.Length;
+        int count = checked((int)Varint.Read(payload[offset..], out int countBytes));
+        offset += countBytes;
+        if (count < 0)
+            return false;
+
+        entries = new List<FullTextPostingChunkBucket>(count);
+        for (int i = 0; i < count; i++)
+        {
+            int encodedLength = checked((int)Varint.Read(payload[offset..], out int termLengthBytes));
+            offset += termLengthBytes;
+            if (encodedLength <= 0)
+                return false;
+
+            int termLength = encodedLength - 1;
+            if (offset + termLength > payload.Length)
+                return false;
+
+            string term = Encoding.UTF8.GetString(payload.Slice(offset, termLength));
+            offset += termLength;
+
+            long firstDocId = checked((long)Varint.Read(payload[offset..], out int firstDocIdBytes));
+            offset += firstDocIdBytes;
+
+            int postingsLength = checked((int)Varint.Read(payload[offset..], out int postingsLengthBytes));
+            offset += postingsLengthBytes;
+            if (postingsLength <= 0 || offset + postingsLength > payload.Length)
+                return false;
+
+            byte[] postingsPayload = payload.Slice(offset, postingsLength).ToArray();
+            offset += postingsLength;
+
+            entries.Add(new FullTextPostingChunkBucket(term, firstDocId, postingsPayload));
+        }
+
+        return offset == payload.Length;
+    }
+
+    private static byte[] EncodeEntries(IReadOnlyList<FullTextPostingChunkBucket> entries)
+    {
+        int size = MagicBytes.Length + Varint.SizeOf(entries.Count);
+        for (int i = 0; i < entries.Count; i++)
+        {
+            int termByteLength = Encoding.UTF8.GetByteCount(entries[i].Term);
+            size += Varint.SizeOf(termByteLength + 1) + termByteLength;
+            size += Varint.SizeOf(entries[i].FirstDocId);
+            size += Varint.SizeOf(entries[i].PostingsPayload.Length) + entries[i].PostingsPayload.Length;
+        }
+
+        byte[] payload = GC.AllocateUninitializedArray<byte>(size);
+        MagicBytes.CopyTo(payload, 0);
+        int offset = MagicBytes.Length;
+        offset += Varint.Write(payload.AsSpan(offset), entries.Count);
+
+        for (int i = 0; i < entries.Count; i++)
+        {
+            FullTextPostingChunkBucket entry = entries[i];
+            int termByteLength = Encoding.UTF8.GetByteCount(entry.Term);
+            offset += Varint.Write(payload.AsSpan(offset), termByteLength + 1);
+            offset += Encoding.UTF8.GetBytes(entry.Term, payload.AsSpan(offset, termByteLength));
+            offset += Varint.Write(payload.AsSpan(offset), entry.FirstDocId);
+            offset += Varint.Write(payload.AsSpan(offset), entry.PostingsPayload.Length);
+            entry.PostingsPayload.CopyTo(payload.AsSpan(offset));
+            offset += entry.PostingsPayload.Length;
+        }
+
+        return payload;
+    }
+
+    private static int FindInsertIndex(
+        IReadOnlyList<FullTextPostingChunkBucket> entries,
+        string term,
+        long firstDocId,
+        out bool exists)
+    {
+        int low = 0;
+        int high = entries.Count - 1;
+        while (low <= high)
+        {
+            int mid = low + ((high - low) / 2);
+            int comparison = Compare(entries[mid], term, firstDocId);
+            if (comparison == 0)
+            {
+                exists = true;
+                return mid;
+            }
+
+            if (comparison < 0)
+                low = mid + 1;
+            else
+                high = mid - 1;
+        }
+
+        exists = false;
+        return low;
+    }
+
+    private static int FindEntryIndex(
+        IReadOnlyList<FullTextPostingChunkBucket> entries,
+        string term,
+        long firstDocId)
+    {
+        int low = 0;
+        int high = entries.Count - 1;
+        while (low <= high)
+        {
+            int mid = low + ((high - low) / 2);
+            int comparison = Compare(entries[mid], term, firstDocId);
+            if (comparison == 0)
+                return mid;
+
+            if (comparison < 0)
+                low = mid + 1;
+            else
+                high = mid - 1;
+        }
+
+        return -1;
+    }
+
+    private static int Compare(FullTextPostingChunkBucket entry, string term, long firstDocId)
+    {
+        int comparison = string.Compare(entry.Term, term, StringComparison.Ordinal);
+        return comparison != 0 ? comparison : entry.FirstDocId.CompareTo(firstDocId);
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>2.0.0</Version>
+    <Version>4.0.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />

--- a/tests/CSharpDB.Benchmarks/Micro/FullTextSearchBenchmarks.cs
+++ b/tests/CSharpDB.Benchmarks/Micro/FullTextSearchBenchmarks.cs
@@ -80,6 +80,112 @@ public class FullTextIndexBuildBenchmarks
     }
 }
 
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 1, iterationCount: 3)]
+public class FullTextHotTokenBuildBenchmarks
+{
+    [Params(20_000, 100_000, 500_000)]
+    public int PostingCount { get; set; }
+
+    [Benchmark(Description = "FTS hot-token incremental insert/index")]
+    public async Task<long> InsertAndIndexHotTokenRows()
+    {
+        await using var bench = await FullTextHotTokenBenchmarkData.CreateEmptyAsync();
+        await bench.Db.EnsureFullTextIndexAsync(
+            FullTextHotTokenBenchmarkData.IndexName,
+            FullTextHotTokenBenchmarkData.TableName,
+            [FullTextHotTokenBenchmarkData.BodyColumn]);
+
+        await FullTextHotTokenBenchmarkData.SeedHotTokenRowsAsync(bench, PostingCount);
+        var hits = await bench.Db.SearchAsync(FullTextHotTokenBenchmarkData.IndexName, FullTextHotTokenBenchmarkData.HotQuery);
+        if (hits.Count != PostingCount)
+            throw new InvalidOperationException($"Expected {PostingCount} hits; got {hits.Count}.");
+
+        return FullTextHotTokenBenchmarkData.GetDatabaseBytes(bench);
+    }
+}
+
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 10)]
+public class FullTextHotTokenQueryBenchmarks
+{
+    [Params(20_000, 100_000, 500_000)]
+    public int PostingCount { get; set; }
+
+    private BenchmarkDatabase _bench = null!;
+    private int _sink;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+        => _bench = FullTextHotTokenBenchmarkData.CreatePopulatedAsync(PostingCount).GetAwaiter().GetResult();
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+        => _bench.Dispose();
+
+    [Benchmark(Description = "FTS hot-token search")]
+    public async Task<int> SearchHotToken()
+    {
+        var hits = await _bench.Db.SearchAsync(FullTextHotTokenBenchmarkData.IndexName, FullTextHotTokenBenchmarkData.HotQuery);
+        _sink ^= hits.Count;
+        if (hits.Count > 0)
+            _sink ^= (int)hits[0].RowId;
+        return hits.Count;
+    }
+}
+
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 1, iterationCount: 5)]
+public class FullTextHotTokenDeleteBenchmarks
+{
+    [Params(20_000, 100_000, 500_000)]
+    public int PostingCount { get; set; }
+
+    private BenchmarkDatabase _bench = null!;
+
+    [IterationSetup]
+    public void IterationSetup()
+        => _bench = FullTextHotTokenBenchmarkData.CreatePopulatedAsync(PostingCount).GetAwaiter().GetResult();
+
+    [IterationCleanup]
+    public void IterationCleanup()
+        => _bench.Dispose();
+
+    [Benchmark(Description = "FTS hot-token indexed DELETE maintenance")]
+    public async Task<int> DeleteMiddleHotTokenRow()
+    {
+        await using var result = await _bench.Db.ExecuteAsync(
+            FormattableString.Invariant($"DELETE FROM {FullTextHotTokenBenchmarkData.TableName} WHERE id = {PostingCount / 2}"));
+        return result.RowsAffected;
+    }
+}
+
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 1, iterationCount: 5)]
+public class FullTextHotTokenUpdateBenchmarks
+{
+    [Params(20_000, 100_000, 500_000)]
+    public int PostingCount { get; set; }
+
+    private BenchmarkDatabase _bench = null!;
+
+    [IterationSetup]
+    public void IterationSetup()
+        => _bench = FullTextHotTokenBenchmarkData.CreatePopulatedAsync(PostingCount).GetAwaiter().GetResult();
+
+    [IterationCleanup]
+    public void IterationCleanup()
+        => _bench.Dispose();
+
+    [Benchmark(Description = "FTS hot-token indexed UPDATE maintenance")]
+    public async Task<int> UpdateMiddleHotTokenRow()
+    {
+        await using var result = await _bench.Db.ExecuteAsync(
+            FormattableString.Invariant($"UPDATE {FullTextHotTokenBenchmarkData.TableName} SET body = 'cool unique_{PostingCount}' WHERE id = {PostingCount / 2}"));
+        return result.RowsAffected;
+    }
+}
+
 internal static class FullTextBenchmarkData
 {
     public const string TableName = "bench_fts";
@@ -105,5 +211,42 @@ internal static class FullTextBenchmarkData
             string body = $"{cadence} signal {category} {segment} {rare} payload{id:D5}";
             return $"INSERT INTO {tableName} VALUES ({id}, '{title}', '{body}')";
         });
+    }
+}
+
+internal static class FullTextHotTokenBenchmarkData
+{
+    public const string TableName = "bench_hot_fts";
+    public const string IndexName = "fts_bench_hot_fts";
+    public const string BodyColumn = "body";
+    public const string HotQuery = "line";
+    public const string CreateTableSql =
+        "CREATE TABLE bench_hot_fts (id INTEGER PRIMARY KEY, body TEXT)";
+
+    public static Task<BenchmarkDatabase> CreateEmptyAsync()
+        => BenchmarkDatabase.CreateWithSchemaAsync(CreateTableSql);
+
+    public static async Task<BenchmarkDatabase> CreatePopulatedAsync(int rowCount)
+    {
+        BenchmarkDatabase bench = await CreateEmptyAsync();
+        await bench.Db.EnsureFullTextIndexAsync(IndexName, TableName, [BodyColumn]);
+        await SeedHotTokenRowsAsync(bench, rowCount);
+        return bench;
+    }
+
+    public static Task SeedHotTokenRowsAsync(BenchmarkDatabase bench, int rowCount)
+    {
+        return bench.SeedAsync(TableName, rowCount, id =>
+            $"INSERT INTO {TableName} VALUES ({id}, 'line hot token payload_{id:D8}')");
+    }
+
+    public static long GetDatabaseBytes(BenchmarkDatabase bench)
+    {
+        long total = 0;
+        if (File.Exists(bench.FilePath))
+            total += new FileInfo(bench.FilePath).Length;
+        if (File.Exists(bench.FilePath + ".wal"))
+            total += new FileInfo(bench.FilePath + ".wal").Length;
+        return total;
     }
 }

--- a/tests/CSharpDB.Benchmarks/Program.cs
+++ b/tests/CSharpDB.Benchmarks/Program.cs
@@ -2,8 +2,11 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using CSharpDB.Benchmarks.Infrastructure;
 using CSharpDB.Benchmarks.Macro;
+using CSharpDB.Benchmarks.Micro;
 using CSharpDB.Benchmarks.Stress;
 using CSharpDB.Benchmarks.Scaling;
+using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 
@@ -61,6 +64,11 @@ public static class Program
 
             case "--filter":
                 RunMicroBenchmarks(StripCustomArgs(args));
+                return;
+
+            case "--fts-hot-token-smoke":
+                EnsureReproConfigured();
+                await RunFullTextHotTokenSmokeAsync(args);
                 return;
 
             case "--macro-batch-memory":
@@ -575,6 +583,73 @@ public static class Program
     {
         RunMicroBenchmarksWithoutPrGuardrails(["--filter", "*"]);
     }
+
+    private static async Task RunFullTextHotTokenSmokeAsync(string[] args)
+    {
+        int postingCount = HasFlag(args, "--postings")
+            ? ParsePositiveInt(GetRequiredOptionValue(args, "--postings"), "--postings")
+            : 20_000;
+
+        await using var bench = await FullTextHotTokenBenchmarkData.CreateEmptyAsync();
+
+        var build = Stopwatch.StartNew();
+        await bench.Db.EnsureFullTextIndexAsync(
+            FullTextHotTokenBenchmarkData.IndexName,
+            FullTextHotTokenBenchmarkData.TableName,
+            [FullTextHotTokenBenchmarkData.BodyColumn]);
+        await FullTextHotTokenBenchmarkData.SeedHotTokenRowsAsync(bench, postingCount);
+        build.Stop();
+
+        long bytesAfterBuild = FullTextHotTokenBenchmarkData.GetDatabaseBytes(bench);
+
+        var query = Stopwatch.StartNew();
+        var hits = await bench.Db.SearchAsync(
+            FullTextHotTokenBenchmarkData.IndexName,
+            FullTextHotTokenBenchmarkData.HotQuery);
+        query.Stop();
+        if (hits.Count != postingCount)
+            throw new InvalidOperationException($"Expected {postingCount} hot-token hits, got {hits.Count}.");
+
+        int updateId = Math.Max(1, postingCount / 2);
+        var update = Stopwatch.StartNew();
+        await bench.Db.ExecuteAsync(
+            FormattableString.Invariant($"UPDATE {FullTextHotTokenBenchmarkData.TableName} SET body = 'cool unique_{postingCount}' WHERE id = {updateId}"));
+        update.Stop();
+
+        var uniqueHits = await bench.Db.SearchAsync(
+            FullTextHotTokenBenchmarkData.IndexName,
+            FormattableString.Invariant($"unique_{postingCount}"));
+        if (uniqueHits.Count != 1 || uniqueHits[0].RowId != updateId)
+            throw new InvalidOperationException("Updated full-text token was not searchable.");
+
+        int deleteId = postingCount <= 1
+            ? updateId
+            : updateId == 1 ? 2 : updateId - 1;
+        var delete = Stopwatch.StartNew();
+        await bench.Db.ExecuteAsync(
+            FormattableString.Invariant($"DELETE FROM {FullTextHotTokenBenchmarkData.TableName} WHERE id = {deleteId}"));
+        delete.Stop();
+
+        var deletedHits = await bench.Db.SearchAsync(
+            FullTextHotTokenBenchmarkData.IndexName,
+            FormattableString.Invariant($"payload_{deleteId:D8}"));
+        if (deletedHits.Count != 0)
+            throw new InvalidOperationException("Deleted full-text token remained searchable.");
+
+        long finalBytes = FullTextHotTokenBenchmarkData.GetDatabaseBytes(bench);
+
+        Console.WriteLine("FullTextHotTokenSmoke");
+        Console.WriteLine($"posting_count={postingCount.ToString(CultureInfo.InvariantCulture)}");
+        Console.WriteLine($"build_insert_index_ms={FormatMilliseconds(build.Elapsed)}");
+        Console.WriteLine($"query_hot_token_ms={FormatMilliseconds(query.Elapsed)}");
+        Console.WriteLine($"update_single_row_ms={FormatMilliseconds(update.Elapsed)}");
+        Console.WriteLine($"delete_single_row_ms={FormatMilliseconds(delete.Elapsed)}");
+        Console.WriteLine($"db_bytes_after_build={bytesAfterBuild.ToString(CultureInfo.InvariantCulture)}");
+        Console.WriteLine($"db_bytes_final={finalBytes.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    private static string FormatMilliseconds(TimeSpan elapsed) =>
+        elapsed.TotalMilliseconds.ToString("F1", CultureInfo.InvariantCulture);
 
     private static void RunMicroBenchmarksWithoutPrGuardrails(string[] args)
     {
@@ -1178,6 +1253,14 @@ public static class Program
         throw new ArgumentException($"Missing required option {option}.");
     }
 
+    private static int ParsePositiveInt(string value, string option)
+    {
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int parsed) || parsed <= 0)
+            throw new ArgumentException($"Invalid {option} value. Use a positive integer.");
+
+        return parsed;
+    }
+
     private static bool ContainsExplicitFilter(string[] args)
     {
         return args.Any(static arg => arg.Equals("--filter", StringComparison.OrdinalIgnoreCase));
@@ -1228,6 +1311,7 @@ public static class Program
         Console.WriteLine("Usage:");
         Console.WriteLine("  dotnet run -- --micro              Run BenchmarkDotNet micro-benchmarks");
         Console.WriteLine("  dotnet run -- --micro --filter *Insert*   Filter micro-benchmarks");
+        Console.WriteLine("  dotnet run -- --fts-hot-token-smoke --postings 20000  Time one hot-token FTS build/query/update/delete smoke run");
         Console.WriteLine("  dotnet run -- --macro              Run macro-benchmarks (sustained workloads)");
         Console.WriteLine("  dotnet run -- --macro-batch-memory Run in-memory rotating batch throughput benchmark");
         Console.WriteLine("  dotnet run -- --write-diagnostics  Run focused pager/WAL durable-write diagnostics");

--- a/tests/CSharpDB.Benchmarks/scripts/Run-FileSearchNuGetBeforeAfter.ps1
+++ b/tests/CSharpDB.Benchmarks/scripts/Run-FileSearchNuGetBeforeAfter.ps1
@@ -1,0 +1,772 @@
+<#
+.SYNOPSIS
+Runs FileSearch benchmarks against baseline and patched CSharpDB NuGet packages.
+
+.DESCRIPTION
+The script builds two local CSharpDB package feeds, creates temporary FileSearch
+worktrees, rewrites CSharpDB PackageReference versions inside those worktrees,
+and runs FileSearch's existing benchmark report command for each package set.
+
+It does not modify the real FileSearch repository. Generated feeds, worktrees,
+logs, raw metrics, and the summary report are written under -OutputDir.
+
+.EXAMPLE
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FileSearchNuGetBeforeAfter.ps1 -Profile smoke
+
+.EXAMPLE
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FileSearchNuGetBeforeAfter.ps1 -Profile standard -TimeoutSeconds 7200
+#>
+[CmdletBinding()]
+param(
+    [string]$CSharpDbRepoRoot = "",
+    [string]$FileSearchRepoRoot = "",
+    [string]$BaselineRef = "HEAD",
+    [ValidateSet("smoke", "standard", "full")]
+    [string]$Profile = "smoke",
+    [string]$OutputDir = "",
+    [string]$Configuration = "Release",
+    [string]$DotNet = "dotnet",
+    [int]$TimeoutSeconds = 3600,
+    [bool]$ForceCorpus = $true,
+    [bool]$ForceIndex = $true,
+    [switch]$SkipBaseline,
+    [switch]$KeepWorktrees
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-DefaultCSharpDbRepoRoot
+{
+    return (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+}
+
+function Resolve-DefaultFileSearchRepoRoot
+{
+    $candidate = Join-Path (Split-Path -Parent (Resolve-DefaultCSharpDbRepoRoot)) "FileSearcher"
+    if (Test-Path $candidate)
+    {
+        return (Resolve-Path $candidate).Path
+    }
+
+    return ""
+}
+
+function ConvertTo-ProcessArgument
+{
+    param([Parameter(Mandatory = $false)][AllowEmptyString()][string]$Argument)
+
+    if ($null -eq $Argument)
+    {
+        return '""'
+    }
+
+    if ($Argument.Length -gt 0 -and $Argument -notmatch '[\s"]')
+    {
+        return $Argument
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    [void]$builder.Append('"')
+    $backslashes = 0
+    foreach ($ch in $Argument.ToCharArray())
+    {
+        if ($ch -eq '\')
+        {
+            $backslashes++
+            continue
+        }
+
+        if ($ch -eq '"')
+        {
+            [void]$builder.Append('\', $backslashes * 2 + 1)
+            [void]$builder.Append('"')
+            $backslashes = 0
+            continue
+        }
+
+        if ($backslashes -gt 0)
+        {
+            [void]$builder.Append('\', $backslashes)
+            $backslashes = 0
+        }
+
+        [void]$builder.Append($ch)
+    }
+
+    if ($backslashes -gt 0)
+    {
+        [void]$builder.Append('\', $backslashes * 2)
+    }
+
+    [void]$builder.Append('"')
+    return $builder.ToString()
+}
+
+function Join-ProcessArguments
+{
+    param([Parameter(Mandatory = $true)][string[]]$ArgumentList)
+
+    return (($ArgumentList | ForEach-Object { ConvertTo-ProcessArgument $_ }) -join " ")
+}
+
+function Invoke-External
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $FilePath
+    $startInfo.Arguments = Join-ProcessArguments -ArgumentList $ArgumentList
+    $startInfo.WorkingDirectory = $WorkingDirectory
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.CreateNoWindow = $true
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start())
+    {
+        throw "Failed to start process '$FilePath'."
+    }
+
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    $completed = $process.WaitForExit([Math]::Max(1, $TimeoutSeconds) * 1000)
+    if (-not $completed)
+    {
+        try
+        {
+            $process.Kill()
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            [void]$process.WaitForExit(30000)
+        }
+        catch
+        {
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $null
+            TimedOut = $true
+            StandardOutput = $stdoutTask.GetAwaiter().GetResult()
+            StandardError = $stderrTask.GetAwaiter().GetResult()
+        }
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $process.ExitCode
+        TimedOut = $false
+        StandardOutput = $stdoutTask.GetAwaiter().GetResult()
+        StandardError = $stderrTask.GetAwaiter().GetResult()
+    }
+}
+
+function Invoke-Checked
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [int]$TimeoutSeconds = 1800
+    )
+
+    $result = Invoke-External -FilePath $FilePath -ArgumentList $ArgumentList -WorkingDirectory $WorkingDirectory -TimeoutSeconds $TimeoutSeconds
+    if ($result.TimedOut)
+    {
+        throw "Command timed out: $FilePath $($ArgumentList -join ' ')"
+    }
+
+    if ($result.ExitCode -ne 0)
+    {
+        throw "Command failed ($($result.ExitCode)): $FilePath $($ArgumentList -join ' ')`n$result.StandardOutput`n$result.StandardError"
+    }
+
+    return $result
+}
+
+function Get-GitText
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $result = Invoke-Checked -FilePath "git" -ArgumentList (@("-C", $Repository) + $Arguments) -WorkingDirectory $Repository -TimeoutSeconds 120
+    return $result.StandardOutput.Trim()
+}
+
+function Get-GitDirty
+{
+    param([Parameter(Mandatory = $true)][string]$Repository)
+
+    $status = Get-GitText -Repository $Repository -Arguments @("status", "--porcelain")
+    return -not [string]::IsNullOrWhiteSpace($status)
+}
+
+function New-DetachedWorktree
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Destination,
+        [Parameter(Mandatory = $true)][string]$Ref
+    )
+
+    if (Test-Path $Destination)
+    {
+        Remove-Item -LiteralPath $Destination -Recurse -Force
+    }
+
+    Invoke-Checked `
+        -FilePath "git" `
+        -ArgumentList @("-C", $Repository, "worktree", "add", "--detach", $Destination, $Ref) `
+        -WorkingDirectory $Repository `
+        -TimeoutSeconds 300 | Out-Null
+}
+
+function Remove-DetachedWorktree
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    if (-not (Test-Path $Destination))
+    {
+        return
+    }
+
+    try
+    {
+        Invoke-Checked `
+            -FilePath "git" `
+            -ArgumentList @("-C", $Repository, "worktree", "remove", "--force", $Destination) `
+            -WorkingDirectory $Repository `
+            -TimeoutSeconds 300 | Out-Null
+    }
+    catch
+    {
+        Write-Warning "Could not remove worktree '$Destination': $_"
+    }
+}
+
+function Get-CSharpDbPackageProjects
+{
+    param([Parameter(Mandatory = $true)][string]$Repository)
+
+    $relative = @(
+        "src\CSharpDB.Primitives\CSharpDB.Primitives.csproj",
+        "src\CSharpDB.Storage\CSharpDB.Storage.csproj",
+        "src\CSharpDB.Storage.Diagnostics\CSharpDB.Storage.Diagnostics.csproj",
+        "src\CSharpDB.Sql\CSharpDB.Sql.csproj",
+        "src\CSharpDB.ImportExport\CSharpDB.ImportExport.csproj",
+        "src\CSharpDB.Execution\CSharpDB.Execution.csproj",
+        "src\CSharpDB.Engine\CSharpDB.Engine.csproj"
+    )
+
+    return [string[]]($relative | ForEach-Object { Join-Path $Repository $_ })
+}
+
+function New-CSharpDbFeed
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$FeedDirectory,
+        [Parameter(Mandatory = $true)][string]$PackageVersion
+    )
+
+    New-Item -ItemType Directory -Force -Path $FeedDirectory | Out-Null
+    foreach ($project in Get-CSharpDbPackageProjects -Repository $Repository)
+    {
+        if (-not (Test-Path $project))
+        {
+            throw "Package project was not found: $project"
+        }
+
+        Write-Host "Packing $Label package $project as $PackageVersion"
+        Invoke-Checked `
+            -FilePath $DotNet `
+            -ArgumentList @(
+                "pack",
+                $project,
+                "-c",
+                $Configuration,
+                "-o",
+                $FeedDirectory,
+                "--nologo",
+                "-p:PackageVersion=$PackageVersion",
+                "-p:Version=$PackageVersion"
+            ) `
+            -WorkingDirectory $Repository `
+            -TimeoutSeconds 1800 | Out-Null
+    }
+}
+
+function Write-NuGetConfig
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$FeedDirectory
+    )
+
+    $escapedFeed = [System.Security.SecurityElement]::Escape($FeedDirectory)
+    $config = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local-csharpdb" value="$escapedFeed" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"@
+    Set-Content -Path (Join-Path $Repository "NuGet.config") -Value $config -Encoding UTF8
+}
+
+function Update-CSharpDbPackageReferences
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$PackageVersion
+    )
+
+    $projects = Get-ChildItem -Path $Repository -Filter *.csproj -Recurse
+    foreach ($project in $projects)
+    {
+        [xml]$xml = Get-Content -Raw -Path $project.FullName
+        $changed = $false
+        foreach ($reference in @($xml.SelectNodes("//*[local-name()='PackageReference']")))
+        {
+            $include = [string]$reference.GetAttribute("Include")
+            $update = [string]$reference.GetAttribute("Update")
+            if (-not ($include.StartsWith("CSharpDB", [StringComparison]::OrdinalIgnoreCase) -or
+                      $update.StartsWith("CSharpDB", [StringComparison]::OrdinalIgnoreCase)))
+            {
+                continue
+            }
+
+            if ($reference.HasAttribute("Version"))
+            {
+                $reference.SetAttribute("Version", $PackageVersion)
+            }
+            else
+            {
+                $versionNode = $reference.SelectSingleNode("*[local-name()='Version']")
+                if ($null -eq $versionNode)
+                {
+                    $versionNode = $xml.CreateElement("Version", $reference.NamespaceURI)
+                    [void]$reference.AppendChild($versionNode)
+                }
+
+                $versionNode.InnerText = $PackageVersion
+            }
+
+            $changed = $true
+        }
+
+        if ($changed)
+        {
+            $xml.Save($project.FullName)
+        }
+    }
+}
+
+function Get-MetricValue
+{
+    param(
+        [Parameter(Mandatory = $false)][AllowNull()]$Report,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $Report)
+    {
+        return $null
+    }
+
+    $metric = @($Report.Metrics | Where-Object { $_.Name -eq $Name } | Select-Object -First 1)
+    if ($metric.Count -eq 0)
+    {
+        return $null
+    }
+
+    return [double]$metric[0].Value
+}
+
+function New-RunSummaryRow
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$CSharpDbHead,
+        [Parameter(Mandatory = $true)][bool]$CSharpDbDirty,
+        [Parameter(Mandatory = $true)][string]$FileSearchHead,
+        [Parameter(Mandatory = $true)][string]$PackageVersion,
+        [Parameter(Mandatory = $true)][string]$Status,
+        [Parameter(Mandatory = $true)][double]$WallClockSeconds,
+        [Parameter(Mandatory = $false)][AllowNull()]$Report = $null,
+        [string]$ErrorText = ""
+    )
+
+    return [pscustomobject]@{
+        label = $Label
+        profile = $Profile
+        csharpdb_head = $CSharpDbHead
+        csharpdb_dirty = $CSharpDbDirty
+        filesearch_head = $FileSearchHead
+        package_version = $PackageVersion
+        status = $Status
+        wall_clock_seconds = $WallClockSeconds
+        initial_index_throughput = Get-MetricValue -Report $Report -Name "initial_index_throughput"
+        incremental_catch_up_throughput = Get-MetricValue -Report $Report -Name "incremental_catch_up_throughput"
+        index_freshness_after_event = Get-MetricValue -Report $Report -Name "index_freshness_after_event"
+        indexed_content_query_p50 = Get-MetricValue -Report $Report -Name "indexed_content_query_p50"
+        indexed_content_query_p95 = Get-MetricValue -Report $Report -Name "indexed_content_query_p95"
+        indexed_query_phase_fts_lookup_avg = Get-MetricValue -Report $Report -Name "indexed_query_phase_fts_lookup_avg"
+        metadata_query_p95 = Get-MetricValue -Report $Report -Name "metadata_query_p95"
+        time_to_first_result = Get-MetricValue -Report $Report -Name "time_to_first_result"
+        index_disk_size = Get-MetricValue -Report $Report -Name "index_disk_size"
+        benchmark_process_working_set = Get-MetricValue -Report $Report -Name "benchmark_process_working_set"
+        extraction_success_rate = Get-MetricValue -Report $Report -Name "extraction_success_rate"
+        error = $ErrorText
+    }
+}
+
+function Export-MetricRows
+{
+    param(
+        [Parameter(Mandatory = $true)][object[]]$SummaryRows,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $metricNames = @(
+        "initial_index_throughput",
+        "incremental_catch_up_throughput",
+        "index_freshness_after_event",
+        "indexed_content_query_p50",
+        "indexed_content_query_p95",
+        "indexed_query_phase_fts_lookup_avg",
+        "metadata_query_p95",
+        "time_to_first_result",
+        "index_disk_size",
+        "benchmark_process_working_set",
+        "extraction_success_rate"
+    )
+
+    $rows = foreach ($name in $metricNames)
+    {
+        $baseline = $SummaryRows | Where-Object { $_.label -eq "baseline" } | Select-Object -First 1
+        $after = $SummaryRows | Where-Object { $_.label -eq "after" } | Select-Object -First 1
+        $baselineValue = if ($baseline) { $baseline.$name } else { $null }
+        $afterValue = if ($after) { $after.$name } else { $null }
+        [pscustomobject]@{
+            metric = $name
+            baseline = $baselineValue
+            after = $afterValue
+            after_div_baseline = if ($baselineValue -and $afterValue) { [double]$afterValue / [double]$baselineValue } else { $null }
+            baseline_div_after = if ($baselineValue -and $afterValue) { [double]$baselineValue / [double]$afterValue } else { $null }
+        }
+    }
+
+    $rows | Export-Csv -NoTypeInformation -Path $Path
+}
+
+function Write-MarkdownReport
+{
+    param(
+        [Parameter(Mandatory = $true)][object[]]$SummaryRows,
+        [Parameter(Mandatory = $true)][string]$MetricCsv,
+        [Parameter(Mandatory = $true)][string]$SummaryCsv,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $metrics = Import-Csv $MetricCsv
+    $builder = New-Object System.Collections.Generic.List[string]
+    $builder.Add("# FileSearch CSharpDB NuGet Before/After")
+    $builder.Add("")
+    $builder.Add("Profile: ``$Profile``")
+    $builder.Add("")
+    $builder.Add("| Label | Status | CSharpDB package | Wall seconds |")
+    $builder.Add("| --- | --- | --- | ---: |")
+    foreach ($row in $SummaryRows)
+    {
+        $builder.Add(("{0} | {1} | {2} | {3:N1} |" -f ("| " + $row.label), $row.status, $row.package_version, [double]$row.wall_clock_seconds))
+    }
+
+    $builder.Add("")
+    $builder.Add("| Metric | Baseline | After | After/Baseline | Baseline/After |")
+    $builder.Add("| --- | ---: | ---: | ---: | ---: |")
+    foreach ($metric in $metrics)
+    {
+        $builder.Add(("| `{0}` | {1} | {2} | {3} | {4} |" -f
+            $metric.metric,
+            (Format-NullableNumber $metric.baseline),
+            (Format-NullableNumber $metric.after),
+            (Format-NullableNumber $metric.after_div_baseline),
+            (Format-NullableNumber $metric.baseline_div_after)))
+    }
+
+    $builder.Add("")
+    $builder.Add("Summary CSV: ``$SummaryCsv``")
+    $builder.Add("Metric comparison CSV: ``$MetricCsv``")
+    Set-Content -Path $Path -Value $builder -Encoding UTF8
+}
+
+function Format-NullableNumber
+{
+    param([Parameter(Mandatory = $false)][AllowNull()][string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value))
+    {
+        return ""
+    }
+
+    $number = [double]::Parse($Value, [System.Globalization.CultureInfo]::InvariantCulture)
+    if ([Math]::Abs($number) -ge 1000)
+    {
+        return $number.ToString("N2", [System.Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    return $number.ToString("0.###", [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Invoke-FileSearchBenchmark
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$PackageVersion,
+        [Parameter(Mandatory = $true)][string]$CSharpDbHead,
+        [Parameter(Mandatory = $true)][bool]$CSharpDbDirty,
+        [Parameter(Mandatory = $true)][string]$FileSearchHead,
+        [Parameter(Mandatory = $true)][string]$RunRoot
+    )
+
+    $benchmarkProject = Join-Path $Repository "benchmarks\FileSearch.Benchmarks\FileSearch.Benchmarks.csproj"
+    $logDir = Join-Path $RunRoot "logs"
+    New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+    Invoke-Checked `
+        -FilePath $DotNet `
+        -ArgumentList @("restore", $benchmarkProject, "--force-evaluate", "--no-cache") `
+        -WorkingDirectory $Repository `
+        -TimeoutSeconds 1800 | Out-Null
+
+    Invoke-Checked `
+        -FilePath $DotNet `
+        -ArgumentList @("build", $benchmarkProject, "-c", $Configuration, "--no-restore", "--nologo") `
+        -WorkingDirectory $Repository `
+        -TimeoutSeconds 1800 | Out-Null
+
+    $benchmarkRoot = Join-Path $RunRoot "benchmark-root"
+    $arguments = @(
+        "run",
+        "-c",
+        $Configuration,
+        "--no-build",
+        "--project",
+        $benchmarkProject,
+        "--",
+        "report",
+        "--profile",
+        $Profile,
+        "--root",
+        $benchmarkRoot
+    )
+    if ($ForceCorpus)
+    {
+        $arguments += "--force-corpus"
+    }
+    if ($ForceIndex)
+    {
+        $arguments += "--force-index"
+    }
+
+    Write-Host "Running FileSearch $Label benchmark profile=$Profile"
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $result = Invoke-External -FilePath $DotNet -ArgumentList $arguments -WorkingDirectory $Repository -TimeoutSeconds $TimeoutSeconds
+    $stopwatch.Stop()
+
+    Set-Content -Path (Join-Path $logDir "stdout.log") -Value $result.StandardOutput -Encoding UTF8
+    Set-Content -Path (Join-Path $logDir "stderr.log") -Value $result.StandardError -Encoding UTF8
+
+    if ($result.TimedOut)
+    {
+        return New-RunSummaryRow `
+            -Label $Label `
+            -CSharpDbHead $CSharpDbHead `
+            -CSharpDbDirty $CSharpDbDirty `
+            -FileSearchHead $FileSearchHead `
+            -PackageVersion $PackageVersion `
+            -Status "timeout" `
+            -WallClockSeconds $stopwatch.Elapsed.TotalSeconds `
+            -ErrorText "Timed out after $TimeoutSeconds seconds."
+    }
+
+    if ($result.ExitCode -ne 0)
+    {
+        return New-RunSummaryRow `
+            -Label $Label `
+            -CSharpDbHead $CSharpDbHead `
+            -CSharpDbDirty $CSharpDbDirty `
+            -FileSearchHead $FileSearchHead `
+            -PackageVersion $PackageVersion `
+            -Status "failed" `
+            -WallClockSeconds $stopwatch.Elapsed.TotalSeconds `
+            -ErrorText (($result.StandardError + "`n" + $result.StandardOutput).Trim())
+    }
+
+    $reportPath = Join-Path $benchmarkRoot "$Profile\reports\benchmark-report.json"
+    if (-not (Test-Path $reportPath))
+    {
+        return New-RunSummaryRow `
+            -Label $Label `
+            -CSharpDbHead $CSharpDbHead `
+            -CSharpDbDirty $CSharpDbDirty `
+            -FileSearchHead $FileSearchHead `
+            -PackageVersion $PackageVersion `
+            -Status "failed" `
+            -WallClockSeconds $stopwatch.Elapsed.TotalSeconds `
+            -ErrorText "Benchmark report was not written: $reportPath"
+    }
+
+    Copy-Item -LiteralPath $reportPath -Destination (Join-Path $RunRoot "benchmark-report.json") -Force
+    $markdownReport = Join-Path $benchmarkRoot "$Profile\reports\benchmark-report.md"
+    if (Test-Path $markdownReport)
+    {
+        Copy-Item -LiteralPath $markdownReport -Destination (Join-Path $RunRoot "benchmark-report.md") -Force
+    }
+
+    $report = Get-Content -Raw -Path $reportPath | ConvertFrom-Json
+    return New-RunSummaryRow `
+        -Label $Label `
+        -CSharpDbHead $CSharpDbHead `
+        -CSharpDbDirty $CSharpDbDirty `
+        -FileSearchHead $FileSearchHead `
+        -PackageVersion $PackageVersion `
+        -Status "completed" `
+        -WallClockSeconds $stopwatch.Elapsed.TotalSeconds `
+        -Report $report
+}
+
+if ([string]::IsNullOrWhiteSpace($CSharpDbRepoRoot))
+{
+    $CSharpDbRepoRoot = Resolve-DefaultCSharpDbRepoRoot
+}
+$CSharpDbRepoRoot = (Resolve-Path $CSharpDbRepoRoot).Path
+
+if ([string]::IsNullOrWhiteSpace($FileSearchRepoRoot))
+{
+    $FileSearchRepoRoot = Resolve-DefaultFileSearchRepoRoot
+}
+if ([string]::IsNullOrWhiteSpace($FileSearchRepoRoot) -or -not (Test-Path $FileSearchRepoRoot))
+{
+    throw "FileSearch repo was not found. Pass -FileSearchRepoRoot."
+}
+$FileSearchRepoRoot = (Resolve-Path $FileSearchRepoRoot).Path
+
+if (Get-GitDirty -Repository $FileSearchRepoRoot)
+{
+    throw "FileSearch repo has uncommitted changes. Commit/stash them or run from a clean checkout so package-version patching stays isolated."
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDir))
+{
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $OutputDir = Join-Path $CSharpDbRepoRoot "artifacts\filesearch-nuget-before-after\$stamp"
+}
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+Write-Host "Output: $OutputDir"
+
+$stampVersion = (Get-Date -Format "yyyyMMddHHmmss")
+$baselineVersion = "4.0.2-ftsbaseline.$stampVersion"
+$afterVersion = "4.0.2-ftsafter.$stampVersion"
+
+$baselineCSharpDbWorktree = Join-Path $OutputDir "csharpdb-baseline-worktree"
+$baselineFileSearchWorktree = Join-Path $OutputDir "filesearch-baseline-worktree"
+$afterFileSearchWorktree = Join-Path $OutputDir "filesearch-after-worktree"
+$summaryRows = New-Object System.Collections.Generic.List[object]
+$summaryCsv = Join-Path $OutputDir "filesearch-nuget-before-after-summary.csv"
+$metricCsv = Join-Path $OutputDir "filesearch-nuget-before-after-metrics.csv"
+$markdownPath = Join-Path $OutputDir "filesearch-nuget-before-after.md"
+
+try
+{
+    $fileSearchHead = Get-GitText -Repository $FileSearchRepoRoot -Arguments @("rev-parse", "HEAD")
+
+    if (-not $SkipBaseline)
+    {
+        New-DetachedWorktree -Repository $CSharpDbRepoRoot -Destination $baselineCSharpDbWorktree -Ref $BaselineRef
+        $baselineCSharpDbHead = Get-GitText -Repository $baselineCSharpDbWorktree -Arguments @("rev-parse", "HEAD")
+        $baselineFeed = Join-Path $OutputDir "nuget-baseline"
+        New-CSharpDbFeed -Label "baseline" -Repository $baselineCSharpDbWorktree -FeedDirectory $baselineFeed -PackageVersion $baselineVersion
+
+        New-DetachedWorktree -Repository $FileSearchRepoRoot -Destination $baselineFileSearchWorktree -Ref "HEAD"
+        Write-NuGetConfig -Repository $baselineFileSearchWorktree -FeedDirectory $baselineFeed
+        Update-CSharpDbPackageReferences -Repository $baselineFileSearchWorktree -PackageVersion $baselineVersion
+
+        $baselineRow = Invoke-FileSearchBenchmark `
+            -Label "baseline" `
+            -Repository $baselineFileSearchWorktree `
+            -PackageVersion $baselineVersion `
+            -CSharpDbHead $baselineCSharpDbHead `
+            -CSharpDbDirty $false `
+            -FileSearchHead $fileSearchHead `
+            -RunRoot (Join-Path $OutputDir "runs\baseline")
+        $summaryRows.Add($baselineRow) | Out-Null
+        $summaryRows | Export-Csv -NoTypeInformation -Path $summaryCsv
+        Export-MetricRows -SummaryRows $summaryRows.ToArray() -Path $metricCsv
+    }
+
+    $afterCSharpDbHead = Get-GitText -Repository $CSharpDbRepoRoot -Arguments @("rev-parse", "HEAD")
+    $afterCSharpDbDirty = Get-GitDirty -Repository $CSharpDbRepoRoot
+    $afterFeed = Join-Path $OutputDir "nuget-after"
+    New-CSharpDbFeed -Label "after" -Repository $CSharpDbRepoRoot -FeedDirectory $afterFeed -PackageVersion $afterVersion
+
+    New-DetachedWorktree -Repository $FileSearchRepoRoot -Destination $afterFileSearchWorktree -Ref "HEAD"
+    Write-NuGetConfig -Repository $afterFileSearchWorktree -FeedDirectory $afterFeed
+    Update-CSharpDbPackageReferences -Repository $afterFileSearchWorktree -PackageVersion $afterVersion
+
+    $afterRow = Invoke-FileSearchBenchmark `
+        -Label "after" `
+        -Repository $afterFileSearchWorktree `
+        -PackageVersion $afterVersion `
+        -CSharpDbHead $afterCSharpDbHead `
+        -CSharpDbDirty $afterCSharpDbDirty `
+        -FileSearchHead $fileSearchHead `
+        -RunRoot (Join-Path $OutputDir "runs\after")
+    $summaryRows.Add($afterRow) | Out-Null
+    $summaryRows | Export-Csv -NoTypeInformation -Path $summaryCsv
+    Export-MetricRows -SummaryRows $summaryRows.ToArray() -Path $metricCsv
+    Write-MarkdownReport -SummaryRows $summaryRows.ToArray() -MetricCsv $metricCsv -SummaryCsv $summaryCsv -Path $markdownPath
+}
+finally
+{
+    if (-not $KeepWorktrees)
+    {
+        Remove-DetachedWorktree -Repository $CSharpDbRepoRoot -Destination $baselineCSharpDbWorktree
+        Remove-DetachedWorktree -Repository $FileSearchRepoRoot -Destination $baselineFileSearchWorktree
+        Remove-DetachedWorktree -Repository $FileSearchRepoRoot -Destination $afterFileSearchWorktree
+    }
+}
+
+$summaryRows | Export-Csv -NoTypeInformation -Path $summaryCsv
+if ($summaryRows.Count -gt 0)
+{
+    Export-MetricRows -SummaryRows $summaryRows.ToArray() -Path $metricCsv
+    Write-MarkdownReport -SummaryRows $summaryRows.ToArray() -MetricCsv $metricCsv -SummaryCsv $summaryCsv -Path $markdownPath
+}
+
+Write-Host "Summary: $summaryCsv"
+Write-Host "Metrics: $metricCsv"
+Write-Host "Report: $markdownPath"

--- a/tests/CSharpDB.Benchmarks/scripts/Run-FullTextHotTokenBeforeAfter.ps1
+++ b/tests/CSharpDB.Benchmarks/scripts/Run-FullTextHotTokenBeforeAfter.ps1
@@ -1,0 +1,738 @@
+<#
+.SYNOPSIS
+Runs a focused full-text hot-token before/after benchmark against two checkouts.
+
+.DESCRIPTION
+The script creates a clean baseline worktree from -BaselineRef and generates a
+small external runner for each checkout. The same runner code is compiled
+against each checkout's CSharpDB.Engine project, so the baseline does not need
+to contain the latest benchmark entry points.
+
+Rows are checkpointed to CSV after each run. Baseline runs that exceed
+-TimeoutSeconds are recorded as timeout rows, which is expected for large
+pre-chunked hot-token corpora.
+
+.EXAMPLE
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FullTextHotTokenBeforeAfter.ps1 -PostingCounts 20000 -BaselinePostingCounts 20000
+
+.EXAMPLE
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FullTextHotTokenBeforeAfter.ps1 -PostingCounts 100000,500000 -BaselinePostingCounts 100000,500000 -TimeoutSeconds 180
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = "",
+    [string]$BaselineRef = "HEAD",
+    [string]$AfterRepoRoot = "",
+    [string[]]$PostingCounts = @("20000", "100000", "500000"),
+    [string[]]$BaselinePostingCounts = @(),
+    [int]$Iterations = 1,
+    [int]$BatchSize = 500,
+    [int]$TimeoutSeconds = 1800,
+    [string]$Configuration = "Release",
+    [string]$OutputDir = "",
+    [string]$DotNet = "dotnet",
+    [switch]$SkipBaseline,
+    [switch]$KeepBaselineWorktree
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-DefaultRepoRoot
+{
+    return (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+}
+
+function ConvertTo-PostingCountArray
+{
+    param([Parameter(Mandatory = $false)][string[]]$Values = @())
+
+    $counts = New-Object System.Collections.Generic.List[int]
+    foreach ($value in @($Values))
+    {
+        if ([string]::IsNullOrWhiteSpace($value))
+        {
+            continue
+        }
+
+        foreach ($part in ($value -split ","))
+        {
+            if ([string]::IsNullOrWhiteSpace($part))
+            {
+                continue
+            }
+
+            $count = [int]::Parse($part.Trim(), [System.Globalization.CultureInfo]::InvariantCulture)
+            if ($count -lt 1)
+            {
+                throw "Posting counts must be positive. Saw '$count'."
+            }
+
+            $counts.Add($count) | Out-Null
+        }
+    }
+
+    if ($counts.Count -eq 0)
+    {
+        throw "At least one posting count is required."
+    }
+
+    return ,([int[]]$counts.ToArray())
+}
+
+function Invoke-External
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $FilePath
+    $startInfo.Arguments = Join-ProcessArguments -ArgumentList $ArgumentList
+    $startInfo.WorkingDirectory = $WorkingDirectory
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.CreateNoWindow = $true
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+
+    $started = $process.Start()
+    if (-not $started)
+    {
+        throw "Failed to start process '$FilePath'."
+    }
+
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    $limitMs = [Math]::Max(1, $TimeoutSeconds) * 1000
+    $completed = $process.WaitForExit($limitMs)
+
+    if (-not $completed)
+    {
+        try
+        {
+            $process.Kill()
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            [void]$process.WaitForExit(30000)
+        }
+        catch
+        {
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $null
+            TimedOut = $true
+            StandardOutput = $stdoutTask.GetAwaiter().GetResult()
+            StandardError = $stderrTask.GetAwaiter().GetResult()
+        }
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $process.ExitCode
+        TimedOut = $false
+        StandardOutput = $stdoutTask.GetAwaiter().GetResult()
+        StandardError = $stderrTask.GetAwaiter().GetResult()
+    }
+}
+
+function Join-ProcessArguments
+{
+    param([Parameter(Mandatory = $true)][string[]]$ArgumentList)
+
+    return (($ArgumentList | ForEach-Object { ConvertTo-ProcessArgument $_ }) -join " ")
+}
+
+function ConvertTo-ProcessArgument
+{
+    param([Parameter(Mandatory = $false)][AllowEmptyString()][string]$Argument)
+
+    if ($null -eq $Argument)
+    {
+        return '""'
+    }
+
+    if ($Argument.Length -gt 0 -and $Argument -notmatch '[\s"]')
+    {
+        return $Argument
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    [void]$builder.Append('"')
+    $backslashes = 0
+    foreach ($ch in $Argument.ToCharArray())
+    {
+        if ($ch -eq '\')
+        {
+            $backslashes++
+            continue
+        }
+
+        if ($ch -eq '"')
+        {
+            [void]$builder.Append('\', $backslashes * 2 + 1)
+            [void]$builder.Append('"')
+            $backslashes = 0
+            continue
+        }
+
+        if ($backslashes -gt 0)
+        {
+            [void]$builder.Append('\', $backslashes)
+            $backslashes = 0
+        }
+
+        [void]$builder.Append($ch)
+    }
+
+    if ($backslashes -gt 0)
+    {
+        [void]$builder.Append('\', $backslashes * 2)
+    }
+
+    [void]$builder.Append('"')
+    return $builder.ToString()
+}
+
+function Invoke-Checked
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [int]$TimeoutSeconds = 1800
+    )
+
+    $result = Invoke-External -FilePath $FilePath -ArgumentList $ArgumentList -WorkingDirectory $WorkingDirectory -TimeoutSeconds $TimeoutSeconds
+    if ($result.TimedOut)
+    {
+        throw "Command timed out: $FilePath $($ArgumentList -join ' ')"
+    }
+
+    if ($result.ExitCode -ne 0)
+    {
+        throw "Command failed ($($result.ExitCode)): $FilePath $($ArgumentList -join ' ')`n$result.StandardOutput`n$result.StandardError"
+    }
+
+    return $result
+}
+
+function Get-GitText
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $result = Invoke-Checked -FilePath "git" -ArgumentList (@("-C", $Repository) + $Arguments) -WorkingDirectory $Repository -TimeoutSeconds 120
+    return $result.StandardOutput.Trim()
+}
+
+function Get-GitDirty
+{
+    param([Parameter(Mandatory = $true)][string]$Repository)
+
+    $status = Get-GitText -Repository $Repository -Arguments @("status", "--porcelain")
+    return -not [string]::IsNullOrWhiteSpace($status)
+}
+
+function New-RunnerProject
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$RunnerDir,
+        [Parameter(Mandatory = $true)][string]$TargetRepo
+    )
+
+    New-Item -ItemType Directory -Force -Path $RunnerDir | Out-Null
+
+    $engineProject = Join-Path $TargetRepo "src\CSharpDB.Engine\CSharpDB.Engine.csproj"
+    if (-not (Test-Path $engineProject))
+    {
+        throw "CSharpDB.Engine project was not found under '$TargetRepo'."
+    }
+
+    $escapedProject = [System.Security.SecurityElement]::Escape($engineProject)
+    $projectXml = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$escapedProject" />
+  </ItemGroup>
+</Project>
+"@
+
+    Set-Content -Path (Join-Path $RunnerDir "FtsHotTokenRunner.csproj") -Value $projectXml -Encoding UTF8
+
+    $program = @'
+using System.Diagnostics;
+using System.Text.Json;
+using CSharpDB.Engine;
+
+const string TableName = "bench_hot_fts";
+const string IndexName = "fts_bench_hot_fts";
+const string BodyColumn = "body";
+const string HotQuery = "line";
+
+if (args.Length != 6)
+{
+    Console.Error.WriteLine("Usage: <label> <targetRepo> <postingCount> <batchSize> <workDir> <resultJson>");
+    return 2;
+}
+
+string label = args[0];
+string targetRepo = args[1];
+int postingCount = int.Parse(args[2]);
+int batchSize = int.Parse(args[3]);
+string workDir = args[4];
+string resultJson = args[5];
+
+Directory.CreateDirectory(workDir);
+string dbPath = Path.Combine(workDir, $"{label}_{postingCount}.db");
+DeleteIfExists(dbPath);
+DeleteIfExists(dbPath + ".wal");
+
+var process = Process.GetCurrentProcess();
+var result = new Dictionary<string, object?>
+{
+    ["label"] = label,
+    ["target_repo"] = targetRepo,
+    ["posting_count"] = postingCount,
+    ["batch_size"] = batchSize,
+    ["database_path"] = dbPath,
+    ["started_utc"] = DateTimeOffset.UtcNow.ToString("O"),
+};
+
+try
+{
+    await using var db = await Database.OpenAsync(dbPath);
+    await db.ExecuteAsync($"CREATE TABLE {TableName} (id INTEGER PRIMARY KEY, body TEXT)");
+    await db.EnsureFullTextIndexAsync(IndexName, TableName, new[] { BodyColumn });
+
+    var build = Stopwatch.StartNew();
+    for (int offset = 0; offset < postingCount; offset += batchSize)
+    {
+        await db.BeginTransactionAsync();
+        try
+        {
+            int end = Math.Min(postingCount, offset + batchSize);
+            for (int id = offset; id < end; id++)
+            {
+                await db.ExecuteAsync($"INSERT INTO {TableName} VALUES ({id}, 'line hot token payload_{id:D8}')");
+            }
+
+            await db.CommitAsync();
+        }
+        catch
+        {
+            await db.RollbackAsync();
+            throw;
+        }
+    }
+    build.Stop();
+
+    long bytesAfterBuild = GetDatabaseBytes(dbPath);
+
+    ForceFullCollection();
+    var query = Stopwatch.StartNew();
+    var hotHits = await db.SearchAsync(IndexName, HotQuery);
+    query.Stop();
+    if (hotHits.Count != postingCount)
+        throw new InvalidOperationException($"Expected {postingCount} hot-token hits, found {hotHits.Count}.");
+
+    int updateId = postingCount / 2;
+    ForceFullCollection();
+    var update = Stopwatch.StartNew();
+    var updateResult = await db.ExecuteAsync($"UPDATE {TableName} SET body = 'cool unique_{postingCount}' WHERE id = {updateId}");
+    update.Stop();
+    if (updateResult.RowsAffected != 1)
+        throw new InvalidOperationException($"Expected update to affect 1 row, affected {updateResult.RowsAffected}.");
+
+    var updatedHits = await db.SearchAsync(IndexName, $"unique_{postingCount}");
+    if (updatedHits.Count != 1 || updatedHits[0].RowId != updateId)
+        throw new InvalidOperationException("Updated token was not reflected in the full-text index.");
+
+    int deleteId = updateId + 1 < postingCount ? updateId + 1 : updateId - 1;
+    ForceFullCollection();
+    var delete = Stopwatch.StartNew();
+    var deleteResult = await db.ExecuteAsync($"DELETE FROM {TableName} WHERE id = {deleteId}");
+    delete.Stop();
+    if (deleteResult.RowsAffected != 1)
+        throw new InvalidOperationException($"Expected delete to affect 1 row, affected {deleteResult.RowsAffected}.");
+
+    var deletedHits = await db.SearchAsync(IndexName, $"payload_{deleteId:D8}");
+    if (deletedHits.Count != 0)
+        throw new InvalidOperationException("Deleted token was still visible in the full-text index.");
+
+    result["status"] = "completed";
+    result["build_insert_index_ms"] = build.Elapsed.TotalMilliseconds;
+    result["query_hot_token_ms"] = query.Elapsed.TotalMilliseconds;
+    result["update_single_row_ms"] = update.Elapsed.TotalMilliseconds;
+    result["delete_single_row_ms"] = delete.Elapsed.TotalMilliseconds;
+    result["db_bytes_after_build"] = bytesAfterBuild;
+    result["db_bytes_final"] = GetDatabaseBytes(dbPath);
+    result["peak_working_set_bytes"] = process.PeakWorkingSet64;
+    result["finished_utc"] = DateTimeOffset.UtcNow.ToString("O");
+}
+catch (Exception ex)
+{
+    result["status"] = "failed";
+    result["error"] = ex.ToString();
+    result["finished_utc"] = DateTimeOffset.UtcNow.ToString("O");
+    await WriteResultAsync(resultJson, result);
+    Console.Error.WriteLine(ex);
+    return 1;
+}
+
+await WriteResultAsync(resultJson, result);
+return 0;
+
+static async Task WriteResultAsync(string path, Dictionary<string, object?> result)
+{
+    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+    var options = new JsonSerializerOptions { WriteIndented = true };
+    await File.WriteAllTextAsync(path, JsonSerializer.Serialize(result, options));
+}
+
+static long GetDatabaseBytes(string dbPath)
+{
+    long total = 0;
+    if (File.Exists(dbPath))
+        total += new FileInfo(dbPath).Length;
+    if (File.Exists(dbPath + ".wal"))
+        total += new FileInfo(dbPath + ".wal").Length;
+    return total;
+}
+
+static void DeleteIfExists(string path)
+{
+    if (File.Exists(path))
+        File.Delete(path);
+}
+
+static void ForceFullCollection()
+{
+    GC.Collect();
+    GC.WaitForPendingFinalizers();
+    GC.Collect();
+}
+'@
+
+    Set-Content -Path (Join-Path $RunnerDir "Program.cs") -Value $program -Encoding UTF8
+}
+
+function Build-Runner
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$TargetRepo,
+        [Parameter(Mandatory = $true)][string]$OutputDir
+    )
+
+    $runnerDir = Join-Path $OutputDir "runner-$Label"
+    New-RunnerProject -RunnerDir $runnerDir -TargetRepo $TargetRepo
+    $project = Join-Path $runnerDir "FtsHotTokenRunner.csproj"
+    Invoke-Checked -FilePath $DotNet -ArgumentList @("build", $project, "-c", $Configuration, "--nologo") -WorkingDirectory $runnerDir -TimeoutSeconds 1800 | Out-Null
+    return Join-Path $runnerDir "bin\$Configuration\net10.0\FtsHotTokenRunner.dll"
+}
+
+function Convert-JsonResultToRow
+{
+    param(
+        [Parameter(Mandatory = $true)]$Json,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$GitHead,
+        [Parameter(Mandatory = $true)][bool]$GitDirty,
+        [Parameter(Mandatory = $true)][int]$Iteration,
+        [Parameter(Mandatory = $true)][double]$WallClockSeconds,
+        [string]$ErrorText = ""
+    )
+
+    return [pscustomobject]@{
+        label = $Label
+        git_head = $GitHead
+        git_dirty = $GitDirty
+        posting_count = [int]$Json.posting_count
+        iteration = $Iteration
+        status = [string]$Json.status
+        build_insert_index_ms = [double]$Json.build_insert_index_ms
+        query_hot_token_ms = [double]$Json.query_hot_token_ms
+        update_single_row_ms = [double]$Json.update_single_row_ms
+        delete_single_row_ms = [double]$Json.delete_single_row_ms
+        db_bytes_after_build = [long]$Json.db_bytes_after_build
+        db_bytes_final = [long]$Json.db_bytes_final
+        peak_working_set_bytes = [long]$Json.peak_working_set_bytes
+        wall_clock_seconds = $WallClockSeconds
+        error = $ErrorText
+    }
+}
+
+function New-FailedRow
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$GitHead,
+        [Parameter(Mandatory = $true)][bool]$GitDirty,
+        [Parameter(Mandatory = $true)][int]$PostingCount,
+        [Parameter(Mandatory = $true)][int]$Iteration,
+        [Parameter(Mandatory = $true)][string]$Status,
+        [Parameter(Mandatory = $true)][double]$WallClockSeconds,
+        [string]$ErrorText = ""
+    )
+
+    return [pscustomobject]@{
+        label = $Label
+        git_head = $GitHead
+        git_dirty = $GitDirty
+        posting_count = $PostingCount
+        iteration = $Iteration
+        status = $Status
+        build_insert_index_ms = $null
+        query_hot_token_ms = $null
+        update_single_row_ms = $null
+        delete_single_row_ms = $null
+        db_bytes_after_build = $null
+        db_bytes_final = $null
+        peak_working_set_bytes = $null
+        wall_clock_seconds = $WallClockSeconds
+        error = $ErrorText
+    }
+}
+
+function Invoke-HotTokenRun
+{
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$TargetRepo,
+        [Parameter(Mandatory = $true)][string]$RunnerDll,
+        [Parameter(Mandatory = $true)][string]$GitHead,
+        [Parameter(Mandatory = $true)][bool]$GitDirty,
+        [Parameter(Mandatory = $true)][int]$PostingCount,
+        [Parameter(Mandatory = $true)][int]$Iteration,
+        [Parameter(Mandatory = $true)][string]$OutputDir
+    )
+
+    $runDir = Join-Path $OutputDir ("runs\{0}\{1}\iter-{2}" -f $Label, $PostingCount, $Iteration)
+    New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+    $jsonPath = Join-Path $runDir "result.json"
+
+    Write-Host ("Running {0} postings={1} iteration={2} timeout={3}s" -f $Label, $PostingCount, $Iteration, $TimeoutSeconds)
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $result = Invoke-External `
+        -FilePath $DotNet `
+        -ArgumentList @($RunnerDll, $Label, $TargetRepo, [string]$PostingCount, [string]$BatchSize, $runDir, $jsonPath) `
+        -WorkingDirectory $runDir `
+        -TimeoutSeconds $TimeoutSeconds
+    $stopwatch.Stop()
+
+    Set-Content -Path (Join-Path $runDir "stdout.log") -Value $result.StandardOutput -Encoding UTF8
+    Set-Content -Path (Join-Path $runDir "stderr.log") -Value $result.StandardError -Encoding UTF8
+
+    if ($result.TimedOut)
+    {
+        return New-FailedRow -Label $Label -GitHead $GitHead -GitDirty $GitDirty -PostingCount $PostingCount -Iteration $Iteration -Status "timeout" -WallClockSeconds $stopwatch.Elapsed.TotalSeconds -ErrorText "Timed out after $TimeoutSeconds seconds."
+    }
+
+    if ($result.ExitCode -ne 0)
+    {
+        $errorText = ($result.StandardError + "`n" + $result.StandardOutput).Trim()
+        return New-FailedRow -Label $Label -GitHead $GitHead -GitDirty $GitDirty -PostingCount $PostingCount -Iteration $Iteration -Status "failed" -WallClockSeconds $stopwatch.Elapsed.TotalSeconds -ErrorText $errorText
+    }
+
+    if (-not (Test-Path $jsonPath))
+    {
+        return New-FailedRow -Label $Label -GitHead $GitHead -GitDirty $GitDirty -PostingCount $PostingCount -Iteration $Iteration -Status "failed" -WallClockSeconds $stopwatch.Elapsed.TotalSeconds -ErrorText "Runner did not write result JSON."
+    }
+
+    $json = Get-Content -Raw -Path $jsonPath | ConvertFrom-Json
+    return Convert-JsonResultToRow -Json $json -Label $Label -GitHead $GitHead -GitDirty $GitDirty -Iteration $Iteration -WallClockSeconds $stopwatch.Elapsed.TotalSeconds
+}
+
+function Get-Median
+{
+    param([Parameter(Mandatory = $false)][AllowEmptyCollection()][object[]]$Values = @())
+
+    $numbers = @($Values | Where-Object { $null -ne $_ -and $_ -ne "" } | ForEach-Object { [double]$_ } | Sort-Object)
+    if ($numbers.Count -eq 0)
+    {
+        return $null
+    }
+
+    $middle = [int][Math]::Floor($numbers.Count / 2)
+    if (($numbers.Count % 2) -eq 1)
+    {
+        return $numbers[$middle]
+    }
+
+    return ($numbers[$middle - 1] + $numbers[$middle]) / 2.0
+}
+
+function Write-Summary
+{
+    param(
+        [Parameter(Mandatory = $true)][object[]]$Rows,
+        [Parameter(Mandatory = $true)][string]$SummaryPath
+    )
+
+    $summary = New-Object System.Collections.Generic.List[object]
+    $counts = @($Rows | Select-Object -ExpandProperty posting_count -Unique | Sort-Object)
+    foreach ($count in $counts)
+    {
+        $baselineRows = @($Rows | Where-Object { $_.label -eq "baseline" -and $_.posting_count -eq $count -and $_.status -eq "completed" })
+        $afterRows = @($Rows | Where-Object { $_.label -eq "after" -and $_.posting_count -eq $count -and $_.status -eq "completed" })
+        $baselineStatuses = (($Rows | Where-Object { $_.label -eq "baseline" -and $_.posting_count -eq $count } | Select-Object -ExpandProperty status -Unique) -join ";")
+        $afterStatuses = (($Rows | Where-Object { $_.label -eq "after" -and $_.posting_count -eq $count } | Select-Object -ExpandProperty status -Unique) -join ";")
+
+        $baselineBuild = Get-Median @($baselineRows | Select-Object -ExpandProperty build_insert_index_ms)
+        $afterBuild = Get-Median @($afterRows | Select-Object -ExpandProperty build_insert_index_ms)
+        $baselineQuery = Get-Median @($baselineRows | Select-Object -ExpandProperty query_hot_token_ms)
+        $afterQuery = Get-Median @($afterRows | Select-Object -ExpandProperty query_hot_token_ms)
+        $baselineUpdate = Get-Median @($baselineRows | Select-Object -ExpandProperty update_single_row_ms)
+        $afterUpdate = Get-Median @($afterRows | Select-Object -ExpandProperty update_single_row_ms)
+        $baselineDelete = Get-Median @($baselineRows | Select-Object -ExpandProperty delete_single_row_ms)
+        $afterDelete = Get-Median @($afterRows | Select-Object -ExpandProperty delete_single_row_ms)
+
+        $summary.Add([pscustomobject]@{
+            posting_count = $count
+            baseline_status = $baselineStatuses
+            after_status = $afterStatuses
+            baseline_build_insert_index_ms = $baselineBuild
+            after_build_insert_index_ms = $afterBuild
+            build_speedup = if ($baselineBuild -and $afterBuild) { $baselineBuild / $afterBuild } else { $null }
+            baseline_query_hot_token_ms = $baselineQuery
+            after_query_hot_token_ms = $afterQuery
+            query_speedup = if ($baselineQuery -and $afterQuery) { $baselineQuery / $afterQuery } else { $null }
+            baseline_update_single_row_ms = $baselineUpdate
+            after_update_single_row_ms = $afterUpdate
+            update_speedup = if ($baselineUpdate -and $afterUpdate) { $baselineUpdate / $afterUpdate } else { $null }
+            baseline_delete_single_row_ms = $baselineDelete
+            after_delete_single_row_ms = $afterDelete
+            delete_speedup = if ($baselineDelete -and $afterDelete) { $baselineDelete / $afterDelete } else { $null }
+        }) | Out-Null
+    }
+
+    $summary | Export-Csv -NoTypeInformation -Path $SummaryPath
+}
+
+if ([string]::IsNullOrWhiteSpace($RepoRoot))
+{
+    $RepoRoot = Resolve-DefaultRepoRoot
+}
+$RepoRoot = (Resolve-Path $RepoRoot).Path
+
+if ([string]::IsNullOrWhiteSpace($AfterRepoRoot))
+{
+    $AfterRepoRoot = $RepoRoot
+}
+$AfterRepoRoot = (Resolve-Path $AfterRepoRoot).Path
+
+$resolvedPostingCounts = ConvertTo-PostingCountArray -Values $PostingCounts
+$resolvedBaselinePostingCounts = if ($BaselinePostingCounts.Count -eq 0)
+{
+    $resolvedPostingCounts
+}
+else
+{
+    ConvertTo-PostingCountArray -Values $BaselinePostingCounts
+}
+$PostingCounts = $resolvedPostingCounts
+$BaselinePostingCounts = $resolvedBaselinePostingCounts
+
+if ($Iterations -lt 1)
+{
+    throw "Iterations must be at least 1."
+}
+if ($BatchSize -lt 1)
+{
+    throw "BatchSize must be at least 1."
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDir))
+{
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $OutputDir = Join-Path $RepoRoot "artifacts\fts-hot-token-before-after\$stamp"
+}
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$rawCsv = Join-Path $OutputDir "fulltext-hot-token-before-after-raw.csv"
+$summaryCsv = Join-Path $OutputDir "fulltext-hot-token-before-after-summary.csv"
+
+Write-Host "Output: $OutputDir"
+
+$rows = New-Object System.Collections.Generic.List[object]
+$baselineRoot = $null
+
+try
+{
+    if (-not $SkipBaseline)
+    {
+        $baselineRoot = Join-Path $OutputDir "baseline-worktree"
+        Invoke-Checked -FilePath "git" -ArgumentList @("-C", $RepoRoot, "worktree", "add", "--detach", $baselineRoot, $BaselineRef) -WorkingDirectory $RepoRoot -TimeoutSeconds 300 | Out-Null
+
+        $baselineHead = Get-GitText -Repository $baselineRoot -Arguments @("rev-parse", "HEAD")
+        $baselineDirty = Get-GitDirty -Repository $baselineRoot
+        $baselineRunner = Build-Runner -Label "baseline" -TargetRepo $baselineRoot -OutputDir $OutputDir
+
+        foreach ($count in $BaselinePostingCounts)
+        {
+            for ($iteration = 1; $iteration -le $Iterations; $iteration++)
+            {
+                $row = Invoke-HotTokenRun -Label "baseline" -TargetRepo $baselineRoot -RunnerDll $baselineRunner -GitHead $baselineHead -GitDirty $baselineDirty -PostingCount $count -Iteration $iteration -OutputDir $OutputDir
+                $rows.Add($row) | Out-Null
+                $rows | Export-Csv -NoTypeInformation -Path $rawCsv
+                Write-Summary -Rows $rows.ToArray() -SummaryPath $summaryCsv
+            }
+        }
+    }
+
+    $afterHead = Get-GitText -Repository $AfterRepoRoot -Arguments @("rev-parse", "HEAD")
+    $afterDirty = Get-GitDirty -Repository $AfterRepoRoot
+    $afterRunner = Build-Runner -Label "after" -TargetRepo $AfterRepoRoot -OutputDir $OutputDir
+
+    foreach ($count in $PostingCounts)
+    {
+        for ($iteration = 1; $iteration -le $Iterations; $iteration++)
+        {
+            $row = Invoke-HotTokenRun -Label "after" -TargetRepo $AfterRepoRoot -RunnerDll $afterRunner -GitHead $afterHead -GitDirty $afterDirty -PostingCount $count -Iteration $iteration -OutputDir $OutputDir
+            $rows.Add($row) | Out-Null
+            $rows | Export-Csv -NoTypeInformation -Path $rawCsv
+            Write-Summary -Rows $rows.ToArray() -SummaryPath $summaryCsv
+        }
+    }
+}
+finally
+{
+    if ($baselineRoot -and -not $KeepBaselineWorktree)
+    {
+        try
+        {
+            Invoke-Checked -FilePath "git" -ArgumentList @("-C", $RepoRoot, "worktree", "remove", "--force", $baselineRoot) -WorkingDirectory $RepoRoot -TimeoutSeconds 300 | Out-Null
+        }
+        catch
+        {
+            Write-Warning "Could not remove baseline worktree '$baselineRoot': $_"
+        }
+    }
+}
+
+$rows | Export-Csv -NoTypeInformation -Path $rawCsv
+Write-Summary -Rows $rows.ToArray() -SummaryPath $summaryCsv
+
+Write-Host "Raw results: $rawCsv"
+Write-Host "Summary: $summaryCsv"

--- a/tests/CSharpDB.Tests/FullTextIndexTests.cs
+++ b/tests/CSharpDB.Tests/FullTextIndexTests.cs
@@ -1,6 +1,8 @@
 using CSharpDB.Engine;
 using CSharpDB.Primitives;
+using CSharpDB.Storage.Catalog;
 using CSharpDB.Storage.Indexing;
+using System.Reflection;
 
 namespace CSharpDB.Tests;
 
@@ -74,10 +76,10 @@ public sealed class FullTextIndexTests : IAsyncLifetime
             .OrderBy(static index => index.IndexName, StringComparer.Ordinal)
             .ToArray();
 
-        Assert.Equal(5, indexes.Length);
+        Assert.Equal(6, indexes.Length);
         Assert.Contains(indexes, static index => index.IndexName == "fts_docs" && index.Kind == IndexKind.FullText);
         Assert.Equal(
-            4,
+            5,
             indexes.Count(static index => index.Kind == IndexKind.FullTextInternal && index.OwnerIndexName == "fts_docs"));
 
         await _db.ExecuteAsync("DROP INDEX fts_docs", Ct);
@@ -115,7 +117,7 @@ public sealed class FullTextIndexTests : IAsyncLifetime
         await _db.EnsureFullTextIndexAsync("fts_docs", "docs", ["body"], ct: Ct);
         await _db.EnsureFullTextIndexAsync("fts_docs", "docs", ["body"], ct: Ct);
 
-        Assert.Equal(5, _db.GetIndexes().Count(static index => index.IndexName.StartsWith("fts_docs", StringComparison.Ordinal)));
+        Assert.Equal(6, _db.GetIndexes().Count(static index => index.IndexName.StartsWith("fts_docs", StringComparison.Ordinal)));
 
         var differentColumns = await Assert.ThrowsAsync<CSharpDbException>(() =>
             _db.EnsureFullTextIndexAsync("fts_docs", "docs", ["title"], ct: Ct).AsTask());
@@ -155,12 +157,9 @@ public sealed class FullTextIndexTests : IAsyncLifetime
     [Fact]
     public async Task FullTextIndex_HotTermPostingsGrowPastOneLeafCell()
     {
-        // Regression: a term shared by thousands of rows grows its postings
-        // blob past one 4 KB leaf cell. FullTextInternal stores must spill to
-        // overflow pages; without that the insert dies inside the B-tree with
-        // "Unable to split leaf page N: no byte-balanced redistribution fits
-        // within page capacity" (a single cell larger than a page can never
-        // be split). Positions storage makes the blob grow fastest.
+        // Regression: a term shared by thousands of rows must span multiple
+        // bounded posting chunks instead of rewriting one growing postings
+        // blob on every insert. Positions storage makes postings grow fastest.
         await _db.ExecuteAsync("CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)", Ct);
         await _db.EnsureFullTextIndexAsync(
             "fts_docs",
@@ -197,8 +196,176 @@ public sealed class FullTextIndexTests : IAsyncLifetime
         AssertHitRowIds(await _db.SearchAsync("fts_docs", "needle_2999", Ct), 2999);
     }
 
+    [Fact]
+    public async Task FullTextIndex_ChunkedPostingsHandleOutOfOrderRowIds()
+    {
+        await _db.ExecuteAsync("CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)", Ct);
+        await _db.EnsureFullTextIndexAsync("fts_docs", "docs", ["body"], ct: Ct);
+
+        const int DocumentCount = 1100;
+        for (int i = 0; i < DocumentCount; i++)
+        {
+            int id = 1000 + i;
+            await _db.ExecuteAsync(
+                FormattableString.Invariant($"INSERT INTO docs VALUES ({id}, 'line high_{id}')"),
+                Ct);
+        }
+
+        await _db.ExecuteAsync("INSERT INTO docs VALUES (1, 'line low')", Ct);
+
+        IReadOnlyList<FullTextSearchHit> hits = await _db.SearchAsync("fts_docs", "line", Ct);
+        Assert.Equal(DocumentCount + 1, hits.Count);
+        Assert.Equal(1, hits[0].RowId);
+        Assert.Equal(1000, hits[1].RowId);
+
+        await _db.ExecuteAsync("DELETE FROM docs WHERE id = 1", Ct);
+        hits = await _db.SearchAsync("fts_docs", "line", Ct);
+        Assert.Equal(DocumentCount, hits.Count);
+        Assert.Equal(1000, hits[0].RowId);
+    }
+
+    [Fact]
+    public async Task FullTextIndex_ChunkedMutationRollbackRestoresPostings()
+    {
+        await _db.ExecuteAsync("CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)", Ct);
+        await _db.EnsureFullTextIndexAsync("fts_docs", "docs", ["body"], ct: Ct);
+
+        const int DocumentCount = 1100;
+        for (int i = 1; i <= DocumentCount; i++)
+        {
+            await _db.ExecuteAsync(
+                FormattableString.Invariant($"INSERT INTO docs VALUES ({i}, 'line token_{i}')"),
+                Ct);
+        }
+
+        Assert.Equal(DocumentCount, (await _db.SearchAsync("fts_docs", "line", Ct)).Count);
+
+        await _db.BeginTransactionAsync(Ct);
+        try
+        {
+            await _db.ExecuteAsync("DELETE FROM docs WHERE id = 10", Ct);
+            await _db.ExecuteAsync("UPDATE docs SET body = 'changed unique_20' WHERE id = 20", Ct);
+            await _db.ExecuteAsync("INSERT INTO docs VALUES (2000, 'line inserted')", Ct);
+
+            Assert.Equal(DocumentCount - 1, (await _db.SearchAsync("fts_docs", "line", Ct)).Count);
+            Assert.Empty(await _db.SearchAsync("fts_docs", "token_20", Ct));
+            AssertHitRowIds(await _db.SearchAsync("fts_docs", "unique_20", Ct), 20);
+
+            await _db.RollbackAsync(Ct);
+        }
+        catch
+        {
+            await _db.RollbackAsync(CancellationToken.None);
+            throw;
+        }
+
+        Assert.Equal(DocumentCount, (await _db.SearchAsync("fts_docs", "line", Ct)).Count);
+        AssertHitRowIds(await _db.SearchAsync("fts_docs", "token_10", Ct), 10);
+        AssertHitRowIds(await _db.SearchAsync("fts_docs", "token_20", Ct), 20);
+        Assert.Empty(await _db.SearchAsync("fts_docs", "unique_20", Ct));
+        Assert.Empty(await _db.SearchAsync("fts_docs", "inserted", Ct));
+    }
+
+    [Fact]
+    public async Task FullTextIndex_ExistingLegacyOwnedStoresAreUpgradedOnOpenAndMigratedOnWrite()
+    {
+        await _db.ExecuteAsync("CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)", Ct);
+        await CreateLegacyFullTextIndexAsync(_db, "fts_docs", "docs", ["body"]);
+
+        Assert.Equal(
+            5,
+            _db.GetIndexes().Count(static index => index.IndexName.StartsWith("fts_docs", StringComparison.Ordinal)));
+        Assert.DoesNotContain(
+            _db.GetIndexes(),
+            static index => index.IndexName == FullTextIndexNaming.GetPostingChunksIndexName("fts_docs"));
+
+        await _db.ExecuteAsync("INSERT INTO docs VALUES (1, 'line legacy_one')", Ct);
+        await _db.ExecuteAsync("INSERT INTO docs VALUES (2, 'line legacy_two')", Ct);
+
+        AssertHitRowIds(await _db.SearchAsync("fts_docs", "line", Ct), 1, 2);
+        AssertLegacyPostingsPayload("fts_docs", "line");
+
+        await _db.DisposeAsync();
+        _db = await Database.OpenAsync(_dbPath, Ct);
+
+        Assert.Contains(
+            _db.GetIndexes(),
+            static index => index.IndexName == FullTextIndexNaming.GetPostingChunksIndexName("fts_docs"));
+        AssertHitRowIds(await _db.SearchAsync("fts_docs", "line", Ct), 1, 2);
+        AssertLegacyPostingsPayload("fts_docs", "line");
+
+        await _db.ExecuteAsync("INSERT INTO docs VALUES (3, 'line legacy_three')", Ct);
+
+        AssertHitRowIds(await _db.SearchAsync("fts_docs", "line", Ct), 1, 2, 3);
+        AssertChunkedPostingsPayload("fts_docs", "line");
+    }
+
     private static void AssertHitRowIds(IReadOnlyList<FullTextSearchHit> hits, params long[] expectedRowIds)
     {
         Assert.Equal(expectedRowIds, hits.Select(static hit => hit.RowId).ToArray());
+    }
+
+    private static async ValueTask CreateLegacyFullTextIndexAsync(
+        Database db,
+        string indexName,
+        string tableName,
+        IReadOnlyList<string> columns)
+    {
+        SchemaCatalog catalog = GetCatalog(db);
+        var logicalIndex = FullTextIndexCatalog.CreateLogicalSchema(
+            indexName,
+            tableName,
+            columns,
+            new FullTextIndexOptions());
+
+        await db.BeginTransactionAsync(Ct);
+        try
+        {
+            await catalog.CreateIndexAsync(logicalIndex, Ct);
+            foreach (IndexSchema internalIndex in FullTextIndexCatalog.CreateInternalSchemas(logicalIndex))
+            {
+                if (internalIndex.IndexName == FullTextIndexNaming.GetPostingChunksIndexName(indexName))
+                    continue;
+
+                await catalog.CreateIndexAsync(internalIndex, Ct);
+            }
+
+            await db.CommitAsync(Ct);
+        }
+        catch
+        {
+            await db.RollbackAsync(CancellationToken.None);
+            throw;
+        }
+    }
+
+    private void AssertLegacyPostingsPayload(string indexName, string term)
+    {
+        byte[] payload = ReadPostingsPayload(indexName, term);
+        Assert.True(FullTextPostingsPayloadCodec.IsEncoded(payload));
+        Assert.False(FullTextPostingChunkManifestCodec.IsEncoded(payload));
+    }
+
+    private void AssertChunkedPostingsPayload(string indexName, string term)
+    {
+        byte[] payload = ReadPostingsPayload(indexName, term);
+        Assert.True(FullTextPostingChunkManifestCodec.IsEncoded(payload));
+        Assert.False(FullTextPostingsPayloadCodec.IsEncoded(payload));
+    }
+
+    private byte[] ReadPostingsPayload(string indexName, string term)
+    {
+        SchemaCatalog catalog = GetCatalog(_db);
+        var store = catalog.GetIndexStore(FullTextIndexNaming.GetPostingsIndexName(indexName));
+        byte[]? payload = store.FindAsync(FullTextTermKeyCodec.ComputeKey(term), Ct).AsTask().GetAwaiter().GetResult();
+        Assert.NotNull(payload);
+        return payload;
+    }
+
+    private static SchemaCatalog GetCatalog(Database db)
+    {
+        var field = typeof(Database).GetField("_catalog", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsType<SchemaCatalog>(field.GetValue(db));
     }
 }

--- a/tests/CSharpDB.Tests/MutationPlannerTests.cs
+++ b/tests/CSharpDB.Tests/MutationPlannerTests.cs
@@ -1,0 +1,132 @@
+using CSharpDB.Engine;
+using CSharpDB.Execution;
+using CSharpDB.Sql;
+using System.Reflection;
+
+namespace CSharpDB.Tests;
+
+public sealed class MutationPlannerTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task Delete_IndexedEqualityPredicate_CollectsTargetsFromIndex()
+    {
+        await using var db = await Database.OpenInMemoryAsync(Ct);
+        await SetupMutationItemsAsync(db);
+        AssertCanBuildIndexedMutationSource(
+            db,
+            "DELETE FROM mutation_items WHERE code = 42",
+            expectedOperatorType: typeof(IndexScanOperator));
+
+        db.ResetMutationTargetCollectionDiagnostics();
+
+        var deleteResult = await db.ExecuteAsync(
+            "DELETE FROM mutation_items WHERE code = 42",
+            Ct);
+
+        Assert.Equal(1, deleteResult.RowsAffected);
+        var diagnostics = db.GetMutationTargetCollectionDiagnosticsSnapshot();
+        Assert.Equal(1, diagnostics.IndexedCollectionCount);
+        Assert.Equal(0, diagnostics.ScannedCollectionCount);
+
+        await using var deletedRows = await db.ExecuteAsync(
+            "SELECT id FROM mutation_items WHERE code = 42",
+            Ct);
+        Assert.Empty(await deletedRows.ToListAsync(Ct));
+
+        await using var neighborRows = await db.ExecuteAsync(
+            "SELECT id FROM mutation_items WHERE code = 41",
+            Ct);
+        var rows = await neighborRows.ToListAsync(Ct);
+        Assert.Equal(41L, Assert.Single(rows)[0].AsInteger);
+    }
+
+    [Fact]
+    public async Task Update_IndexedRangePredicate_CollectsTargetsFromIndexAndMaintainsIndex()
+    {
+        await using var db = await Database.OpenInMemoryAsync(Ct);
+        await SetupMutationItemsAsync(db);
+        AssertCanBuildIndexedMutationSource(
+            db,
+            "UPDATE mutation_items SET code = code + 1000 WHERE code BETWEEN 40 AND 42",
+            expectedOperatorType: typeof(IndexOrderedScanOperator));
+
+        db.ResetMutationTargetCollectionDiagnostics();
+
+        var updateResult = await db.ExecuteAsync(
+            "UPDATE mutation_items SET code = code + 1000 WHERE code BETWEEN 40 AND 42",
+            Ct);
+
+        Assert.Equal(3, updateResult.RowsAffected);
+        var diagnostics = db.GetMutationTargetCollectionDiagnosticsSnapshot();
+        Assert.Equal(1, diagnostics.IndexedCollectionCount);
+        Assert.Equal(0, diagnostics.ScannedCollectionCount);
+
+        await using var oldRangeRows = await db.ExecuteAsync(
+            "SELECT id FROM mutation_items WHERE code BETWEEN 40 AND 42 ORDER BY id",
+            Ct);
+        Assert.Empty(await oldRangeRows.ToListAsync(Ct));
+
+        await using var newRangeRows = await db.ExecuteAsync(
+            "SELECT id, code FROM mutation_items WHERE code BETWEEN 1040 AND 1042 ORDER BY id",
+            Ct);
+        var rows = await newRangeRows.ToListAsync(Ct);
+
+        Assert.Equal([40L, 41L, 42L], rows.Select(static row => row[0].AsInteger).ToArray());
+        Assert.Equal([1040L, 1041L, 1042L], rows.Select(static row => row[1].AsInteger).ToArray());
+    }
+
+    private static async ValueTask SetupMutationItemsAsync(Database db)
+    {
+        await db.ExecuteAsync(
+            "CREATE TABLE mutation_items (id INTEGER PRIMARY KEY, code INTEGER NOT NULL, payload TEXT)",
+            Ct);
+        await db.ExecuteAsync(
+            "CREATE INDEX idx_mutation_items_code ON mutation_items(code)",
+            Ct);
+
+        await db.BeginTransactionAsync(Ct);
+        for (int i = 1; i <= 100; i++)
+        {
+            await db.ExecuteAsync(
+                $"INSERT INTO mutation_items VALUES ({i}, {i}, 'payload-{i}')",
+                Ct);
+        }
+        await db.CommitAsync(Ct);
+    }
+
+    private static void AssertCanBuildIndexedMutationSource(Database db, string sql, Type expectedOperatorType)
+    {
+        var plannerField = typeof(Database).GetField("_planner", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(plannerField);
+        object? planner = plannerField.GetValue(db);
+        Assert.NotNull(planner);
+
+        Expression? where = Parser.Parse(sql) switch
+        {
+            DeleteStatement delete => delete.Where,
+            UpdateStatement update => update.Where,
+            _ => throw new InvalidOperationException("Expected a mutation statement."),
+        };
+        Assert.NotNull(where);
+
+        var schema = db.GetTableSchema("mutation_items");
+        Assert.NotNull(schema);
+
+        foreach (string methodName in new[] { "TryBuildIndexScan", "TryBuildIntegerIndexRangeScan", "TryBuildOrderedTextIndexRangeScan" })
+        {
+            var method = planner.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            object?[] args = ["mutation_items", where, schema, null];
+            object? op = method.Invoke(planner, args);
+            if (op != null)
+            {
+                Assert.IsType(expectedOperatorType, op);
+                return;
+            }
+        }
+
+        Assert.Fail($"No indexed mutation source was built for '{sql}'.");
+    }
+}


### PR DESCRIPTION
## Summary

Prepare the version4.0.2 release for review.

This release makes CSharpDB full-text indexing scale better for large corpora by storing hot-token postings in bounded chunks instead of one rewritten postings blob. It also improves `DELETE` and `UPDATE` planning so indexed predicates collect target row IDs through available secondary indexes instead of falling back to full-table scans.

The full-text storage change is backward compatible: legacy posting blobs remain readable, old full-text indexes get the new chunk store on open, and legacy posting blobs migrate to chunked postings on the next write for that term.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

None linked.

## Testing

Validation performed for the version4.0.2 branch:

- [x] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Commands and benchmarks run successfully during this work:

```powershell
dotnet build CSharpDB.slnx -c Release
dotnet test tests\CSharpDB.Tests\CSharpDB.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~FullTextIndexTests|FullyQualifiedName~MutationPlannerTests" --verbosity minimal
dotnet test CSharpDB.slnx -c Release --no-build --verbosity minimal
powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FullTextHotTokenBeforeAfter.ps1
powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FileSearchNuGetBeforeAfter.ps1 -Profile smoke -TimeoutSeconds 1200 -OutputDir .\artifacts\filesearch-nuget-before-after\smoke-before-after
powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\CSharpDB.Benchmarks\scripts\Run-FileSearchNuGetBeforeAfter.ps1 -Profile standard -TimeoutSeconds 7200 -OutputDir .\artifacts\filesearch-nuget-before-after\standard-before-after
```

Latest validation:

- `dotnet build CSharpDB.slnx -c Release` passed with existing NU1903 dependency vulnerability warnings.
- Focused full-text and mutation planner tests passed: 11 passed, 0 failed.

Observed benchmark results:

- Hot-token 20k postings improved from 44.7s to 4.31s.
- Hot-token 100k and 500k baseline runs timed out at 180s; patched runs completed in 18.85s and 124.35s.
- FileSearcher standard NuGet before/after completed with baseline 2,153.8s and patched 1,867.4s wall clock.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

The new full-text layout keeps the existing postings index as the term manifest store and adds an owned posting-chunks internal store. Legacy posting blobs are not eagerly rewritten on open; they are read as-is and migrated lazily when a write touches the term.

Deletes and updates use the simplest correct chunk rewrite model for now: only the chunk containing the affected row is decoded, rewritten, and persisted. Tombstones and background compaction were intentionally left out until workload data shows they are needed.

The FileSearcher `full` profile was not run in this branch because it is intended for a dedicated release-machine run. Smoke and standard FileSearcher profiles were run through local NuGet package feeds so FileSearcher consumed packaged CSharpDB builds rather than project references.
