### PR TITLE
Prepare version4.0.3: large-value storage and native desktop dialogs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,7 @@ version4.0.3 removes the single-page B-tree payload limit, allowing large SQL va
 
 - The Windows desktop shell now provides native Open, Save, and Select Folder dialogs for databases, code-module workspaces, compare/deploy sources and targets, pipeline inputs and outputs, backups, restores, migration backups, imports, exports, and table archives.
 - Open and Save dialogs apply the appropriate file filters, default extensions, existence checks, and overwrite prompts. Cancellation is handled safely, and manual path entry remains available for browser-hosted Admin sessions and relative paths.
+- Native Browse controls now appear only when the page is running inside the trusted Desktop WebView, avoiding inactive controls when the desktop child host is opened in a regular browser.
 - Desktop startup now locates the Admin host reliably in installed, development, and published layouts.
 
 ### Compatibility
@@ -30,4 +31,4 @@ version4.0.3 removes the single-page B-tree payload limit, allowing large SQL va
 - BenchmarkDotNet comparisons found no measurable steady-state regression for existing inline workloads.
 - A roughly 6 KB overflow value measured 2.365 ms per durable insert and 4.595 microseconds per hot primary-key read on the benchmark machine. The previous version cannot complete this workload.
 - Corrected the B-tree cursor benchmark to retain the final root page after splits so seek measurements exercise the intended tree path.
-- Final Release validation passed all 2,127 tests. Desktop Admin Debug/Release builds, JavaScript validation, isolated host launches, and unsigned Store package generation also completed successfully.
+- Final Release validation passed all 2,127 tests. Desktop Admin Debug/Release builds, JavaScript capability validation, isolated host launches, signed Store package generation, and a packaged Open/Save/Select Folder smoke test also completed successfully.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## version4.0.3
 
-version4.0.3 removes the single-page B-tree payload limit, allowing large SQL values and Collection documents to span multiple 4 KiB pages safely.
+version4.0.3 removes the single-page B-tree payload limit, allowing large SQL values and Collection documents to span multiple 4 KiB pages safely. It also improves the Windows Desktop Admin experience with native file and folder dialogs throughout local path workflows.
 
 ### Fixed
 
@@ -11,6 +11,12 @@ version4.0.3 removes the single-page B-tree payload limit, allowing large SQL va
 - Replaced and deleted overflow chains are reclaimed for reuse, while rejected duplicate inserts and missing-key replacements avoid allocating overflow pages.
 - Storage diagnostics recognize overflow pages and validate reference metadata, page types, bounds, lengths, and cycles so corrupt chains are reported clearly.
 - Failed implicit Collection writes now release the write gate correctly, allowing later writes to continue.
+
+### Desktop Admin
+
+- The Windows desktop shell now provides native Open, Save, and Select Folder dialogs for databases, code-module workspaces, compare/deploy sources and targets, pipeline inputs and outputs, backups, restores, migration backups, imports, exports, and table archives.
+- Open and Save dialogs apply the appropriate file filters, default extensions, existence checks, and overwrite prompts. Cancellation is handled safely, and manual path entry remains available for browser-hosted Admin sessions and relative paths.
+- Desktop startup now locates the Admin host reliably in installed, development, and published layouts.
 
 ### Compatibility
 
@@ -24,3 +30,4 @@ version4.0.3 removes the single-page B-tree payload limit, allowing large SQL va
 - BenchmarkDotNet comparisons found no measurable steady-state regression for existing inline workloads.
 - A roughly 6 KB overflow value measured 2.365 ms per durable insert and 4.595 microseconds per hot primary-key read on the benchmark machine. The previous version cannot complete this workload.
 - Corrected the B-tree cursor benchmark to retain the final root page after splits so seek measurements exercise the intended tree path.
+- Final Release validation passed all 2,127 tests. Desktop Admin Debug/Release builds, JavaScript validation, isolated host launches, and unsigned Store package generation also completed successfully.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,26 @@
 # What's New
 
-## version4.0.2
+## version4.0.3
 
-version4.0.2 improves full-text indexing scalability for large corpora and makes indexed mutations avoid unnecessary full-table scans.
+version4.0.3 removes the single-page B-tree payload limit, allowing large SQL values and Collection documents to span multiple 4 KiB pages safely.
 
-### Changed
+### Fixed
 
-- Full-text postings are now stored in bounded posting chunks instead of rewriting one growing postings blob for every hot-token insert. This keeps repeated-token indexing scalable for large corpora.
-- Existing full-text posting blobs remain readable. Databases with the previous full-text storage layout get the new chunk store on open, and legacy posting blobs migrate to chunked postings on the next write for that term.
-- Full-text deletes and updates rewrite only the affected posting chunk while preserving existing search result ordering and transaction rollback behavior.
-- `DELETE` and `UPDATE` statements can now collect target row IDs through available secondary indexes instead of scanning the full table for indexed predicates.
+- B-tree payloads larger than the 4,075-byte inline limit are now stored in linked overflow pages instead of failing when a leaf page cannot be split.
+- Overflow-backed values work across point and snapshot reads, cursor scans, inserts, replacements, deletes, rollback, leaf splits, checkpoints, and database reopen.
+- Replaced and deleted overflow chains are reclaimed for reuse, while rejected duplicate inserts and missing-key replacements avoid allocating overflow pages.
+- Storage diagnostics recognize overflow pages and validate reference metadata, page types, bounds, lengths, and cycles so corrupt chains are reported clearly.
+- Failed implicit Collection writes now release the write gate correctly, allowing later writes to continue.
 
-### Validation
+### Compatibility
 
-- Added focused hot-token before/after benchmark coverage for insert, query, delete, and update paths.
-- Added FileSearcher NuGet before/after benchmark automation that validates real package consumption against local baseline and patched CSharpDB packages.
+- Existing format-v1 databases remain readable and are durably upgraded to format v2 before the next write is committed; read-only opens do not rewrite the file.
+- Once upgraded to format v2, a database requires a CSharpDB version that understands tagged overflow references. Back up the database before upgrading if rollback to an older binary may be required.
+- Explicitly tagged leaf cells keep ordinary inline values unambiguous, including values whose bytes resemble an overflow reference.
+
+### Performance and Validation
+
+- Added coverage for 10–20 KB SQL, Collection, and direct B-tree values across CRUD, rollback, cursor scans, page splits, checkpoint/reopen, page reuse, format migration, and corruption detection.
+- BenchmarkDotNet comparisons found no measurable steady-state regression for existing inline workloads.
+- A roughly 6 KB overflow value measured 2.365 ms per durable insert and 4.595 microseconds per hot primary-key read on the benchmark machine. The previous version cannot complete this workload.
+- Corrected the B-tree cursor benchmark to retain the final root page after splits so seek measurements exercise the intended tree path.

--- a/docs/releases/v4.0.3-pr-notes.md
+++ b/docs/releases/v4.0.3-pr-notes.md
@@ -6,7 +6,7 @@ This release fixes the 4 KiB page-size failure that prevented SQL rows, B-tree v
 
 Overflow-backed values are integrated across point and snapshot reads, cursors, inserts, replacements, deletes, rollback, tree splits, checkpoints, database reopen, and safe page reclamation. The change also extends storage diagnostics to validate complete overflow chains, preserves format-v1 read compatibility with a durable format-v2 write gate, fixes a failed implicit Collection write-scope leak, and corrects the cursor benchmark setup so it retains the root page produced after B-tree splits.
 
-The Desktop Admin now uses native Open, Save, and Select Folder dialogs across 12 local-path workflows: opening or creating databases, selecting code-module workspaces, compare/deploy archives, pipeline inputs and outputs, backup/restore and migration backup paths, import/export paths, and table archives. Manual path entry remains available for browser-hosted and relative-path workflows.
+The Desktop Admin now uses native Open, Save, and Select Folder dialogs across 12 local-path workflows: opening or creating databases, selecting code-module workspaces, compare/deploy archives, pipeline inputs and outputs, backup/restore and migration backup paths, import/export paths, and table archives. Manual path entry remains available for browser-hosted and relative-path workflows, and native Browse controls are hidden unless that browser tab has the WebView2 bridge.
 
 The desktop bridge correlates requests and responses, validates the WebView origin before opening a dialog and again before returning a selected path, rejects malformed or overlapping requests, and treats cancellation as a normal no-selection result. Desktop host discovery now supports packaged, conventional Debug/Release, RID-specific, publish, and custom artifacts layouts without falling back from Release to a stale Debug host.
 
@@ -35,12 +35,14 @@ Validation performed for the version4.0.3 branch:
 Commands run successfully:
 
 ```powershell
-dotnet build src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj -c Debug --artifacts-path .artifacts/admin-picker-final-debug
-dotnet build src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj -c Release --artifacts-path .artifacts/admin-picker-final-release
-dotnet build CSharpDB.slnx -c Release --artifacts-path .artifacts/admin-picker-final-solution
-dotnet test CSharpDB.slnx -c Release --no-build --artifacts-path .artifacts/admin-picker-final-solution
+dotnet build src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj -c Debug --artifacts-path .artifacts/admin-picker-p3-debug
+dotnet build src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj -c Release --artifacts-path .artifacts/admin-picker-p3-release
+dotnet build CSharpDB.slnx -c Release --artifacts-path .artifacts/admin-picker-p3-solution
+dotnet test CSharpDB.slnx -c Release --no-build --artifacts-path .artifacts/admin-picker-p3-solution --verbosity minimal
 node --check src/CSharpDB.Admin/wwwroot/js/interop.js
-.\scripts\Publish-CSharpDbAdminStorePackage.ps1 -Version 4.0.3 -OutputRoot artifacts/admin-store-dialog-final -SkipSigning
+.\scripts\Publish-CSharpDbAdminStorePackage.ps1 -Version 4.0.3 -OutputRoot artifacts/admin-store-dialog-signed
+.\scripts\Publish-CSharpDbAdminStorePackage.ps1 -Version 4.0.3 -OutputRoot artifacts/admin-store-dialog-p3-unsigned -SkipSigning
+Add-AppxPackage -Register artifacts/admin-store-dialog-p3-unsigned/stage/AppxManifest.xml -ForceApplicationShutdown
 dotnet run -c Release --project tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj -- --micro --filter "*RecordSizeBenchmarks*"
 dotnet run -c Release --project tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj -- --micro --filter "*PointLookupBenchmarks.SelectByPrimaryKey" "*InsertBenchmarks.SingleInsert" "*BTreeCursorBenchmarks*" --join
 ```
@@ -51,8 +53,10 @@ Latest validation:
 - Full Release solution test run passed: **2,127 passed, 0 failed** across 11 test assemblies, including **1,375 passed** in `CSharpDB.Tests`.
 - Focused overflow coverage includes the exact 4,075-byte inline / 4,076-byte overflow boundary; 10–20 KB SQL, Collection, and direct B-tree values; CRUD; snapshot and cursor reads; rollback; leaf splits; checkpoints and reopen; reclaimed-page reuse; rejected writes; format migration and cancellation; malformed references; out-of-range pages; cycles; and length mismatches.
 - Desktop Admin Debug and Release builds passed with 0 warnings and 0 errors, and the desktop JavaScript syntax check passed.
+- A JavaScript capability harness verified that a normal browser has neither bridge availability nor the desktop marker, while WebView2 has both. The CSS gate hides all 11 generic native-picker buttons when the marker is absent.
 - Isolated Release non-RID and `win-x64` publish layouts launched the correct Admin host. The native Open Database dialog was manually opened and cancelled successfully in a Debug desktop smoke test.
-- Unsigned Store package generation completed successfully at `artifacts/admin-store-dialog-final/packages/csharpdb-studio-v4.0.3-win-x64.msix`; signing remains a release-publishing step.
+- Signed Store package generation completed at `artifacts/admin-store-dialog-signed/packages/csharpdb-studio-v4.0.3-win-x64.msix`, with matching final JavaScript and CSS assets verified in the package stage.
+- The exact v4.0.3 stage registered in Windows Development Mode with package status `Ok`. Packaged native dialogs for Open Database, Select Code Modules Workspace, and Save Table Export opened with the expected controls and canceled cleanly; the app and temporary registration were then removed.
 
 BenchmarkDotNet same-machine comparisons against the pre-change `HEAD` found no measurable steady-state regression for existing inline workloads. The table shows geometric-mean deltas across each benchmark's configured parameter sets:
 
@@ -88,6 +92,7 @@ The overflow insert was approximately 4.4% slower than the small-row durable ins
 - Overflow chains are validated completely before reads allocate the output buffer or reclamation frees any page.
 - The steady-state benchmarks do not include the one-time format-v1 to format-v2 header flush.
 - The cursor benchmark now records the final root page after seeding. Without that correction, its seek case starts from a stale leaf and does not measure a valid root-based seek.
-- Native path selection is a Desktop Admin capability. Browser-hosted sessions retain editable path fields; when no trusted desktop bridge is present, a native picker request returns no selection.
+- Native path selection is a Desktop Admin capability. Browser-hosted sessions retain editable path fields and the title-bar prompt fallback; generic Browse controls are hidden when no trusted desktop bridge is present.
 - The WebView bridge only accepts requests from the active loopback Admin origin and revalidates that origin before returning generic filesystem paths after a dialog closes.
 - The desktop host honors `CSHARPDB_ADMIN_EXE` first, then resolves the Admin executable from supported packaged, build, RID, publish, and custom artifacts layouts for the active build configuration.
+- The signed artifact uses the existing `CN=MaxAkbar` local test certificate. The certificate was deliberately not added to a trusted store, so Windows reports the expected untrusted-root chain status; the packaged UI smoke test used Development Mode registration instead of changing machine trust.

--- a/docs/releases/v4.0.3-pr-notes.md
+++ b/docs/releases/v4.0.3-pr-notes.md
@@ -1,10 +1,14 @@
 ## Summary
 
-Prepare the version4.0.3 release for review.
+Prepare the version4.0.3 release for review. This release combines the large-value B-tree fix with native Windows file and folder dialogs for the Desktop Admin.
 
 This release fixes the 4 KiB page-size failure that prevented SQL rows, B-tree values, and Collection documents larger than the 4,075-byte maximum inline payload from being stored. Oversized B-tree payloads now live in validated linked overflow pages while the leaf cell retains a tagged 16-byte reference.
 
 Overflow-backed values are integrated across point and snapshot reads, cursors, inserts, replacements, deletes, rollback, tree splits, checkpoints, database reopen, and safe page reclamation. The change also extends storage diagnostics to validate complete overflow chains, preserves format-v1 read compatibility with a durable format-v2 write gate, fixes a failed implicit Collection write-scope leak, and corrects the cursor benchmark setup so it retains the root page produced after B-tree splits.
+
+The Desktop Admin now uses native Open, Save, and Select Folder dialogs across 12 local-path workflows: opening or creating databases, selecting code-module workspaces, compare/deploy archives, pipeline inputs and outputs, backup/restore and migration backup paths, import/export paths, and table archives. Manual path entry remains available for browser-hosted and relative-path workflows.
+
+The desktop bridge correlates requests and responses, validates the WebView origin before opening a dialog and again before returning a selected path, rejects malformed or overlapping requests, and treats cancellation as a normal no-selection result. Desktop host discovery now supports packaged, conventional Debug/Release, RID-specific, publish, and custom artifacts layouts without falling back from Release to a stale Debug host.
 
 ## Type of Change
 
@@ -31,8 +35,12 @@ Validation performed for the version4.0.3 branch:
 Commands run successfully:
 
 ```powershell
-dotnet build CSharpDB.slnx -c Release
-dotnet test CSharpDB.slnx -c Release --no-build --verbosity minimal
+dotnet build src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj -c Debug --artifacts-path .artifacts/admin-picker-final-debug
+dotnet build src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj -c Release --artifacts-path .artifacts/admin-picker-final-release
+dotnet build CSharpDB.slnx -c Release --artifacts-path .artifacts/admin-picker-final-solution
+dotnet test CSharpDB.slnx -c Release --no-build --artifacts-path .artifacts/admin-picker-final-solution
+node --check src/CSharpDB.Admin/wwwroot/js/interop.js
+.\scripts\Publish-CSharpDbAdminStorePackage.ps1 -Version 4.0.3 -OutputRoot artifacts/admin-store-dialog-final -SkipSigning
 dotnet run -c Release --project tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj -- --micro --filter "*RecordSizeBenchmarks*"
 dotnet run -c Release --project tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj -- --micro --filter "*PointLookupBenchmarks.SelectByPrimaryKey" "*InsertBenchmarks.SingleInsert" "*BTreeCursorBenchmarks*" --join
 ```
@@ -42,6 +50,9 @@ Latest validation:
 - Release solution build passed with 0 errors. The 12 warnings are existing NU1903 advisories for `Microsoft.OpenApi` and `SQLitePCLRaw.lib.e_sqlite3`.
 - Full Release solution test run passed: **2,127 passed, 0 failed** across 11 test assemblies, including **1,375 passed** in `CSharpDB.Tests`.
 - Focused overflow coverage includes the exact 4,075-byte inline / 4,076-byte overflow boundary; 10–20 KB SQL, Collection, and direct B-tree values; CRUD; snapshot and cursor reads; rollback; leaf splits; checkpoints and reopen; reclaimed-page reuse; rejected writes; format migration and cancellation; malformed references; out-of-range pages; cycles; and length mismatches.
+- Desktop Admin Debug and Release builds passed with 0 warnings and 0 errors, and the desktop JavaScript syntax check passed.
+- Isolated Release non-RID and `win-x64` publish layouts launched the correct Admin host. The native Open Database dialog was manually opened and cancelled successfully in a Debug desktop smoke test.
+- Unsigned Store package generation completed successfully at `artifacts/admin-store-dialog-final/packages/csharpdb-studio-v4.0.3-win-x64.msix`; signing remains a release-publishing step.
 
 BenchmarkDotNet same-machine comparisons against the pre-change `HEAD` found no measurable steady-state regression for existing inline workloads. The table shows geometric-mean deltas across each benchmark's configured parameter sets:
 
@@ -77,3 +88,6 @@ The overflow insert was approximately 4.4% slower than the small-row durable ins
 - Overflow chains are validated completely before reads allocate the output buffer or reclamation frees any page.
 - The steady-state benchmarks do not include the one-time format-v1 to format-v2 header flush.
 - The cursor benchmark now records the final root page after seeding. Without that correction, its seek case starts from a stale leaf and does not measure a valid root-based seek.
+- Native path selection is a Desktop Admin capability. Browser-hosted sessions retain editable path fields; when no trusted desktop bridge is present, a native picker request returns no selection.
+- The WebView bridge only accepts requests from the active loopback Admin origin and revalidates that origin before returning generic filesystem paths after a dialog closes.
+- The desktop host honors `CSHARPDB_ADMIN_EXE` first, then resolves the Admin executable from supported packaged, build, RID, publish, and custom artifacts layouts for the active build configuration.

--- a/docs/releases/v4.0.3-pr-notes.md
+++ b/docs/releases/v4.0.3-pr-notes.md
@@ -1,0 +1,79 @@
+## Summary
+
+Prepare the version4.0.3 release for review.
+
+This release fixes the 4 KiB page-size failure that prevented SQL rows, B-tree values, and Collection documents larger than the 4,075-byte maximum inline payload from being stored. Oversized B-tree payloads now live in validated linked overflow pages while the leaf cell retains a tagged 16-byte reference.
+
+Overflow-backed values are integrated across point and snapshot reads, cursors, inserts, replacements, deletes, rollback, tree splits, checkpoints, database reopen, and safe page reclamation. The change also extends storage diagnostics to validate complete overflow chains, preserves format-v1 read compatibility with a durable format-v2 write gate, fixes a failed implicit Collection write-scope leak, and corrects the cursor benchmark setup so it retains the root page produced after B-tree splits.
+
+## Type of Change
+
+- [x] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [x] Documentation update
+- [x] Refactor / maintenance
+- [ ] Tests only
+
+## Related Issues
+
+None linked.
+
+## Testing
+
+Validation performed for the version4.0.3 branch:
+
+- [x] `dotnet build CSharpDB.slnx`
+- [x] Relevant tests executed
+- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
+- [x] Manual verification performed (if applicable)
+
+Commands run successfully:
+
+```powershell
+dotnet build CSharpDB.slnx -c Release
+dotnet test CSharpDB.slnx -c Release --no-build --verbosity minimal
+dotnet run -c Release --project tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj -- --micro --filter "*RecordSizeBenchmarks*"
+dotnet run -c Release --project tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj -- --micro --filter "*PointLookupBenchmarks.SelectByPrimaryKey" "*InsertBenchmarks.SingleInsert" "*BTreeCursorBenchmarks*" --join
+```
+
+Latest validation:
+
+- Release solution build passed with 0 errors. The 12 warnings are existing NU1903 advisories for `Microsoft.OpenApi` and `SQLitePCLRaw.lib.e_sqlite3`.
+- Full Release solution test run passed: **2,127 passed, 0 failed** across 11 test assemblies, including **1,375 passed** in `CSharpDB.Tests`.
+- Focused overflow coverage includes the exact 4,075-byte inline / 4,076-byte overflow boundary; 10–20 KB SQL, Collection, and direct B-tree values; CRUD; snapshot and cursor reads; rollback; leaf splits; checkpoints and reopen; reclaimed-page reuse; rejected writes; format migration and cancellation; malformed references; out-of-range pages; cycles; and length mismatches.
+
+BenchmarkDotNet same-machine comparisons against the pre-change `HEAD` found no measurable steady-state regression for existing inline workloads. The table shows geometric-mean deltas across each benchmark's configured parameter sets:
+
+| Existing inline workload | Current vs. baseline |
+|---|---:|
+| Durable inserts | 1.6% faster |
+| SQL primary-key reads | 2.4% faster |
+| B-tree full scans | 1.0% faster |
+| Cursor seek + 1,024 rows | 1.1% slower |
+
+For the new approximately 6 KB overflow-row workload:
+
+| Operation | Mean | Throughput | Allocated |
+|---|---:|---:|---:|
+| Durable insert | 2.365 ms | 423 ops/sec | 93,083 B |
+| Hot primary-key read | 4.595 microseconds | 218K ops/sec | 19,368 B |
+
+The overflow insert was approximately 4.4% slower than the small-row durable insert. Overflow reads were approximately 9.7 times slower than tiny inline reads because the overflow pages must be fetched and the payload reassembled. The baseline cannot complete the large-row benchmark because setup fails with the original leaf-split error.
+
+## Checklist
+
+- [x] I followed the project style and conventions.
+- [x] I added or updated tests for behavior changes.
+- [x] I covered both success and failure paths for changed behavior.
+- [x] I updated docs for user-facing changes.
+- [x] I verified no sensitive data was added.
+
+## Notes for Reviewers
+
+- Existing format-v1 databases remain readable without modification. Before a write can commit, the base header is durably upgraded to format v2 so an older reader cannot accept a file whose WAL may contain tagged overflow references. A later failure may leave the header at v2 even when that write does not commit.
+- Once the header is upgraded, the database requires a CSharpDB version that understands format v2. Back up before upgrading when rollback to an older binary may be required.
+- Only encoded B-tree payloads above 4,075 bytes use overflow pages; existing inline payloads keep their normal representation.
+- Overflow chains are validated completely before reads allocate the output buffer or reclamation frees any page.
+- The steady-state benchmarks do not include the one-time format-v1 to format-v2 header flush.
+- The cursor benchmark now records the final root page after seeding. Without that correction, its seek case starts from a stale leaf and does not measure a valid root-based seek.

--- a/src/CSharpDB.Admin.Desktop/AdminHostProcess.cs
+++ b/src/CSharpDB.Admin.Desktop/AdminHostProcess.cs
@@ -12,6 +12,13 @@ internal sealed class AdminHostProcess : IAsyncDisposable
     private const string AdminExecutableName = "CSharpDB.Admin.exe";
     private const string AdminExecutableEnvironmentVariable = "CSHARPDB_ADMIN_EXE";
     private const string DesktopShellTokenHeaderName = "X-CSharpDB-Desktop-Shell-Token";
+    private const string AdminTargetFramework = "net10.0";
+
+#if DEBUG
+    private const string BuildConfiguration = "Debug";
+#else
+    private const string BuildConfiguration = "Release";
+#endif
 
     private readonly CancellationTokenSource _logCancellation = new();
     private Process? _process;
@@ -21,6 +28,7 @@ internal sealed class AdminHostProcess : IAsyncDisposable
     public async Task<AdminHostSession> StartAsync(Action<string> reportStatus, CancellationToken ct)
     {
         string adminExecutablePath = ResolveAdminExecutablePath();
+        string adminEnvironment = ResolveAdminEnvironment(adminExecutablePath);
         int port = ReserveLoopbackPort();
         string token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
         var adminUri = new Uri($"http://127.0.0.1:{port}/");
@@ -44,8 +52,8 @@ internal sealed class AdminHostProcess : IAsyncDisposable
         startInfo.Environment["CSharpDB__DesktopShell"] = "true";
         startInfo.Environment["CSharpDB__DesktopShellToken"] = token;
         startInfo.Environment["CSharpDB__DesktopShellLogDirectory"] = DesktopPaths.LogDirectory;
-        startInfo.Environment["DOTNET_ENVIRONMENT"] = "Production";
-        startInfo.Environment["ASPNETCORE_ENVIRONMENT"] = "Production";
+        startInfo.Environment["DOTNET_ENVIRONMENT"] = adminEnvironment;
+        startInfo.Environment["ASPNETCORE_ENVIRONMENT"] = adminEnvironment;
 
         _process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start the CSharpDB Admin host process.");
@@ -106,6 +114,8 @@ internal sealed class AdminHostProcess : IAsyncDisposable
 
         while (!linked.IsCancellationRequested)
         {
+            ct.ThrowIfCancellationRequested();
+
             if (_process is { HasExited: true })
                 throw new InvalidOperationException($"The CSharpDB Admin host exited early with code {_process.ExitCode}.");
 
@@ -134,6 +144,7 @@ internal sealed class AdminHostProcess : IAsyncDisposable
             }
         }
 
+        ct.ThrowIfCancellationRequested();
         throw new TimeoutException("Timed out waiting for the CSharpDB Admin host to become ready.");
     }
 
@@ -153,23 +164,140 @@ internal sealed class AdminHostProcess : IAsyncDisposable
             return Path.GetFullPath(configured);
 
         string baseDirectory = AppContext.BaseDirectory;
-        string[] candidates =
-        [
-            Path.Combine(baseDirectory, "admin", AdminExecutableName),
-            Path.Combine(baseDirectory, AdminExecutableName),
-            Path.GetFullPath(Path.Combine(baseDirectory, "..", "CSharpDB.Admin", AdminExecutableName)),
-            Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", "..", "CSharpDB.Admin", "bin", "Release", "net10.0", "win-x64", "publish", AdminExecutableName)),
-            Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", "..", "CSharpDB.Admin", "bin", "Debug", "net10.0", AdminExecutableName)),
-        ];
-
-        foreach (string candidate in candidates)
+        foreach (string candidate in EnumerateAdminExecutableCandidates(baseDirectory).Distinct(StringComparer.OrdinalIgnoreCase))
         {
             if (File.Exists(candidate))
                 return candidate;
         }
 
         throw new FileNotFoundException(
-            $"Could not find {AdminExecutableName}. Publish CSharpDB.Admin into an 'admin' subfolder next to the desktop shell, or set {AdminExecutableEnvironmentVariable}.");
+            $"Could not find the {BuildConfiguration} {AdminExecutableName}. Publish CSharpDB.Admin into an 'admin' subfolder next to the desktop shell, or set {AdminExecutableEnvironmentVariable}.");
+    }
+
+    private static IEnumerable<string> EnumerateAdminExecutableCandidates(string baseDirectory)
+    {
+        // Packaged layouts take precedence over development output discovery.
+        yield return Path.Combine(baseDirectory, "admin", AdminExecutableName);
+        yield return Path.Combine(baseDirectory, AdminExecutableName);
+        yield return Path.GetFullPath(Path.Combine(baseDirectory, "..", "CSharpDB.Admin", AdminExecutableName));
+
+        var current = new DirectoryInfo(baseDirectory);
+        while (current is not null)
+        {
+            if (IsBuildConfigurationDirectory(current.Name))
+            {
+                foreach (string candidate in EnumerateArtifactsOutputCandidates(current))
+                    yield return candidate;
+
+                foreach (string candidate in EnumerateConventionalOutputCandidates(current, baseDirectory))
+                    yield return candidate;
+            }
+
+            current = current.Parent;
+        }
+    }
+
+    private static IEnumerable<string> EnumerateArtifactsOutputCandidates(DirectoryInfo configurationDirectory)
+    {
+        // --artifacts-path uses <output-kind>/<ProjectName>/<configuration-pivot>.
+        DirectoryInfo? desktopProjectOutput = configurationDirectory.Parent;
+        DirectoryInfo? outputDirectory = desktopProjectOutput?.Parent;
+        if (desktopProjectOutput is null || outputDirectory is null ||
+            !desktopProjectOutput.Name.Equals("CSharpDB.Admin.Desktop", StringComparison.OrdinalIgnoreCase))
+        {
+            yield break;
+        }
+
+        if (outputDirectory.Name.Equals("bin", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return Path.Combine(
+                outputDirectory.FullName,
+                "CSharpDB.Admin",
+                configurationDirectory.Name,
+                AdminExecutableName);
+            yield break;
+        }
+
+        if (!outputDirectory.Name.Equals("publish", StringComparison.OrdinalIgnoreCase) ||
+            outputDirectory.Parent is not { } artifactsDirectory)
+        {
+            yield break;
+        }
+
+        // Publishing with --artifacts-path places this executable under
+        // publish/<ProjectName>/<configuration-pivot>, while project references
+        // are built under bin/<ProjectName>/<configuration-pivot>. Prefer a
+        // separately published Admin host when present, then fall back to the
+        // referenced project's build output produced by the desktop publish.
+        yield return Path.Combine(
+            outputDirectory.FullName,
+            "CSharpDB.Admin",
+            configurationDirectory.Name,
+            AdminExecutableName);
+        yield return Path.Combine(
+            artifactsDirectory.FullName,
+            "bin",
+            "CSharpDB.Admin",
+            configurationDirectory.Name,
+            AdminExecutableName);
+    }
+
+    private static IEnumerable<string> EnumerateConventionalOutputCandidates(
+        DirectoryInfo configurationDirectory,
+        string baseDirectory)
+    {
+        // Normal SDK output uses <project>/bin/<configuration>/<tfm>[/<rid>][/publish].
+        DirectoryInfo? binDirectory = configurationDirectory.Parent;
+        DirectoryInfo? desktopProjectDirectory = binDirectory?.Parent;
+        DirectoryInfo? sourceDirectory = desktopProjectDirectory?.Parent;
+        if (binDirectory is null || desktopProjectDirectory is null || sourceDirectory is null ||
+            !binDirectory.Name.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+            !desktopProjectDirectory.Name.Equals("CSharpDB.Admin.Desktop", StringComparison.OrdinalIgnoreCase))
+        {
+            yield break;
+        }
+
+        string adminOutputDirectory = Path.Combine(
+            sourceDirectory.FullName,
+            "CSharpDB.Admin",
+            "bin",
+            configurationDirectory.Name,
+            AdminTargetFramework);
+
+        string[] relativeSegments = Path.GetRelativePath(configurationDirectory.FullName, baseDirectory)
+            .Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
+        string? runtimeIdentifier = relativeSegments.Length >= 2 &&
+            !relativeSegments[1].Equals("publish", StringComparison.OrdinalIgnoreCase)
+                ? relativeSegments[1]
+                : null;
+        bool isPublished = relativeSegments.Any(segment =>
+            segment.Equals("publish", StringComparison.OrdinalIgnoreCase));
+
+        if (runtimeIdentifier is not null)
+        {
+            string runtimeOutputDirectory = Path.Combine(adminOutputDirectory, runtimeIdentifier);
+            if (isPublished)
+                yield return Path.Combine(runtimeOutputDirectory, "publish", AdminExecutableName);
+
+            yield return Path.Combine(runtimeOutputDirectory, AdminExecutableName);
+        }
+        else if (isPublished)
+        {
+            yield return Path.Combine(adminOutputDirectory, "publish", AdminExecutableName);
+        }
+
+        yield return Path.Combine(adminOutputDirectory, AdminExecutableName);
+    }
+
+    private static bool IsBuildConfigurationDirectory(string directoryName) =>
+        directoryName.Equals(BuildConfiguration, StringComparison.OrdinalIgnoreCase) ||
+        directoryName.StartsWith($"{BuildConfiguration}_", StringComparison.OrdinalIgnoreCase);
+
+    private static string ResolveAdminEnvironment(string adminExecutablePath)
+    {
+        string adminDirectory = Path.GetDirectoryName(adminExecutablePath) ?? AppContext.BaseDirectory;
+        string staticAssetsManifest = Path.Combine(adminDirectory, "CSharpDB.Admin.staticwebassets.runtime.json");
+        return File.Exists(staticAssetsManifest) ? "Development" : "Production";
     }
 
     private static async Task CopyOutputAsync(StreamReader reader, string path, CancellationToken ct)

--- a/src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj
+++ b/src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CSharpDB.Admin\CSharpDB.Admin.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="..\..\docs\images\CSharpDB.ico" Link="Assets\CSharpDB.ico" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\CSharpDB.Admin\wwwroot\icon2.png" Link="Assets\icon2.png" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/CSharpDB.Admin.Desktop/MainWindow.xaml.cs
+++ b/src/CSharpDB.Admin.Desktop/MainWindow.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading;
 using System.Windows;
 using System.Windows.Media.Imaging;
@@ -12,9 +13,15 @@ namespace CSharpDB.Admin.Desktop;
 
 public partial class MainWindow : Window
 {
+    private const string DialogRequestType = "desktop-shell-dialog-request";
+    private const string DialogResultType = "desktop-shell-dialog-result";
+    private static readonly JsonSerializerOptions WebMessageJsonOptions = new(JsonSerializerDefaults.Web);
+
     private readonly CancellationTokenSource _shutdown = new();
     private readonly AdminHostProcess _adminHost = new();
     private AdminHostSession? _adminHostSession;
+    private bool _nativeDialogOpen;
+    private bool _isClosing;
 
     public MainWindow()
     {
@@ -37,12 +44,17 @@ public partial class MainWindow : Window
                 userDataFolder: DesktopPaths.WebViewDataDirectory);
 
             await Browser.EnsureCoreWebView2Async(environment);
+            Browser.CoreWebView2.WebMessageReceived += OnWebMessageReceived;
             Browser.CoreWebView2.Settings.AreDevToolsEnabled = false;
             Browser.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
             Browser.Source = _adminHostSession.BaseUri;
             Browser.Visibility = Visibility.Visible;
             StartupPanel.Visibility = Visibility.Collapsed;
             OpenDatabaseMenuItem.IsEnabled = true;
+        }
+        catch (OperationCanceledException) when (_isClosing)
+        {
+            // Normal shutdown can cancel host or WebView initialization.
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -52,7 +64,11 @@ public partial class MainWindow : Window
 
     protected override async void OnClosed(EventArgs e)
     {
+        _isClosing = true;
         _shutdown.Cancel();
+
+        if (Browser.CoreWebView2 is not null)
+            Browser.CoreWebView2.WebMessageReceived -= OnWebMessageReceived;
 
         await _adminHost.DisposeAsync();
         _shutdown.Dispose();
@@ -76,47 +92,301 @@ public partial class MainWindow : Window
     }
 
     private async void OnOpenDatabase(object sender, RoutedEventArgs e)
+        => await OpenDatabaseAsync(showErrors: true);
+
+    private async void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
     {
-        if (_adminHostSession is null)
-            return;
-
-        var dialog = new OpenFileDialog
+        DesktopDialogRequest? request = null;
+        try
         {
-            Title = "Open CSharpDB Database",
-            Filter = "Database files (*.db;*.cdb;*.csdb)|*.db;*.cdb;*.csdb|All files (*.*)|*.*",
-            CheckFileExists = false,
-            AddExtension = true,
-            DefaultExt = ".db",
-        };
+            if (!IsCurrentAdminSource(e.Source))
+                return;
 
-        if (dialog.ShowDialog(this) != true)
-            return;
+            request = ParseDialogRequest(e.WebMessageAsJson);
+            if (request is null)
+                return;
 
+            DialogOutcome outcome = request.Dialog switch
+            {
+                "open-database" => await OpenDatabaseAsync(showErrors: true),
+                "open-file" => ShowPathDialog(() => ShowOpenFileDialog(request.Options)),
+                "save-file" => ShowPathDialog(() => ShowSaveFileDialog(request.Options)),
+                "open-folder" => ShowPathDialog(() => ShowOpenFolderDialog(request.Options)),
+                _ => DialogOutcome.Failed($"Unknown native dialog '{request.Dialog}'."),
+            };
+
+            PostDialogResponse(request.RequestId, outcome);
+        }
+        catch (OperationCanceledException) when (_isClosing)
+        {
+            if (request is not null)
+                PostDialogResponse(request.RequestId, DialogOutcome.CanceledByUser());
+        }
+        catch (Exception ex)
+        {
+            // WebView messages are an external input boundary. Never allow a malformed
+            // message or a dialog failure to escape this async-void event handler.
+            if (request is not null)
+                PostDialogResponse(request.RequestId, DialogOutcome.Failed(ex.Message));
+        }
+    }
+
+    private async Task<DialogOutcome> OpenDatabaseAsync(bool showErrors)
+    {
+        AdminHostSession? session = _adminHostSession;
+        if (session is null)
+            return DialogOutcome.Failed("The local Admin host is not ready.");
+        if (_isClosing)
+            return DialogOutcome.CanceledByUser();
+        if (_nativeDialogOpen)
+            return DialogOutcome.Failed("Another native dialog is already open.");
+
+        _nativeDialogOpen = true;
         OpenDatabaseMenuItem.IsEnabled = false;
         try
         {
-            using var client = new HttpClient { BaseAddress = _adminHostSession.BaseUri };
+            var dialog = new OpenFileDialog
+            {
+                Title = "Open CSharpDB Database",
+                Filter = "Database files (*.db;*.cdb;*.csdb)|*.db;*.cdb;*.csdb|All files (*.*)|*.*",
+                CheckFileExists = false,
+                AddExtension = true,
+                DefaultExt = ".db",
+            };
+
+            if (dialog.ShowDialog(this) != true)
+                return DialogOutcome.CanceledByUser();
+
+            using var client = new HttpClient { BaseAddress = session.BaseUri };
             using var request = new HttpRequestMessage(HttpMethod.Post, "_desktop/open-database")
             {
                 Content = JsonContent.Create(new { databasePath = dialog.FileName }),
             };
             request.Headers.TryAddWithoutValidation(
                 "X-CSharpDB-Desktop-Shell-Token",
-                _adminHostSession.DesktopShellToken);
+                session.DesktopShellToken);
 
             using HttpResponseMessage response = await client.SendAsync(request, _shutdown.Token);
             response.EnsureSuccessStatusCode();
 
-            Browser.CoreWebView2?.Reload();
+            if (!_isClosing)
+                Browser.CoreWebView2?.Reload();
+
+            // The selected database path deliberately stays in the native host and is
+            // sent only to the token-protected loopback endpoint.
+            return DialogOutcome.Completed();
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException) when (_isClosing)
         {
-            MessageBox.Show(this, ex.Message, "Open Database Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            return DialogOutcome.CanceledByUser();
+        }
+        catch (Exception ex)
+        {
+            if (showErrors && !_isClosing)
+                MessageBox.Show(this, ex.Message, "Open Database Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+
+            return DialogOutcome.Failed(ex.Message);
         }
         finally
         {
-            OpenDatabaseMenuItem.IsEnabled = _adminHostSession is not null && !_shutdown.IsCancellationRequested;
+            _nativeDialogOpen = false;
+            OpenDatabaseMenuItem.IsEnabled = _adminHostSession is not null && !_isClosing;
         }
+    }
+
+    private bool IsCurrentAdminSource(string source)
+    {
+        if (_adminHostSession is null || !Uri.TryCreate(source, UriKind.Absolute, out Uri? sourceUri))
+            return false;
+
+        Uri adminUri = _adminHostSession.BaseUri;
+        return sourceUri.Scheme.Equals(adminUri.Scheme, StringComparison.OrdinalIgnoreCase) &&
+               sourceUri.IdnHost.Equals(adminUri.IdnHost, StringComparison.OrdinalIgnoreCase) &&
+               sourceUri.Port == adminUri.Port;
+    }
+
+    private static DesktopDialogRequest? ParseDialogRequest(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json.Length > 16_384)
+            return null;
+
+        DesktopDialogRequest? request;
+        try
+        {
+            request = JsonSerializer.Deserialize<DesktopDialogRequest>(json, WebMessageJsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+
+        if (request is null ||
+            request.Type != DialogRequestType ||
+            string.IsNullOrWhiteSpace(request.RequestId) ||
+            request.RequestId.Length > 128 ||
+            string.IsNullOrWhiteSpace(request.Dialog))
+        {
+            return null;
+        }
+
+        return request;
+    }
+
+    private DialogOutcome ShowPathDialog(Func<DialogOutcome> showDialog)
+    {
+        if (_isClosing)
+            return DialogOutcome.CanceledByUser();
+        if (_nativeDialogOpen)
+            return DialogOutcome.Failed("Another native dialog is already open.");
+
+        _nativeDialogOpen = true;
+        OpenDatabaseMenuItem.IsEnabled = false;
+        try
+        {
+            return showDialog();
+        }
+        catch (Exception ex)
+        {
+            return DialogOutcome.Failed(ex.Message);
+        }
+        finally
+        {
+            _nativeDialogOpen = false;
+            OpenDatabaseMenuItem.IsEnabled = _adminHostSession is not null && !_isClosing;
+        }
+    }
+
+    private DialogOutcome ShowOpenFileDialog(DesktopDialogOptions? options)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Title = ValueOrDefault(options?.Title, "Open File"),
+            Filter = ValueOrDefault(options?.Filter, "All files (*.*)|*.*"),
+            CheckFileExists = options?.CheckFileExists ?? true,
+            CheckPathExists = options?.CheckPathExists ?? true,
+            AddExtension = options?.AddExtension ?? true,
+            Multiselect = false,
+        };
+        ApplyFileDialogOptions(dialog, options);
+
+        return dialog.ShowDialog(this) == true
+            ? DialogOutcome.Completed(dialog.FileName)
+            : DialogOutcome.CanceledByUser();
+    }
+
+    private DialogOutcome ShowSaveFileDialog(DesktopDialogOptions? options)
+    {
+        var dialog = new SaveFileDialog
+        {
+            Title = ValueOrDefault(options?.Title, "Save File"),
+            Filter = ValueOrDefault(options?.Filter, "All files (*.*)|*.*"),
+            CheckFileExists = options?.CheckFileExists ?? false,
+            CheckPathExists = options?.CheckPathExists ?? true,
+            AddExtension = options?.AddExtension ?? true,
+            OverwritePrompt = options?.OverwritePrompt ?? true,
+            CreatePrompt = options?.CreatePrompt ?? false,
+        };
+        ApplyFileDialogOptions(dialog, options);
+
+        return dialog.ShowDialog(this) == true
+            ? DialogOutcome.Completed(dialog.FileName)
+            : DialogOutcome.CanceledByUser();
+    }
+
+    private DialogOutcome ShowOpenFolderDialog(DesktopDialogOptions? options)
+    {
+        var dialog = new OpenFolderDialog
+        {
+            Title = ValueOrDefault(options?.Title, "Select Folder"),
+            InitialDirectory = options?.Path ?? options?.InitialDirectory ?? string.Empty,
+            FolderName = options?.Path ?? options?.FolderName ?? string.Empty,
+            Multiselect = false,
+        };
+
+        return dialog.ShowDialog(this) == true
+            ? DialogOutcome.Completed(dialog.FolderName)
+            : DialogOutcome.CanceledByUser();
+    }
+
+    private static void ApplyFileDialogOptions(FileDialog dialog, DesktopDialogOptions? options)
+    {
+        if (options is null)
+            return;
+
+        dialog.InitialDirectory = options.InitialDirectory ?? string.Empty;
+        dialog.FileName = options.Path ?? options.FileName ?? string.Empty;
+        dialog.DefaultExt = options.DefaultExt ?? options.DefaultExtension ?? string.Empty;
+    }
+
+    private static string ValueOrDefault(string? value, string defaultValue)
+        => string.IsNullOrWhiteSpace(value) ? defaultValue : value;
+
+    private void PostDialogResponse(string requestId, DialogOutcome outcome)
+    {
+        CoreWebView2? webView = Browser.CoreWebView2;
+        if (_isClosing || webView is null || !IsCurrentAdminSource(webView.Source))
+            return;
+
+        try
+        {
+            var response = new DesktopDialogResponse(
+                DialogResultType,
+                requestId,
+                outcome.Canceled,
+                outcome.Succeeded,
+                outcome.Path,
+                outcome.Error);
+            webView.PostWebMessageAsJson(
+                JsonSerializer.Serialize(response, WebMessageJsonOptions));
+        }
+        catch
+        {
+            // The page or WebView may have gone away while a native dialog was open.
+        }
+    }
+
+    private sealed record DesktopDialogRequest(
+        string? Type,
+        string RequestId,
+        string Dialog,
+        DesktopDialogOptions? Options);
+
+    private sealed record DesktopDialogOptions(
+        string? Title,
+        string? Filter,
+        string? DefaultExtension,
+        string? DefaultExt,
+        string? InitialDirectory,
+        string? FileName,
+        string? FolderName,
+        string? Path,
+        bool? AddExtension,
+        bool? CheckFileExists,
+        bool? CheckPathExists,
+        bool? OverwritePrompt,
+        bool? CreatePrompt);
+
+    private sealed record DesktopDialogResponse(
+        string Type,
+        string RequestId,
+        bool Canceled,
+        bool Succeeded,
+        string? Path,
+        string? Error);
+
+    private readonly record struct DialogOutcome(
+        bool Canceled,
+        bool Succeeded,
+        string? Path,
+        string? Error)
+    {
+        public static DialogOutcome Completed(string? path = null) => new(false, true, path, null);
+        public static DialogOutcome CanceledByUser() => new(true, false, null, null);
+        public static DialogOutcome Failed(string error) => new(false, false, null, error);
     }
 
     private void OnExit(object sender, RoutedEventArgs e)

--- a/src/CSharpDB.Admin.ImportExport/Pages/ImportExport.razor
+++ b/src/CSharpDB.Admin.ImportExport/Pages/ImportExport.razor
@@ -1,6 +1,10 @@
 @namespace CSharpDB.Admin.ImportExport.Pages
+@using Microsoft.Extensions.Configuration
+@using Microsoft.JSInterop
 @inject ICSharpDbClient DbClient
 @inject ITableImportExportService ImportExportService
+@inject IConfiguration Configuration
+@inject IJSRuntime JS
 
 <div class="import-export-tab">
     <div class="import-export-header">
@@ -61,10 +65,23 @@
 
                     @if (_destination == TableExportDestination.ServerPath)
                     {
-                        <label class="wide">
-                            <span>Path</span>
-                            <input value="@_serverPath" @oninput="e => _serverPath = e.Value?.ToString() ?? string.Empty" disabled="@_busy" />
-                        </label>
+                        <div class="import-export-field wide">
+                            <span id="table-export-path-label">Path</span>
+                            <div class="native-path-picker">
+                                <input aria-labelledby="table-export-path-label" value="@_serverPath" @oninput="e => _serverPath = e.Value?.ToString() ?? string.Empty" disabled="@_busy" />
+                                @if (UseDesktopPickers)
+                                {
+                                    <button type="button"
+                                            class="data-toolbar-btn icon-only"
+                                            title="Choose export destination"
+                                            aria-label="Choose export destination"
+                                            @onclick="PickServerExportPathAsync"
+                                            disabled="@_busy">
+                                        <i class="bi bi-folder2-open"></i>
+                                    </button>
+                                }
+                            </div>
+                        </div>
                     }
 
                     <div class="import-export-actions wide">
@@ -89,10 +106,23 @@
                         <span>External table</span>
                         <input value="@_externalTableName" @oninput="e => _externalTableName = e.Value?.ToString() ?? string.Empty" disabled="@_busy" />
                     </label>
-                    <label class="wide">
-                        <span>Archive path</span>
-                        <input value="@_externalArchivePath" @oninput="e => _externalArchivePath = e.Value?.ToString() ?? string.Empty" disabled="@_busy" />
-                    </label>
+                    <div class="import-export-field wide">
+                        <span id="external-archive-path-label">Archive path</span>
+                        <div class="native-path-picker">
+                            <input aria-labelledby="external-archive-path-label" value="@_externalArchivePath" @oninput="e => _externalArchivePath = e.Value?.ToString() ?? string.Empty" disabled="@_busy" />
+                            @if (UseDesktopPickers)
+                            {
+                                <button type="button"
+                                        class="data-toolbar-btn icon-only"
+                                        title="Choose table archive"
+                                        aria-label="Choose table archive"
+                                        @onclick="PickExternalArchivePathAsync"
+                                        disabled="@_busy">
+                                    <i class="bi bi-folder2-open"></i>
+                                </button>
+                            }
+                        </div>
+                    </div>
                     <div class="import-export-actions wide">
                         <button type="button" class="data-toolbar-btn primary" @onclick="RegisterExternalTableAsync" disabled="@(!CanRegisterExternal)">
                             <i class="bi bi-link-45deg"></i> Register
@@ -134,10 +164,23 @@
 
             case ImportExportMode.RestoreTable:
                 <div class="import-export-grid">
-                    <label class="wide">
-                        <span>Archive path</span>
-                        <input value="@_restoreArchivePath" @oninput="e => _restoreArchivePath = e.Value?.ToString() ?? string.Empty" disabled="@_busy" />
-                    </label>
+                    <div class="import-export-field wide">
+                        <span id="restore-archive-path-label">Archive path</span>
+                        <div class="native-path-picker">
+                            <input aria-labelledby="restore-archive-path-label" value="@_restoreArchivePath" @oninput="e => _restoreArchivePath = e.Value?.ToString() ?? string.Empty" disabled="@_busy" />
+                            @if (UseDesktopPickers)
+                            {
+                                <button type="button"
+                                        class="data-toolbar-btn icon-only"
+                                        title="Choose table archive"
+                                        aria-label="Choose table archive"
+                                        @onclick="PickRestoreArchivePathAsync"
+                                        disabled="@_busy">
+                                    <i class="bi bi-folder2-open"></i>
+                                </button>
+                            }
+                        </div>
+                    </div>
                     <label>
                         <span>Target table</span>
                         <input value="@_restoreTableName" @oninput="e => _restoreTableName = e.Value?.ToString() ?? string.Empty" disabled="@_busy" />
@@ -182,6 +225,40 @@
     private bool CanRestore => !_busy && !string.IsNullOrWhiteSpace(_restoreArchivePath);
     private ICSharpDbClient ActiveClient => ClientOverride ?? DbClient;
     private ITableImportExportService ActiveImportExportService => ImportExportServiceOverride ?? ImportExportService;
+    private bool UseDesktopPickers => Configuration.GetValue<bool>("CSharpDB:DesktopShell");
+
+    private async Task PickServerExportPathAsync()
+    {
+        string? path = await PickTableArchivePathAsync("saveFile", "Choose Table Export Destination", _serverPath);
+        if (!string.IsNullOrWhiteSpace(path))
+            _serverPath = path;
+    }
+
+    private async Task PickExternalArchivePathAsync()
+    {
+        string? path = await PickTableArchivePathAsync("openFile", "Choose External Table Archive", _externalArchivePath);
+        if (!string.IsNullOrWhiteSpace(path))
+            _externalArchivePath = path;
+    }
+
+    private async Task PickRestoreArchivePathAsync()
+    {
+        string? path = await PickTableArchivePathAsync("openFile", "Choose Table Archive to Restore", _restoreArchivePath);
+        if (!string.IsNullOrWhiteSpace(path))
+            _restoreArchivePath = path;
+    }
+
+    private Task<string?> PickTableArchivePathAsync(string kind, string title, string path)
+        => JS.InvokeAsync<string?>("desktopShellInterop.pickPath", new
+        {
+            kind,
+            title,
+            filter = "CSharpDB table archives (*.csdbtable)|*.csdbtable|All files (*.*)|*.*",
+            defaultExt = ".csdbtable",
+            path,
+            checkFileExists = kind == "openFile",
+            overwritePrompt = kind == "saveFile",
+        }).AsTask();
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/CSharpDB.Admin/Components/Layout/TitleBar.razor
+++ b/src/CSharpDB.Admin/Components/Layout/TitleBar.razor
@@ -5,6 +5,8 @@
 @inject DatabaseChangeService Changes
 @inject ModalService Modal
 @inject ToastService Toast
+@inject IConfiguration Configuration
+@inject IJSRuntime JS
 @implements IDisposable
 
 <div class="titlebar">
@@ -109,6 +111,9 @@
 
     private async Task OpenDatabase()
     {
+        if (await TryOpenDatabaseInDesktopShellAsync())
+            return;
+
         var path = await Modal.PromptAsync(
             "Open Database",
             "Enter the path to the database file:",
@@ -128,6 +133,23 @@
         catch (Exception ex)
         {
             Toast.Error($"Failed to open database: {ex.Message}");
+        }
+    }
+
+    private async Task<bool> TryOpenDatabaseInDesktopShellAsync()
+    {
+        if (!Configuration.GetValue<bool>("CSharpDB:DesktopShell"))
+            return false;
+
+        try
+        {
+            return await JS.InvokeAsync<bool>("desktopShellInterop.openDatabase");
+        }
+        catch (JSException)
+        {
+            // A desktop-configured Admin host may also be opened in a normal browser.
+            // In that case, keep the existing path prompt available as a fallback.
+            return false;
         }
     }
 

--- a/src/CSharpDB.Admin/Components/Tabs/CodeModulesTab.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/CodeModulesTab.razor
@@ -1,6 +1,8 @@
 @using CSharpDB.CodeModules
 @inject CSharpDbCodeModuleClient CodeModules
 @inject ToastService Toast
+@inject IConfiguration Configuration
+@inject IJSRuntime JS
 
 <div class="data-tab code-modules-tab">
     <div class="data-toolbar">
@@ -32,10 +34,22 @@
         </div>
 
         <div class="data-toolbar-group">
-            <input class="query-name-input"
-                   value="@_workspacePath"
-                   @onchange="e => _workspacePath = e.Value?.ToString() ?? string.Empty"
-                   placeholder="Workspace folder" />
+            <div class="native-path-picker">
+                <input class="query-name-input"
+                       value="@_workspacePath"
+                       @onchange="e => _workspacePath = e.Value?.ToString() ?? string.Empty"
+                       placeholder="Workspace folder" />
+                @if (UseDesktopPickers)
+                {
+                    <button type="button"
+                            class="data-toolbar-btn icon-only"
+                            title="Choose workspace folder"
+                            aria-label="Choose workspace folder"
+                            @onclick="PickWorkspaceFolderAsync">
+                        <i class="bi bi-folder2-open"></i>
+                    </button>
+                }
+            </div>
         </div>
 
         <div class="data-toolbar-group">
@@ -173,11 +187,25 @@
     private string _workspacePath = string.Empty;
 
     private bool CanTrust => _lastBuild?.Succeeded == true && _trustState?.IsTrusted != true;
+    private bool UseDesktopPickers => Configuration.GetValue<bool>("CSharpDB:DesktopShell");
 
     protected override async Task OnInitializedAsync()
     {
         _workspacePath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         await RefreshAsync();
+    }
+
+    private async Task PickWorkspaceFolderAsync()
+    {
+        string? path = await JS.InvokeAsync<string?>("desktopShellInterop.pickPath", new
+        {
+            kind = "folder",
+            title = "Choose Code Modules Workspace",
+            path = GetWorkspacePath(),
+        });
+
+        if (!string.IsNullOrWhiteSpace(path))
+            _workspacePath = path;
     }
 
     private async Task RefreshAsync()

--- a/src/CSharpDB.Admin/Components/Tabs/CompareDeployTab.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/CompareDeployTab.razor
@@ -4,6 +4,8 @@
 @inject DatabaseChangeService Changes
 @inject ToastService Toast
 @inject ModalService Modal
+@inject IConfiguration Configuration
+@inject IJSRuntime JS
 
 <div class="compare-deploy-tab">
     <div class="toolbar compare-deploy-toolbar">
@@ -97,11 +99,24 @@
                 </div>
                 <div class="schema-field wide">
                     <label>@(_mode == CompareDeployMode.Drift ? "Baseline path" : "Source path")</label>
-                    <input class="schema-input mono"
-                           value="@_sourcePath"
-                           @oninput="OnSourcePathChanged"
-                           disabled="@(_sourceKind == CompareDeployEndpointKind.CurrentDatabase)"
-                           placeholder="@GetPathPlaceholder(_sourceKind)" />
+                    <div class="native-path-picker">
+                        <input class="schema-input mono"
+                               value="@_sourcePath"
+                               @oninput="OnSourcePathChanged"
+                               disabled="@(_sourceKind == CompareDeployEndpointKind.CurrentDatabase)"
+                               placeholder="@GetPathPlaceholder(_sourceKind)" />
+                        @if (UseDesktopPickers)
+                        {
+                            <button type="button"
+                                    class="toolbar-btn icon-only"
+                                    title="Choose source file"
+                                    aria-label="Choose source file"
+                                    disabled="@(_loading || _sourceKind == CompareDeployEndpointKind.CurrentDatabase)"
+                                    @onclick="() => PickEndpointPathAsync(source: true)">
+                                <i class="bi bi-folder2-open"></i>
+                            </button>
+                        }
+                    </div>
                 </div>
                 <div class="schema-field">
                     <label>@(_mode == CompareDeployMode.Drift ? "Current type" : "Target type")</label>
@@ -113,11 +128,24 @@
                 </div>
                 <div class="schema-field wide">
                     <label>@(_mode == CompareDeployMode.Drift ? "Current path" : "Target path")</label>
-                    <input class="schema-input mono"
-                           value="@_targetPath"
-                           @oninput="OnTargetPathChanged"
-                           disabled="@(_targetKind == CompareDeployEndpointKind.CurrentDatabase)"
-                           placeholder="@GetPathPlaceholder(_targetKind)" />
+                    <div class="native-path-picker">
+                        <input class="schema-input mono"
+                               value="@_targetPath"
+                               @oninput="OnTargetPathChanged"
+                               disabled="@(_targetKind == CompareDeployEndpointKind.CurrentDatabase)"
+                               placeholder="@GetPathPlaceholder(_targetKind)" />
+                        @if (UseDesktopPickers)
+                        {
+                            <button type="button"
+                                    class="toolbar-btn icon-only"
+                                    title="Choose target file"
+                                    aria-label="Choose target file"
+                                    disabled="@(_loading || _targetKind == CompareDeployEndpointKind.CurrentDatabase)"
+                                    @onclick="() => PickEndpointPathAsync(source: false)">
+                                <i class="bi bi-folder2-open"></i>
+                            </button>
+                        }
+                    </div>
                 </div>
             </div>
             <div class="compare-deploy-form-grid">
@@ -393,6 +421,8 @@
         _driftReport is not null
         && !string.Equals(_driftSignature, BuildDriftSignature(), StringComparison.Ordinal);
 
+    private bool UseDesktopPickers => Configuration.GetValue<bool>("CSharpDB:DesktopShell");
+
     private bool CanGenerateSchemaScript =>
         !_loading
         && _schemaReport is not null
@@ -578,6 +608,37 @@
         if (_schemaScriptEndpoint == CompareDeployScriptEndpoint.Target)
             ClearScriptObjects();
         InvalidateScript();
+    }
+
+    private async Task PickEndpointPathAsync(bool source)
+    {
+        CompareDeployEndpointKind kind = source ? _sourceKind : _targetKind;
+        if (kind == CompareDeployEndpointKind.CurrentDatabase)
+            return;
+
+        string filter = kind == CompareDeployEndpointKind.TableArchive
+            ? "CSharpDB table archives (*.csdbtable)|*.csdbtable|All files (*.*)|*.*"
+            : "CSharpDB databases (*.db;*.cdb;*.csdb)|*.db;*.cdb;*.csdb|All files (*.*)|*.*";
+        string defaultExt = kind == CompareDeployEndpointKind.TableArchive ? ".csdbtable" : ".db";
+        string currentPath = source ? _sourcePath : _targetPath;
+        string? path = await JS.InvokeAsync<string?>("desktopShellInterop.pickPath", new
+        {
+            kind = "openFile",
+            title = source ? "Choose Compare Source" : "Choose Compare Target",
+            filter,
+            defaultExt,
+            path = currentPath,
+            checkFileExists = true,
+        });
+
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        var args = new ChangeEventArgs { Value = path };
+        if (source)
+            OnSourcePathChanged(args);
+        else
+            OnTargetPathChanged(args);
     }
 
     private async Task OnTableChanged(ChangeEventArgs e)

--- a/src/CSharpDB.Admin/Components/Tabs/PipelineDesigner.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/PipelineDesigner.razor
@@ -4,6 +4,8 @@
 @using PrimitiveDbType = CSharpDB.Primitives.DbType
 @inject ICSharpDbClient DbClient
 @inject IWebHostEnvironment HostEnvironment
+@inject IConfiguration Configuration
+@inject IJSRuntime JS
 
 <div class="pipeline-designer-shell">
     <aside class="pipeline-designer-toolbox">
@@ -224,10 +226,22 @@
                         {
                             <div class="schema-field">
                                 <label>Path</label>
-                                <input class="schema-input mono"
-                                       @bind="_state.Source.Path"
-                                       @bind:event="oninput"
-                                       @bind:after="OnSourcePathChangedAsync" />
+                                <div class="native-path-picker">
+                                    <input class="schema-input mono"
+                                           @bind="_state.Source.Path"
+                                           @bind:event="oninput"
+                                           @bind:after="OnSourcePathChangedAsync" />
+                                    @if (UseDesktopPickers)
+                                    {
+                                        <button type="button"
+                                                class="toolbar-btn icon-only"
+                                                title="Choose source file"
+                                                aria-label="Choose source file"
+                                                @onclick="PickSourcePathAsync">
+                                            <i class="bi bi-folder2-open"></i>
+                                        </button>
+                                    }
+                                </div>
                             </div>
                         }
                         @if (_state.Source.Kind is PipelineSourceKind.CSharpDbTable)
@@ -531,10 +545,22 @@
                         {
                             <div class="schema-field">
                                 <label>Path</label>
-                                <input class="schema-input mono"
-                                       @bind="_state.Destination.Path"
-                                       @bind:event="oninput"
-                                       @bind:after="PublishPackageAsync" />
+                                <div class="native-path-picker">
+                                    <input class="schema-input mono"
+                                           @bind="_state.Destination.Path"
+                                           @bind:event="oninput"
+                                           @bind:after="PublishPackageAsync" />
+                                    @if (UseDesktopPickers)
+                                    {
+                                        <button type="button"
+                                                class="toolbar-btn icon-only"
+                                                title="Choose destination file"
+                                                aria-label="Choose destination file"
+                                                @onclick="PickDestinationPathAsync">
+                                            <i class="bi bi-folder2-open"></i>
+                                        </button>
+                                    }
+                                </div>
                             </div>
                         }
                         @if (_state.Destination.Kind is PipelineDestinationKind.CSharpDbTable)
@@ -696,6 +722,7 @@
             : null;
 
     private ICSharpDbClient ActiveClient => ClientOverride ?? DbClient;
+    private bool UseDesktopPickers => Configuration.GetValue<bool>("CSharpDB:DesktopShell");
 
     protected override async Task OnInitializedAsync()
     {
@@ -913,6 +940,52 @@
         await RefreshSourceColumnsAsync();
         await PublishPackageAsync();
     }
+
+    private async Task PickSourcePathAsync()
+    {
+        (string filter, string defaultExt) = GetPipelineFilePickerConfig(_state.Source.Kind == PipelineSourceKind.CsvFile);
+        string? path = await JS.InvokeAsync<string?>("desktopShellInterop.pickPath", new
+        {
+            kind = "openFile",
+            title = "Choose Pipeline Source",
+            filter,
+            defaultExt,
+            path = _state.Source.Path,
+            checkFileExists = true,
+        });
+
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        _state.Source.Path = path;
+        await OnSourcePathChangedAsync();
+    }
+
+    private async Task PickDestinationPathAsync()
+    {
+        (string filter, string defaultExt) = GetPipelineFilePickerConfig(_state.Destination.Kind == PipelineDestinationKind.CsvFile);
+        string? path = await JS.InvokeAsync<string?>("desktopShellInterop.pickPath", new
+        {
+            kind = "saveFile",
+            title = "Choose Pipeline Destination",
+            filter,
+            defaultExt,
+            path = _state.Destination.Path,
+            checkFileExists = false,
+            overwritePrompt = true,
+        });
+
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        _state.Destination.Path = path;
+        await PublishPackageAsync();
+    }
+
+    private static (string Filter, string DefaultExt) GetPipelineFilePickerConfig(bool csv)
+        => csv
+            ? ("CSV files (*.csv)|*.csv|All files (*.*)|*.*", ".csv")
+            : ("JSON files (*.json)|*.json|All files (*.*)|*.*", ".json");
 
     private async Task OnCsvHeaderSettingsChangedAsync()
     {

--- a/src/CSharpDB.Admin/Components/Tabs/StorageTab.razor
+++ b/src/CSharpDB.Admin/Components/Tabs/StorageTab.razor
@@ -6,6 +6,8 @@
 @inject ICSharpDbClient DbClient
 @inject ToastService Toast
 @inject DatabaseChangeService Changes
+@inject IConfiguration Configuration
+@inject IJSRuntime JS
 
 <div class="storage-tab">
     <div class="toolbar">
@@ -207,11 +209,25 @@
                     <p class="schema-empty">Paths are resolved on the connected host. For HTTP or gRPC connections, choose server-local paths.</p>
 
                     <div class="storage-action-row">
-                        <input class="storage-input mono storage-path-input"
-                               type="text"
-                               @bind="_backupPath"
-                               placeholder="Backup destination path"
-                               disabled="@_maintenanceBusy" />
+                        <div class="native-path-picker storage-native-path-picker">
+                            <input class="storage-input mono storage-path-input"
+                                   type="text"
+                                   @bind="_backupPath"
+                                   placeholder="Backup destination path"
+                                   disabled="@_maintenanceBusy" />
+
+                            @if (UseDesktopPickers)
+                            {
+                                <button type="button"
+                                        class="toolbar-btn icon-only"
+                                        title="Choose backup destination"
+                                        aria-label="Choose backup destination"
+                                        @onclick="PickBackupPathAsync"
+                                        disabled="@_maintenanceBusy">
+                                    <i class="bi bi-folder2-open"></i>
+                                </button>
+                            }
+                        </div>
 
                         <label class="storage-check">
                             <input type="checkbox" @bind="_backupWithManifest" disabled="@_maintenanceBusy" />
@@ -224,11 +240,25 @@
                     </div>
 
                     <div class="storage-action-row">
-                        <input class="storage-input mono storage-path-input"
-                               type="text"
-                               @bind="_restoreSourcePath"
-                               placeholder="Restore source path"
-                               disabled="@_maintenanceBusy" />
+                        <div class="native-path-picker storage-native-path-picker">
+                            <input class="storage-input mono storage-path-input"
+                                   type="text"
+                                   @bind="_restoreSourcePath"
+                                   placeholder="Restore source path"
+                                   disabled="@_maintenanceBusy" />
+
+                            @if (UseDesktopPickers)
+                            {
+                                <button type="button"
+                                        class="toolbar-btn icon-only"
+                                        title="Choose restore source"
+                                        aria-label="Choose restore source"
+                                        @onclick="PickRestorePathAsync"
+                                        disabled="@_maintenanceBusy">
+                                    <i class="bi bi-folder2-open"></i>
+                                </button>
+                            }
+                        </div>
 
                         <button class="toolbar-btn" @onclick="ValidateRestoreAsync" disabled="@(_maintenanceBusy || string.IsNullOrWhiteSpace(_restoreSourcePath))">
                             <i class="bi bi-shield-check"></i> Validate
@@ -261,11 +291,25 @@
                               placeholder='{"validateOnly":true,"violationSampleLimit":100,"constraints":[{"tableName":"orders","columnName":"customer_id","referencedTableName":"customers","referencedColumnName":"id","onDelete":"Restrict"}]}'></textarea>
 
                     <div class="storage-action-row">
-                        <input class="storage-input mono storage-path-input"
-                               type="text"
-                               @bind="_foreignKeyMigrationBackupPath"
-                               placeholder="Optional backup destination path"
-                               disabled="@_maintenanceBusy" />
+                        <div class="native-path-picker storage-native-path-picker">
+                            <input class="storage-input mono storage-path-input"
+                                   type="text"
+                                   @bind="_foreignKeyMigrationBackupPath"
+                                   placeholder="Optional backup destination path"
+                                   disabled="@_maintenanceBusy" />
+
+                            @if (UseDesktopPickers)
+                            {
+                                <button type="button"
+                                        class="toolbar-btn icon-only"
+                                        title="Choose migration backup destination"
+                                        aria-label="Choose migration backup destination"
+                                        @onclick="PickForeignKeyMigrationBackupPathAsync"
+                                        disabled="@_maintenanceBusy">
+                                    <i class="bi bi-folder2-open"></i>
+                                </button>
+                            }
+                        </div>
 
                         <button class="toolbar-btn" @onclick="ValidateForeignKeyMigrationAsync" disabled="@(_maintenanceBusy || string.IsNullOrWhiteSpace(_foreignKeyMigrationSpecJson))">
                             <i class="bi bi-shield-check"></i> Validate
@@ -536,6 +580,7 @@
     private bool _loading;
     private bool _loadingPage;
     private bool _maintenanceBusy;
+    private bool UseDesktopPickers => Configuration.GetValue<bool>("CSharpDB:DesktopShell");
     private string _pageIdText = "0";
     private bool _includeHex;
     private ReindexScope _reindexScope = ReindexScope.All;
@@ -929,6 +974,78 @@
             ReindexScope.All => null,
             _ => _reindexName,
         };
+    }
+
+    private async Task PickBackupPathAsync()
+    {
+        string? path = await PickDatabasePathAsync(
+            "saveFile",
+            "Choose Database Backup Destination",
+            _backupPath,
+            checkFileExists: false,
+            overwritePrompt: true);
+        if (!string.IsNullOrWhiteSpace(path))
+            _backupPath = path;
+    }
+
+    private async Task PickRestorePathAsync()
+    {
+        string? currentDatabasePath = _dbReport?.DatabasePath ?? DbClient.DataSource;
+        string? path = await PickDatabasePathAsync(
+            "openFile",
+            "Choose Database Restore Source",
+            _restoreSourcePath,
+            checkFileExists: true,
+            overwritePrompt: false,
+            initialDirectory: TryGetDirectoryName(currentDatabasePath));
+        if (!string.IsNullOrWhiteSpace(path))
+            _restoreSourcePath = path;
+    }
+
+    private async Task PickForeignKeyMigrationBackupPathAsync()
+    {
+        string? path = await PickDatabasePathAsync(
+            "saveFile",
+            "Choose Migration Backup Destination",
+            _foreignKeyMigrationBackupPath ?? _backupPath,
+            checkFileExists: false,
+            overwritePrompt: true);
+        if (!string.IsNullOrWhiteSpace(path))
+            _foreignKeyMigrationBackupPath = path;
+    }
+
+    private Task<string?> PickDatabasePathAsync(
+        string kind,
+        string title,
+        string? path,
+        bool checkFileExists,
+        bool overwritePrompt,
+        string? initialDirectory = null)
+        => JS.InvokeAsync<string?>("desktopShellInterop.pickPath", new
+        {
+            kind,
+            title,
+            filter = "CSharpDB databases (*.db;*.cdb;*.csdb)|*.db;*.cdb;*.csdb|All files (*.*)|*.*",
+            defaultExt = ".db",
+            path,
+            initialDirectory,
+            checkFileExists,
+            overwritePrompt,
+        }).AsTask();
+
+    private static string? TryGetDirectoryName(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        try
+        {
+            return Path.GetDirectoryName(Path.GetFullPath(path));
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private void EnsureBackupRestorePaths()

--- a/src/CSharpDB.Admin/wwwroot/css/app.css
+++ b/src/CSharpDB.Admin/wwwroot/css/app.css
@@ -2766,6 +2766,32 @@ body {
     gap: 8px;
 }
 
+.native-path-picker {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: center;
+    min-width: 0;
+}
+
+.native-path-picker > .toolbar-btn.icon-only,
+.native-path-picker > .data-toolbar-btn.icon-only {
+    width: 36px;
+    min-width: 36px;
+    height: 36px;
+    padding: 0;
+    justify-content: center;
+}
+
+.storage-native-path-picker {
+    flex: 1 1 400px;
+}
+
+.storage-native-path-picker > .storage-path-input {
+    width: 100%;
+    min-width: 0;
+}
+
 .pipeline-table-chip-row,
 .pipeline-schema-preview-columns {
     display: flex;

--- a/src/CSharpDB.Admin/wwwroot/css/app.css
+++ b/src/CSharpDB.Admin/wwwroot/css/app.css
@@ -2768,10 +2768,18 @@ body {
 
 .native-path-picker {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     gap: 8px;
     align-items: center;
     min-width: 0;
+}
+
+html.desktop-shell-bridge .native-path-picker {
+    grid-template-columns: minmax(0, 1fr) auto;
+}
+
+html:not(.desktop-shell-bridge) .native-path-picker > button {
+    display: none;
 }
 
 .native-path-picker > .toolbar-btn.icon-only,

--- a/src/CSharpDB.Admin/wwwroot/js/interop.js
+++ b/src/CSharpDB.Admin/wwwroot/js/interop.js
@@ -28,6 +28,7 @@ window.clipboardInterop = {
 window.desktopShellInterop = (() => {
     const requestType = 'desktop-shell-dialog-request';
     const resultType = 'desktop-shell-dialog-result';
+    const bridgeClassName = 'desktop-shell-bridge';
     const pending = new Map();
     let fallbackRequestId = 0;
     let subscribedBridge = null;
@@ -40,6 +41,14 @@ window.desktopShellInterop = (() => {
             ? bridge
             : null;
     };
+
+    const syncBridgeAvailability = () => {
+        const available = getBridge() !== null;
+        document.documentElement.classList.toggle(bridgeClassName, available);
+        return available;
+    };
+
+    syncBridgeAvailability();
 
     const onMessage = (event) => {
         const message = event?.data;
@@ -125,7 +134,7 @@ window.desktopShellInterop = (() => {
     };
 
     const pickPath = (options) => {
-        if (!getBridge()) return Promise.resolve(null);
+        if (!syncBridgeAvailability()) return Promise.resolve(null);
 
         const kind = options?.kind;
         const dialogs = {
@@ -144,9 +153,9 @@ window.desktopShellInterop = (() => {
     };
 
     return {
-        isAvailable: () => getBridge() !== null,
+        isAvailable: syncBridgeAvailability,
         openDatabase: () => {
-            if (!getBridge()) return false;
+            if (!syncBridgeAvailability()) return false;
 
             // Opening a database reloads the WebView after the host switches its
             // connection. Report bridge acceptance synchronously so that reload is

--- a/src/CSharpDB.Admin/wwwroot/js/interop.js
+++ b/src/CSharpDB.Admin/wwwroot/js/interop.js
@@ -25,6 +25,141 @@ window.clipboardInterop = {
     writeText: (text) => navigator.clipboard.writeText(text || '')
 };
 
+window.desktopShellInterop = (() => {
+    const requestType = 'desktop-shell-dialog-request';
+    const resultType = 'desktop-shell-dialog-result';
+    const pending = new Map();
+    let fallbackRequestId = 0;
+    let subscribedBridge = null;
+
+    const getBridge = () => {
+        const bridge = window.chrome?.webview;
+        return bridge &&
+            typeof bridge.postMessage === 'function' &&
+            typeof bridge.addEventListener === 'function'
+            ? bridge
+            : null;
+    };
+
+    const onMessage = (event) => {
+        const message = event?.data;
+        if (!message ||
+            typeof message !== 'object' ||
+            message.type !== resultType ||
+            typeof message.requestId !== 'string') {
+            return;
+        }
+
+        const request = pending.get(message.requestId);
+        if (!request) return;
+
+        pending.delete(message.requestId);
+        if (typeof message.error === 'string' && message.error.length > 0) {
+            request.reject(new Error(message.error));
+            return;
+        }
+
+        request.resolve(message);
+    };
+
+    const ensureBridge = () => {
+        const bridge = getBridge();
+        if (!bridge) return null;
+
+        if (subscribedBridge !== bridge) {
+            if (subscribedBridge && typeof subscribedBridge.removeEventListener === 'function') {
+                subscribedBridge.removeEventListener('message', onMessage);
+            }
+            bridge.addEventListener('message', onMessage);
+            subscribedBridge = bridge;
+        }
+
+        return bridge;
+    };
+
+    const createRequestId = () => {
+        if (typeof window.crypto?.randomUUID === 'function') {
+            return window.crypto.randomUUID();
+        }
+
+        fallbackRequestId += 1;
+        return `${Date.now()}-${fallbackRequestId}`;
+    };
+
+    const requestDialog = (dialog, options) => new Promise((resolve, reject) => {
+        const bridge = ensureBridge();
+        if (!bridge) {
+            reject(new Error('The native desktop dialog bridge is not available.'));
+            return;
+        }
+
+        const requestId = createRequestId();
+        pending.set(requestId, { resolve, reject });
+
+        try {
+            bridge.postMessage({
+                type: requestType,
+                requestId,
+                dialog,
+                options: options && typeof options === 'object' && !Array.isArray(options)
+                    ? options
+                    : {}
+            });
+        } catch (error) {
+            pending.delete(requestId);
+            reject(error instanceof Error ? error : new Error(String(error)));
+        }
+    });
+
+    const selectPath = async (dialog, options) => {
+        try {
+            const result = await requestDialog(dialog, options);
+            return result.canceled === true ? null : (typeof result.path === 'string' ? result.path : null);
+        } catch (error) {
+            // Native picker failures should not escape a Blazor event callback and
+            // tear down the interactive circuit. Keep the editable path field as
+            // the fallback and leave a diagnostic in the WebView console.
+            console.error('Native path picker failed.', error);
+            return null;
+        }
+    };
+
+    const pickPath = (options) => {
+        if (!getBridge()) return Promise.resolve(null);
+
+        const kind = options?.kind;
+        const dialogs = {
+            openFile: 'open-file',
+            saveFile: 'save-file',
+            folder: 'open-folder'
+        };
+        const dialog = Object.prototype.hasOwnProperty.call(dialogs, kind)
+            ? dialogs[kind]
+            : null;
+        if (!dialog) {
+            return Promise.reject(new Error(`Unsupported native path picker kind '${kind ?? ''}'.`));
+        }
+
+        return selectPath(dialog, options);
+    };
+
+    return {
+        isAvailable: () => getBridge() !== null,
+        openDatabase: () => {
+            if (!getBridge()) return false;
+
+            // Opening a database reloads the WebView after the host switches its
+            // connection. Report bridge acceptance synchronously so that reload is
+            // not part of the JavaScript interop result.
+            requestDialog('open-database', {}).catch((error) => {
+                console.error('Native database dialog failed.', error);
+            });
+            return true;
+        },
+        pickPath
+    };
+})();
+
 window.contextMenuInterop = {
     position: (menu, requestedX, requestedY) => {
         if (!menu) return;

--- a/src/CSharpDB.Engine/Collection.cs
+++ b/src/CSharpDB.Engine/Collection.cs
@@ -1457,22 +1457,13 @@ public sealed class Collection<
 
     private async ValueTask ExecuteImplicitAutoCommitCoreAsync(Func<ValueTask> action, CancellationToken ct)
     {
-        PagerCommitResult commit = PagerCommitResult.Completed;
         IDisposable? writeScope = null;
         try
         {
             writeScope = await _enterWriteScopeAsync(ct);
             await _pager.BeginTransactionAsync(ct);
             await action();
-            commit = await _beginImplicitCommitAsync(_catalogTableName, ct);
-        }
-        catch
-        {
-            await RecoverCatalogStateAfterFailedCommitAsync();
-            throw;
-        }
-        try
-        {
+            PagerCommitResult commit = await _beginImplicitCommitAsync(_catalogTableName, ct);
             await commit.WaitAsync();
         }
         catch

--- a/src/CSharpDB.Storage.Diagnostics/Internal/InspectorEngine.cs
+++ b/src/CSharpDB.Storage.Diagnostics/Internal/InspectorEngine.cs
@@ -9,6 +9,8 @@ internal static class InspectorEngine
     internal const long TriggerCatalogSentinel = long.MaxValue - 2;
     internal const long TableStatsCatalogSentinel = long.MaxValue - 3;
     internal const long ColumnStatsCatalogSentinel = long.MaxValue - 4;
+    private const int BTreeOverflowReferenceLength = 16;
+    private static ReadOnlySpan<byte> BTreeOverflowReferenceMagic => "CSDBBOV1"u8;
 
     internal sealed class ParsedLeafCell
     {
@@ -16,6 +18,7 @@ internal static class InspectorEngine
         public ushort CellOffset { get; init; }
         public int HeaderBytes { get; init; }
         public int CellTotalBytes { get; init; }
+        public bool IsOverflowPayload { get; init; }
         public long? Key { get; init; }
         public byte[]? Payload { get; init; }
     }
@@ -39,6 +42,7 @@ internal static class InspectorEngine
         public required ushort CellContentStart { get; init; }
         public required uint RightChildOrNextLeaf { get; init; }
         public required int FreeSpaceBytes { get; init; }
+        public ushort? OverflowChunkLength { get; init; }
 
         public required List<ushort> CellOffsets { get; init; }
         public required List<ParsedLeafCell> LeafCells { get; init; }
@@ -238,6 +242,8 @@ internal static class InspectorEngine
             issues.AddRange(parsed.Issues);
         }
 
+        ValidateOverflowReferences(pages, physicalPageCount, issues);
+
         return new DatabaseSnapshot
         {
             DatabasePath = databasePath,
@@ -317,13 +323,67 @@ internal static class InspectorEngine
         }
 
         byte pageType = pageBytes[baseOffset + PageConstants.PageTypeOffset];
+        if (pageType == PageConstants.PageTypeOverflow)
+        {
+            int nextOffset = baseOffset + PageConstants.OverflowNextOffset;
+            int chunkLengthOffset = baseOffset + PageConstants.OverflowChunkLengthOffset;
+            uint nextPageId = BinaryPrimitives.ReadUInt32LittleEndian(
+                pageBytes.AsSpan(nextOffset, sizeof(uint)));
+            ushort chunkLength = BinaryPrimitives.ReadUInt16LittleEndian(
+                pageBytes.AsSpan(chunkLengthOffset, sizeof(ushort)));
+            int maxChunkLength = PageConstants.PageSize -
+                baseOffset -
+                PageConstants.OverflowPageHeaderSize;
+
+            if (chunkLength == 0 || chunkLength > maxChunkLength)
+            {
+                issues.Add(new IntegrityIssue
+                {
+                    Code = "OVERFLOW_CHUNK_LENGTH_INVALID",
+                    Severity = InspectSeverity.Error,
+                    Message = $"Overflow page {pageId} has invalid chunk length {chunkLength}.",
+                    PageId = pageId,
+                    Offset = chunkLengthOffset,
+                });
+            }
+
+            if (nextPageId == pageId)
+            {
+                issues.Add(new IntegrityIssue
+                {
+                    Code = "OVERFLOW_SELF_REFERENCE",
+                    Severity = InspectSeverity.Error,
+                    Message = $"Overflow page {pageId} points to itself.",
+                    PageId = pageId,
+                    Offset = nextOffset,
+                });
+            }
+
+            return new ParsePageResult(
+                new ParsedPage
+                {
+                    PageId = pageId,
+                    BaseOffset = baseOffset,
+                    PageType = pageType,
+                    CellCount = 0,
+                    CellContentStart = checked((ushort)(baseOffset + PageConstants.OverflowPageHeaderSize)),
+                    RightChildOrNextLeaf = nextPageId,
+                    FreeSpaceBytes = Math.Max(0, maxChunkLength - chunkLength),
+                    OverflowChunkLength = chunkLength,
+                    CellOffsets = [],
+                    LeafCells = [],
+                    InteriorCells = [],
+                    ChildPageReferences = nextPageId == PageConstants.NullPageId ? [] : [nextPageId],
+                },
+                issues);
+        }
+
         ushort cellCount = BinaryPrimitives.ReadUInt16LittleEndian(pageBytes.AsSpan(baseOffset + PageConstants.CellCountOffset, 2));
         ushort cellContentStart = BinaryPrimitives.ReadUInt16LittleEndian(pageBytes.AsSpan(baseOffset + PageConstants.FreeSpaceStartOffset, 2));
         uint rightChildOrNextLeaf = BinaryPrimitives.ReadUInt32LittleEndian(pageBytes.AsSpan(baseOffset + PageConstants.RightChildOffset, 4));
 
         if (pageType != PageConstants.PageTypeLeaf &&
-            pageType != PageConstants.PageTypeInterior &&
-            pageType != PageConstants.PageTypeOverflow)
+            pageType != PageConstants.PageTypeInterior)
         {
             if (pageType != PageConstants.PageTypeFreelist)
             {
@@ -439,11 +499,11 @@ internal static class InspectorEngine
             if (cellOffset < baseOffset || cellOffset >= PageConstants.PageSize)
                 continue;
 
-            ulong payloadSize;
+            ulong encodedPayloadSize;
             int headerBytes;
             try
             {
-                payloadSize = Varint.Read(pageBytes.AsSpan(cellOffset), out headerBytes);
+                encodedPayloadSize = Varint.Read(pageBytes.AsSpan(cellOffset), out headerBytes);
             }
             catch
             {
@@ -456,6 +516,22 @@ internal static class InspectorEngine
                     Offset = cellOffset,
                 });
                 continue;
+            }
+
+            bool isOverflowPayload =
+                (encodedPayloadSize & PageConstants.LeafCellOverflowFlag) != 0;
+            ulong payloadSize = encodedPayloadSize & PageConstants.CellPayloadSizeMask;
+
+            if (isOverflowPayload && pageType != PageConstants.PageTypeLeaf)
+            {
+                issues.Add(new IntegrityIssue
+                {
+                    Code = "INTERIOR_CELL_OVERFLOW_FLAG_INVALID",
+                    Severity = InspectSeverity.Error,
+                    Message = $"Interior cell {i} has the leaf overflow-payload flag set.",
+                    PageId = pageId,
+                    Offset = cellOffset,
+                });
             }
 
             long cellTotal = headerBytes + (long)payloadSize;
@@ -540,6 +616,7 @@ internal static class InspectorEngine
                     CellOffset = cellOffset,
                     HeaderBytes = headerBytes,
                     CellTotalBytes = checked((int)cellTotal),
+                    IsOverflowPayload = isOverflowPayload,
                     Key = key,
                     Payload = payload,
                 });
@@ -633,6 +710,154 @@ internal static class InspectorEngine
         };
 
         return new ParsePageResult(parsedPage, issues);
+    }
+
+    private static void ValidateOverflowReferences(
+        IReadOnlyDictionary<uint, ParsedPage> pages,
+        int physicalPageCount,
+        List<IntegrityIssue> issues)
+    {
+        foreach (ParsedPage overflowPage in pages.Values.Where(
+                     static page => page.PageType == PageConstants.PageTypeOverflow))
+        {
+            uint nextPageId = overflowPage.RightChildOrNextLeaf;
+            if (nextPageId != PageConstants.NullPageId && nextPageId >= physicalPageCount)
+            {
+                issues.Add(new IntegrityIssue
+                {
+                    Code = "OVERFLOW_NEXT_PAGE_OOB",
+                    Severity = InspectSeverity.Error,
+                    Message = $"Overflow page {overflowPage.PageId} points outside the database to page {nextPageId}.",
+                    PageId = overflowPage.PageId,
+                    Offset = (long)overflowPage.PageId * PageConstants.PageSize + PageConstants.OverflowNextOffset,
+                });
+            }
+        }
+
+        foreach (ParsedPage leafPage in pages.Values.Where(
+                     static page => page.PageType == PageConstants.PageTypeLeaf))
+        {
+            foreach (ParsedLeafCell cell in leafPage.LeafCells.Where(
+                         static cell => cell.IsOverflowPayload))
+            {
+                if (cell.Payload is null)
+                    continue;
+
+                ReadOnlySpan<byte> reference = cell.Payload;
+                if (reference.Length != BTreeOverflowReferenceLength ||
+                    !reference[..BTreeOverflowReferenceMagic.Length]
+                        .SequenceEqual(BTreeOverflowReferenceMagic))
+                {
+                    issues.Add(new IntegrityIssue
+                    {
+                        Code = "BTREE_OVERFLOW_REFERENCE_INVALID",
+                        Severity = InspectSeverity.Error,
+                        Message = $"Leaf page {leafPage.PageId} cell {cell.CellIndex} has an invalid overflow reference.",
+                        PageId = leafPage.PageId,
+                        Offset = cell.CellOffset,
+                    });
+                    continue;
+                }
+
+                uint firstPageId = BinaryPrimitives.ReadUInt32LittleEndian(reference.Slice(8, sizeof(uint)));
+                int expectedLength = BinaryPrimitives.ReadInt32LittleEndian(reference.Slice(12, sizeof(int)));
+                if (firstPageId == PageConstants.NullPageId || expectedLength <= 0)
+                {
+                    issues.Add(new IntegrityIssue
+                    {
+                        Code = "BTREE_OVERFLOW_REFERENCE_INVALID",
+                        Severity = InspectSeverity.Error,
+                        Message = $"Leaf page {leafPage.PageId} cell {cell.CellIndex} has an invalid overflow page or payload length.",
+                        PageId = leafPage.PageId,
+                        Offset = cell.CellOffset,
+                    });
+                    continue;
+                }
+
+                var visited = new HashSet<uint>();
+                uint pageId = firstPageId;
+                long actualLength = 0;
+                bool reachedEnd = false;
+
+                while (pageId != PageConstants.NullPageId)
+                {
+                    if (pageId >= physicalPageCount)
+                    {
+                        issues.Add(new IntegrityIssue
+                        {
+                            Code = "OVERFLOW_CHAIN_PAGE_OOB",
+                            Severity = InspectSeverity.Error,
+                            Message = $"Overflow reference on leaf page {leafPage.PageId} points outside the database to page {pageId}.",
+                            PageId = leafPage.PageId,
+                            Offset = cell.CellOffset,
+                        });
+                        break;
+                    }
+
+                    if (!visited.Add(pageId))
+                    {
+                        issues.Add(new IntegrityIssue
+                        {
+                            Code = "OVERFLOW_CHAIN_CYCLE",
+                            Severity = InspectSeverity.Error,
+                            Message = $"Overflow reference on leaf page {leafPage.PageId} contains a cycle at page {pageId}.",
+                            PageId = pageId,
+                        });
+                        break;
+                    }
+
+                    if (!pages.TryGetValue(pageId, out ParsedPage? overflowPage))
+                    {
+                        issues.Add(new IntegrityIssue
+                        {
+                            Code = "OVERFLOW_CHAIN_PAGE_MISSING",
+                            Severity = InspectSeverity.Error,
+                            Message = $"Overflow reference on leaf page {leafPage.PageId} is missing page {pageId}.",
+                            PageId = leafPage.PageId,
+                            Offset = cell.CellOffset,
+                        });
+                        break;
+                    }
+
+                    if (overflowPage.PageType != PageConstants.PageTypeOverflow ||
+                        overflowPage.OverflowChunkLength is not ushort chunkLength ||
+                        chunkLength == 0 ||
+                        chunkLength > PageConstants.PageSize - PageConstants.OverflowPageHeaderSize)
+                    {
+                        issues.Add(new IntegrityIssue
+                        {
+                            Code = "OVERFLOW_CHAIN_PAGE_INVALID",
+                            Severity = InspectSeverity.Error,
+                            Message = $"Overflow reference on leaf page {leafPage.PageId} reaches invalid page {pageId}.",
+                            PageId = pageId,
+                        });
+                        break;
+                    }
+
+                    actualLength += chunkLength;
+                    if (actualLength > expectedLength)
+                        break;
+
+                    pageId = overflowPage.RightChildOrNextLeaf;
+                    reachedEnd = pageId == PageConstants.NullPageId;
+                }
+
+                if (reachedEnd && actualLength == expectedLength)
+                    continue;
+
+                if (actualLength != expectedLength)
+                {
+                    issues.Add(new IntegrityIssue
+                    {
+                        Code = "OVERFLOW_CHAIN_LENGTH_MISMATCH",
+                        Severity = InspectSeverity.Error,
+                        Message = $"Overflow reference on leaf page {leafPage.PageId} resolves to {actualLength} bytes; expected {expectedLength}.",
+                        PageId = leafPage.PageId,
+                        Offset = cell.CellOffset,
+                    });
+                }
+            }
+        }
     }
 
     internal static HashSet<uint> WalkBTree(
@@ -795,7 +1020,8 @@ internal static class InspectorEngine
         int version = availableBytes >= 8
             ? BinaryPrimitives.ReadInt32LittleEndian(fileHeader.Slice(PageConstants.VersionOffset, 4))
             : 0;
-        bool versionValid = version == PageConstants.FormatVersion;
+        bool versionValid = version >= PageConstants.MinimumSupportedFormatVersion &&
+                            version <= PageConstants.FormatVersion;
 
         int pageSize = availableBytes >= 12
             ? BinaryPrimitives.ReadInt32LittleEndian(fileHeader.Slice(PageConstants.PageSizeOffset, 4))

--- a/src/CSharpDB.Storage/BTree/BTree.cs
+++ b/src/CSharpDB.Storage/BTree/BTree.cs
@@ -10,7 +10,8 @@ namespace CSharpDB.Storage.BTrees;
 /// <summary>
 /// B+tree keyed by long rowid. Leaf pages store (key, payload). Interior pages store routing keys and child pointers.
 ///
-/// Leaf cell format:   [totalSize:varint] [key:8 bytes] [payload bytes...]
+/// Leaf cell format:   [totalSizeAndFlags:varint] [key:8 bytes] [payload bytes...]
+/// The high flag bit marks payloads that contain an overflow-page reference.
 /// Interior cell format: [totalSize:varint] [leftChild:4 bytes] [key:8 bytes]
 ///
 /// Interior pages also have a "rightmost child" stored in the page header.
@@ -160,7 +161,10 @@ public sealed class BTree
                     {
                         int idx = FindKeyInLeaf(hintSp, key);
                         if (idx < 0) return null;
-                        return ReadLeafPayloadMemory(hintSp, idx);
+                        return await ResolveStoredPayloadAsync(
+                            ReadLeafPayloadMemory(hintSp, idx),
+                            IsLeafPayloadOverflow(hintSp, idx),
+                            ct);
                     }
                 }
 
@@ -191,7 +195,10 @@ public sealed class BTree
 
                     int idx = FindKeyInLeaf(sp, key);
                     if (idx < 0) return null;
-                    return ReadLeafPayloadMemory(sp, idx);
+                    return await ResolveStoredPayloadAsync(
+                        ReadLeafPayloadMemory(sp, idx),
+                        IsLeafPayloadOverflow(sp, idx),
+                        ct);
                 }
 
                 if (populateReadRoutingCache)
@@ -214,7 +221,10 @@ public sealed class BTree
                 {
                     int idx = FindKeyInLeaf(hintSp, key);
                     if (idx < 0) return null;
-                    return ReadLeafPayloadMemory(hintSp, idx);
+                    return await ResolveStoredPayloadAsync(
+                        ReadLeafPayloadMemory(hintSp, idx),
+                        IsLeafPayloadOverflow(hintSp, idx),
+                        ct);
                 }
             }
             // Hint is stale, clear it and fall through to normal traversal
@@ -247,7 +257,10 @@ public sealed class BTree
 
                 int idx = FindKeyInLeaf(sp, key);
                 if (idx < 0) return null;
-                return ReadLeafPayloadMemory(sp, idx);
+                return await ResolveStoredPayloadAsync(
+                    ReadLeafPayloadMemory(sp, idx),
+                    IsLeafPayloadOverflow(sp, idx),
+                    ct);
             }
 
             if (populateReadRoutingCache)
@@ -276,7 +289,10 @@ public sealed class BTree
                     if (idx < 0)
                         return null;
 
-                    return ReadLeafPayloadMemory(sp, idx);
+                    return await ResolveStoredPayloadAsync(
+                        ReadLeafPayloadMemory(sp, idx),
+                        IsLeafPayloadOverflow(sp, idx),
+                        ct);
                 }
 
                 mutablePageId = FindChildPage(sp, key);
@@ -295,10 +311,39 @@ public sealed class BTree
                 if (idx < 0)
                     return null;
 
-                return ReadLeafPayloadMemory(sp, idx);
+                return await ResolveStoredPayloadAsync(
+                    ReadLeafPayloadMemory(sp, idx),
+                    IsLeafPayloadOverflow(sp, idx),
+                    ct);
             }
 
             pageId = FindChildPage(sp, key);
+        }
+    }
+
+    private async ValueTask<bool> ContainsKeyForWriteAsync(long key, CancellationToken ct)
+    {
+        uint pageId = _rootPageId;
+        while (true)
+        {
+            if (_pager.UsesReadOnlyPageViews)
+            {
+                var page = await _pager.GetPageReadAsync(pageId, ct);
+                var sp = new ReadOnlySlottedPage(page.Memory, pageId);
+                if (sp.PageType == PageConstants.PageTypeLeaf)
+                    return FindKeyInLeaf(sp, key) >= 0;
+
+                pageId = FindChildPage(sp, key);
+            }
+            else
+            {
+                var page = await _pager.GetPageAsync(pageId, ct);
+                var sp = new SlottedPage(page, pageId);
+                if (sp.PageType == PageConstants.PageTypeLeaf)
+                    return FindKeyInLeaf(sp, key) >= 0;
+
+                pageId = FindChildPage(sp, key);
+            }
         }
     }
 
@@ -323,7 +368,13 @@ public sealed class BTree
             if (sp.PageType == PageConstants.PageTypeLeaf)
             {
                 int idx = FindKeyInLeaf(sp, key);
-                return idx >= 0 ? ReadLeafPayloadMemory(sp, idx) : null;
+                return idx >= 0
+                    ? await ResolveStoredPayloadAsync(
+                        ReadLeafPayloadMemory(sp, idx),
+                        IsLeafPayloadOverflow(sp, idx),
+                        snapshot,
+                        ct)
+                    : null;
             }
 
             pageId = FindChildPage(sp, key);
@@ -372,6 +423,11 @@ public sealed class BTree
                     {
                         int idx = FindKeyInLeaf(hintSp, key);
                         payload = idx >= 0 ? ReadLeafPayloadMemory(hintSp, idx) : (ReadOnlyMemory<byte>?)null;
+                        if (idx >= 0 && IsLeafPayloadOverflow(hintSp, idx))
+                        {
+                            payload = null;
+                            return false;
+                        }
                         RecordLogicalPointRead(key);
                         return true;
                     }
@@ -406,6 +462,11 @@ public sealed class BTree
 
                     int idx = FindKeyInLeaf(sp, key);
                     payload = idx >= 0 ? ReadLeafPayloadMemory(sp, idx) : (ReadOnlyMemory<byte>?)null;
+                    if (idx >= 0 && IsLeafPayloadOverflow(sp, idx))
+                    {
+                        payload = null;
+                        return false;
+                    }
                     RecordLogicalPointRead(key);
                     return true;
                 }
@@ -430,6 +491,11 @@ public sealed class BTree
                 {
                     int idx = FindKeyInLeaf(hintSp, key);
                     payload = idx >= 0 ? ReadLeafPayloadMemory(hintSp, idx) : (ReadOnlyMemory<byte>?)null;
+                    if (idx >= 0 && IsLeafPayloadOverflow(hintSp, idx))
+                    {
+                        payload = null;
+                        return false;
+                    }
                     RecordLogicalPointRead(key);
                     return true; // cache hit, definitive answer
                 }
@@ -465,6 +531,11 @@ public sealed class BTree
 
                 int idx = FindKeyInLeaf(sp, key);
                 payload = idx >= 0 ? ReadLeafPayloadMemory(sp, idx) : (ReadOnlyMemory<byte>?)null;
+                if (idx >= 0 && IsLeafPayloadOverflow(sp, idx))
+                {
+                    payload = null;
+                    return false;
+                }
                 RecordLogicalPointRead(key);
                 return true; // cache hit, definitive answer
             }
@@ -498,6 +569,11 @@ public sealed class BTree
             {
                 int idx = FindKeyInLeaf(sp, key);
                 payload = idx >= 0 ? ReadLeafPayloadMemory(sp, idx) : (ReadOnlyMemory<byte>?)null;
+                if (idx >= 0 && IsLeafPayloadOverflow(sp, idx))
+                {
+                    payload = null;
+                    return false;
+                }
                 return true;
             }
 
@@ -527,39 +603,77 @@ public sealed class BTree
         ArgumentNullException.ThrowIfNull(traversalPath);
         ArgumentNullException.ThrowIfNull(traversalSet);
 
-        InvalidateReadRoutingCaches();
-        traversalPath.Clear();
-        traversalSet.Clear();
-
-        if (await TryInsertIntoRightEdgeLeafAsync(key, payload, traversalPath, traversalSet, ct))
+        byte[]? newOverflowReference = null;
+        OverflowInstallationState? overflowInstallation = null;
+        try
         {
+            ReadOnlyMemory<byte> storedPayload = payload;
+            bool storedPayloadIsOverflow = false;
+            if (RequiresOverflow(payload.Span))
+            {
+                if (await ContainsKeyForWriteAsync(key, ct))
+                    throw new CSharpDbException(ErrorCode.DuplicateKey, $"Duplicate key: {key}");
+
+                newOverflowReference = await WriteOverflowPayloadAsync(payload, ct);
+                storedPayload = newOverflowReference;
+                storedPayloadIsOverflow = true;
+                overflowInstallation = new OverflowInstallationState();
+            }
+
+            InvalidateReadRoutingCaches();
+            traversalPath.Clear();
+            traversalSet.Clear();
+
+            if (await TryInsertIntoRightEdgeLeafAsync(
+                key,
+                storedPayload,
+                storedPayloadIsOverflow,
+                overflowInstallation,
+                traversalPath,
+                traversalSet,
+                ct))
+            {
+                _cachedEntryCount = null;
+                return;
+            }
+
+            var result = await InsertRecursiveAsync(
+                _rootPageId,
+                key,
+                storedPayload,
+                storedPayloadIsOverflow,
+                overflowInstallation,
+                traversalPath,
+                traversalSet,
+                ct);
+            if (result.Split)
+            {
+                // Root was split — create a new root
+                uint newRootId = await _pager.AllocatePageAsync(ct);
+                var newRoot = await _pager.GetPageAsync(newRootId, ct);
+                var sp = new SlottedPage(newRoot, newRootId);
+                sp.Initialize(PageConstants.PageTypeInterior);
+                sp.RightChildOrNextLeaf = result.NewPageId;
+
+                // Insert single interior cell pointing to old root.
+                // Interior cells are fixed-size (13 bytes), so avoid heap allocation here.
+                Span<byte> rootCell = stackalloc byte[13];
+                WriteInteriorCell(rootCell, _rootPageId, result.SplitKey);
+                sp.InsertCell(0, rootCell);
+                await _pager.MarkDirtyAsync(newRootId, ct);
+
+                _rootPageId = newRootId;
+                _pager.RecordBTreeRootSplit(_logicalResourceName);
+            }
+
             _cachedEntryCount = null;
-            return;
         }
-
-        var result = await InsertRecursiveAsync(_rootPageId, key, payload, traversalPath, traversalSet, ct);
-
-        if (result.Split)
+        catch
         {
-            // Root was split — create a new root
-            uint newRootId = await _pager.AllocatePageAsync(ct);
-            var newRoot = await _pager.GetPageAsync(newRootId, ct);
-            var sp = new SlottedPage(newRoot, newRootId);
-            sp.Initialize(PageConstants.PageTypeInterior);
-            sp.RightChildOrNextLeaf = result.NewPageId;
-
-            // Insert single interior cell pointing to old root.
-            // Interior cells are fixed-size (13 bytes), so avoid heap allocation here.
-            Span<byte> rootCell = stackalloc byte[13];
-            WriteInteriorCell(rootCell, _rootPageId, result.SplitKey);
-            sp.InsertCell(0, rootCell);
-            await _pager.MarkDirtyAsync(newRootId, ct);
-
-            _rootPageId = newRootId;
-            _pager.RecordBTreeRootSplit(_logicalResourceName);
+            if (overflowInstallation?.PayloadInstalled != true && newOverflowReference != null)
+                await SafeReclaimOverflowAsync(newOverflowReference);
+            throw;
         }
-
-        _cachedEntryCount = null;
     }
 
     /// <summary>
@@ -583,31 +697,74 @@ public sealed class BTree
         ArgumentNullException.ThrowIfNull(traversalPath);
         ArgumentNullException.ThrowIfNull(traversalSet);
 
-        InvalidateReadRoutingCaches();
-        traversalPath.Clear();
-        traversalSet.Clear();
-        var result = await ReplaceRecursiveAsync(_rootPageId, key, payload, traversalPath, traversalSet, ct);
-        if (!result.Found)
-            return false;
-
-        if (result.InsertResult.Split)
+        byte[]? newOverflowReference = null;
+        OverflowInstallationState? overflowInstallation = null;
+        try
         {
-            uint newRootId = await _pager.AllocatePageAsync(ct);
-            var newRoot = await _pager.GetPageAsync(newRootId, ct);
-            var sp = new SlottedPage(newRoot, newRootId);
-            sp.Initialize(PageConstants.PageTypeInterior);
-            sp.RightChildOrNextLeaf = result.InsertResult.NewPageId;
+            ReadOnlyMemory<byte> storedPayload = payload;
+            bool storedPayloadIsOverflow = false;
+            if (RequiresOverflow(payload.Span))
+            {
+                if (!await ContainsKeyForWriteAsync(key, ct))
+                    return false;
 
-            Span<byte> rootCell = stackalloc byte[13];
-            WriteInteriorCell(rootCell, _rootPageId, result.InsertResult.SplitKey);
-            sp.InsertCell(0, rootCell);
-            await _pager.MarkDirtyAsync(newRootId, ct);
+                newOverflowReference = await WriteOverflowPayloadAsync(payload, ct);
+                storedPayload = newOverflowReference;
+                storedPayloadIsOverflow = true;
+                overflowInstallation = new OverflowInstallationState();
+            }
 
-            _rootPageId = newRootId;
-            _pager.RecordBTreeRootSplit(_logicalResourceName);
+            InvalidateReadRoutingCaches();
+            traversalPath.Clear();
+            traversalSet.Clear();
+            var result = await ReplaceRecursiveAsync(
+                _rootPageId,
+                key,
+                storedPayload,
+                storedPayloadIsOverflow,
+                overflowInstallation,
+                traversalPath,
+                traversalSet,
+                ct);
+            if (!result.Found)
+            {
+                if (newOverflowReference != null)
+                {
+                    await ReclaimOverflowAsync(newOverflowReference, CancellationToken.None);
+                    newOverflowReference = null;
+                }
+
+                return false;
+            }
+
+            if (result.InsertResult.Split)
+            {
+                uint newRootId = await _pager.AllocatePageAsync(ct);
+                var newRoot = await _pager.GetPageAsync(newRootId, ct);
+                var sp = new SlottedPage(newRoot, newRootId);
+                sp.Initialize(PageConstants.PageTypeInterior);
+                sp.RightChildOrNextLeaf = result.InsertResult.NewPageId;
+
+                Span<byte> rootCell = stackalloc byte[13];
+                WriteInteriorCell(rootCell, _rootPageId, result.InsertResult.SplitKey);
+                sp.InsertCell(0, rootCell);
+                await _pager.MarkDirtyAsync(newRootId, ct);
+
+                _rootPageId = newRootId;
+                _pager.RecordBTreeRootSplit(_logicalResourceName);
+            }
+
+            if (result.PreviousOverflowReference != null)
+                await ReclaimOverflowAsync(result.PreviousOverflowReference, ct);
+
+            return true;
         }
-
-        return true;
+        catch
+        {
+            if (overflowInstallation?.PayloadInstalled != true && newOverflowReference != null)
+                await SafeReclaimOverflowAsync(newOverflowReference);
+            throw;
+        }
     }
 
     /// <summary>
@@ -622,6 +779,8 @@ public sealed class BTree
         if (deleted)
         {
             await CollapseRootIfNeededAsync(ct);
+            if (result.DeletedOverflowReference != null)
+                await ReclaimOverflowAsync(result.DeletedOverflowReference, ct);
             _cachedEntryCount = null;
         }
         return deleted;
@@ -820,6 +979,8 @@ public sealed class BTree
     private async ValueTask<bool> TryInsertIntoRightEdgeLeafAsync(
         long key,
         ReadOnlyMemory<byte> payload,
+        bool payloadIsOverflow,
+        OverflowInstallationState? overflowInstallation,
         List<uint> traversalPath,
         HashSet<uint> traversalSet,
         CancellationToken ct)
@@ -844,7 +1005,15 @@ public sealed class BTree
                 return false;
         }
 
-        if (!await TryInsertIntoLeafWithoutSplitAsync(_rightEdgeLeafPageId, sp, sp.CellCount, key, payload, ct))
+        if (!await TryInsertIntoLeafWithoutSplitAsync(
+            _rightEdgeLeafPageId,
+            sp,
+            sp.CellCount,
+            key,
+            payload,
+            payloadIsOverflow,
+            overflowInstallation,
+            ct))
             return false;
 
         await RecordExplicitRightEdgeLeafInsertTraversalAsync(
@@ -909,17 +1078,20 @@ public sealed class BTree
         int insertIdx,
         long key,
         ReadOnlyMemory<byte> payload,
+        bool payloadIsOverflow,
+        OverflowInstallationState? overflowInstallation,
         CancellationToken ct)
     {
-        int leafCellLength = GetLeafCellLength(payload.Length);
+        int leafCellLength = GetLeafCellLength(payload.Length, payloadIsOverflow);
         if (leafCellLength <= MaxStackLeafCellBytes)
         {
             Span<byte> stackCell = stackalloc byte[leafCellLength];
-            WriteLeafCell(stackCell, key, payload.Span);
+            WriteLeafCell(stackCell, key, payload.Span, payloadIsOverflow);
 
             if (!sp.InsertCell(insertIdx, stackCell))
                 return false;
 
+            overflowInstallation?.MarkInstalled();
             await _pager.MarkDirtyAsync(pageId, ct);
             return true;
         }
@@ -928,10 +1100,11 @@ public sealed class BTree
         try
         {
             var pooledCellSpan = pooledCell.AsSpan(0, leafCellLength);
-            WriteLeafCell(pooledCellSpan, key, payload.Span);
+            WriteLeafCell(pooledCellSpan, key, payload.Span, payloadIsOverflow);
             if (!sp.InsertCell(insertIdx, pooledCellSpan))
                 return false;
 
+            overflowInstallation?.MarkInstalled();
             await _pager.MarkDirtyAsync(pageId, ct);
             return true;
         }
@@ -1006,22 +1179,36 @@ public sealed class BTree
         public uint NewPageId; // the new right sibling
     }
 
+    private sealed class OverflowInstallationState
+    {
+        public bool PayloadInstalled { get; private set; }
+
+        public void MarkInstalled() => PayloadInstalled = true;
+    }
+
     private readonly struct ReplaceResult
     {
-        public ReplaceResult(bool found, InsertResult insertResult)
+        public ReplaceResult(
+            bool found,
+            InsertResult insertResult,
+            byte[]? previousOverflowReference)
         {
             Found = found;
             InsertResult = insertResult;
+            PreviousOverflowReference = previousOverflowReference;
         }
 
         public bool Found { get; }
         public InsertResult InsertResult { get; }
+        public byte[]? PreviousOverflowReference { get; }
     }
 
     private async ValueTask<InsertResult> InsertRecursiveAsync(
         uint pageId,
         long key,
         ReadOnlyMemory<byte> payload,
+        bool payloadIsOverflow,
+        OverflowInstallationState? overflowInstallation,
         List<uint> traversalPath,
         HashSet<uint> traversalSet,
         CancellationToken ct)
@@ -1034,14 +1221,30 @@ public sealed class BTree
             if (sp.PageType == PageConstants.PageTypeLeaf)
             {
                 _pager.RecordExplicitLeafInsertTraversal(_rootPageId, traversalPath);
-                return await InsertIntoLeafAsync(pageId, page, sp, key, payload, ct);
+                return await InsertIntoLeafAsync(
+                    pageId,
+                    page,
+                    sp,
+                    key,
+                    payload,
+                    payloadIsOverflow,
+                    overflowInstallation,
+                    ct);
             }
             else
             {
                 // Find child to descend into
                 uint childPageId = FindChildPageWithIndex(sp, key, out int childIdx);
 
-                var childResult = await InsertRecursiveAsync(childPageId, key, payload, traversalPath, traversalSet, ct);
+                var childResult = await InsertRecursiveAsync(
+                    childPageId,
+                    key,
+                    payload,
+                    payloadIsOverflow,
+                    overflowInstallation,
+                    traversalPath,
+                    traversalSet,
+                    ct);
                 if (!childResult.Split)
                     return childResult;
 
@@ -1059,6 +1262,8 @@ public sealed class BTree
         uint pageId,
         long key,
         ReadOnlyMemory<byte> payload,
+        bool payloadIsOverflow,
+        OverflowInstallationState? overflowInstallation,
         List<uint> traversalPath,
         HashSet<uint> traversalSet,
         CancellationToken ct)
@@ -1074,20 +1279,45 @@ public sealed class BTree
                 if (idx < 0)
                     return default;
 
-                if (TryReplaceLeafPayloadInPlace(sp, idx, payload.Span))
+                byte[]? previousOverflowReference = CopyOverflowReference(sp, idx);
+                if (TryReplaceLeafPayloadInPlace(
+                    sp,
+                    idx,
+                    payload.Span,
+                    payloadIsOverflow))
                 {
+                    overflowInstallation?.MarkInstalled();
                     await _pager.MarkDirtyAsync(pageId, ct);
-                    return new ReplaceResult(found: true, new InsertResult { Split = false });
+                    return new ReplaceResult(
+                        found: true,
+                        new InsertResult { Split = false },
+                        previousOverflowReference);
                 }
 
                 sp.DeleteCell(idx);
                 sp.Defragment();
-                var insertResult = await InsertIntoLeafAsync(pageId, page, sp, key, payload, ct);
-                return new ReplaceResult(found: true, insertResult);
+                var insertResult = await InsertIntoLeafAsync(
+                    pageId,
+                    page,
+                    sp,
+                    key,
+                    payload,
+                    payloadIsOverflow,
+                    overflowInstallation,
+                    ct);
+                return new ReplaceResult(found: true, insertResult, previousOverflowReference);
             }
 
             uint childPageId = FindChildPageWithIndex(sp, key, out int childIdx);
-            var childResult = await ReplaceRecursiveAsync(childPageId, key, payload, traversalPath, traversalSet, ct);
+            var childResult = await ReplaceRecursiveAsync(
+                childPageId,
+                key,
+                payload,
+                payloadIsOverflow,
+                overflowInstallation,
+                traversalPath,
+                traversalSet,
+                ct);
             if (!childResult.Found)
                 return default;
 
@@ -1102,7 +1332,10 @@ public sealed class BTree
                 childResult.InsertResult.NewPageId,
                 childIdx,
                 ct);
-            return new ReplaceResult(found: true, interiorInsertResult);
+            return new ReplaceResult(
+                found: true,
+                interiorInsertResult,
+                childResult.PreviousOverflowReference);
         }
         finally
         {
@@ -1110,7 +1343,15 @@ public sealed class BTree
         }
     }
 
-    private async ValueTask<InsertResult> InsertIntoLeafAsync(uint pageId, byte[] page, SlottedPage sp, long key, ReadOnlyMemory<byte> payload, CancellationToken ct)
+    private async ValueTask<InsertResult> InsertIntoLeafAsync(
+        uint pageId,
+        byte[] page,
+        SlottedPage sp,
+        long key,
+        ReadOnlyMemory<byte> payload,
+        bool payloadIsOverflow,
+        OverflowInstallationState? overflowInstallation,
+        CancellationToken ct)
     {
         // Find insertion point (sorted order)
         int insertIdx = FindInsertPosition(sp, key);
@@ -1123,7 +1364,15 @@ public sealed class BTree
                 throw new CSharpDbException(ErrorCode.DuplicateKey, $"Duplicate key: {key}");
         }
 
-        if (await TryInsertIntoLeafWithoutSplitAsync(pageId, sp, insertIdx, key, payload, ct))
+        if (await TryInsertIntoLeafWithoutSplitAsync(
+            pageId,
+            sp,
+            insertIdx,
+            key,
+            payload,
+            payloadIsOverflow,
+            overflowInstallation,
+            ct))
         {
             if (sp.RightChildOrNextLeaf == PageConstants.NullPageId && insertIdx == sp.CellCount - 1)
                 UpdateRightEdgeLeafHint(pageId, sp);
@@ -1131,16 +1380,24 @@ public sealed class BTree
             return new InsertResult { Split = false };
         }
 
-        int leafCellLength = GetLeafCellLength(payload.Length);
+        int leafCellLength = GetLeafCellLength(payload.Length, payloadIsOverflow);
         if (leafCellLength <= MaxStackLeafCellBytes)
         {
             Span<byte> stackCell = stackalloc byte[leafCellLength];
-            WriteLeafCell(stackCell, key, payload.Span);
+            WriteLeafCell(stackCell, key, payload.Span, payloadIsOverflow);
 
             // Preserve the stack-built cell for split handling.
             byte[] splitCell = GC.AllocateUninitializedArray<byte>(leafCellLength);
             stackCell.CopyTo(splitCell);
-            return await SplitLeafAsync(pageId, page, sp, insertIdx, splitCell, splitCell.Length, ct);
+            return await SplitLeafAsync(
+                pageId,
+                page,
+                sp,
+                insertIdx,
+                splitCell,
+                splitCell.Length,
+                overflowInstallation,
+                ct);
         }
 
         // For larger payloads, rent a temporary buffer instead of allocating per insert.
@@ -1148,10 +1405,18 @@ public sealed class BTree
         try
         {
             var pooledCellSpan = pooledCell.AsSpan(0, leafCellLength);
-            WriteLeafCell(pooledCellSpan, key, payload.Span);
+            WriteLeafCell(pooledCellSpan, key, payload.Span, payloadIsOverflow);
 
             // Page is full — split
-            return await SplitLeafAsync(pageId, page, sp, insertIdx, pooledCell, leafCellLength, ct);
+            return await SplitLeafAsync(
+                pageId,
+                page,
+                sp,
+                insertIdx,
+                pooledCell,
+                leafCellLength,
+                overflowInstallation,
+                ct);
         }
         finally
         {
@@ -1166,6 +1431,7 @@ public sealed class BTree
         int insertIdx,
         byte[] newCell,
         int newCellLength,
+        OverflowInstallationState? overflowInstallation,
         CancellationToken ct)
     {
         int existingCellCount = sp.CellCount;
@@ -1186,6 +1452,7 @@ public sealed class BTree
 
                 if (appendSp.InsertCell(0, newCell.AsSpan(0, newCellLength)))
                 {
+                    overflowInstallation?.MarkInstalled();
                     sp.RightChildOrNextLeaf = appendPageId;
                     await _pager.MarkDirtyAsync(pageId, ct);
                     await _pager.MarkDirtyAsync(appendPageId, ct);
@@ -1237,6 +1504,9 @@ public sealed class BTree
                         ErrorCode.CorruptDatabase,
                         $"Leaf split redistribution overflowed left page {pageId} while inserting key {ReadLeafCellKey(splitCellBuffer.AsSpan(offset, length))}.");
                 }
+
+                if (i == insertIdx)
+                    overflowInstallation?.MarkInstalled();
             }
 
             for (int i = mid; i < totalCellCount; i++)
@@ -1249,6 +1519,9 @@ public sealed class BTree
                         ErrorCode.CorruptDatabase,
                         $"Leaf split redistribution overflowed right page {newPageId} while inserting key {ReadLeafCellKey(splitCellBuffer.AsSpan(offset, length))}.");
                 }
+
+                if (i == insertIdx)
+                    overflowInstallation?.MarkInstalled();
             }
 
             await _pager.MarkDirtyAsync(pageId, ct);
@@ -1473,14 +1746,16 @@ public sealed class BTree
 
     private readonly struct DeleteResult
     {
-        public DeleteResult(bool deleted, bool underflow)
+        public DeleteResult(bool deleted, bool underflow, byte[]? deletedOverflowReference)
         {
             Deleted = deleted;
             Underflow = underflow;
+            DeletedOverflowReference = deletedOverflowReference;
         }
 
         public bool Deleted { get; }
         public bool Underflow { get; }
+        public byte[]? DeletedOverflowReference { get; }
     }
 
     private async ValueTask<DeleteResult> DeleteRecursiveAsync(
@@ -1497,11 +1772,12 @@ public sealed class BTree
             if (idx < 0)
                 return default;
 
+            byte[]? deletedOverflowReference = CopyOverflowReference(sp, idx);
             sp.DeleteCell(idx);
             sp.Defragment();
             await _pager.MarkDirtyAsync(pageId, ct);
             bool underflow = !isRoot && sp.CellCount < MinLeafCells;
-            return new DeleteResult(deleted: true, underflow);
+            return new DeleteResult(deleted: true, underflow, deletedOverflowReference);
         }
 
         uint childPageId = FindChildPageWithIndex(sp, key, out int childIndex);
@@ -1513,7 +1789,10 @@ public sealed class BTree
             await RebalanceUnderflowedChildAsync(pageId, sp, childIndex, childPageId, ct);
 
         bool interiorUnderflow = !isRoot && sp.CellCount < MinInteriorCells;
-        return new DeleteResult(deleted: true, interiorUnderflow);
+        return new DeleteResult(
+            deleted: true,
+            interiorUnderflow,
+            childResult.DeletedOverflowReference);
     }
 
     private async ValueTask RebalanceUnderflowedChildAsync(
@@ -1718,47 +1997,126 @@ public sealed class BTree
 
     internal static byte[] BuildLeafCell(long key, ReadOnlySpan<byte> payload)
     {
-        byte[] cell = GC.AllocateUninitializedArray<byte>(GetLeafCellLength(payload.Length));
-        WriteLeafCell(cell, key, payload);
+        byte[] cell = GC.AllocateUninitializedArray<byte>(GetLeafCellLength(payload.Length, payloadIsOverflow: false));
+        WriteLeafCell(cell, key, payload, payloadIsOverflow: false);
         return cell;
     }
 
-    private static int GetLeafCellLength(int payloadLength)
+    private static int GetLeafCellLength(int payloadLength, bool payloadIsOverflow)
     {
         int payloadPart = 8 + payloadLength;
-        return checked(Varint.SizeOf((ulong)payloadPart) + payloadPart);
+        ulong encodedPayloadSize = (ulong)payloadPart;
+        if (payloadIsOverflow)
+            encodedPayloadSize |= PageConstants.LeafCellOverflowFlag;
+        return checked(Varint.SizeOf(encodedPayloadSize) + payloadPart);
     }
 
-    private static void WriteLeafCell(Span<byte> destination, long key, ReadOnlySpan<byte> payload)
+    private static void WriteLeafCell(
+        Span<byte> destination,
+        long key,
+        ReadOnlySpan<byte> payload,
+        bool payloadIsOverflow)
     {
         // Cell: [totalSize:varint] [key:8] [payload]
         int payloadPart = 8 + payload.Length;
         int pos;
-        if (payloadPart <= 0x7F)
+        if (!payloadIsOverflow && payloadPart <= 0x7F)
         {
             destination[0] = (byte)payloadPart;
             pos = 1;
         }
         else
         {
-            pos = Varint.Write(destination, (ulong)payloadPart);
+            ulong encodedPayloadSize = (ulong)payloadPart;
+            if (payloadIsOverflow)
+                encodedPayloadSize |= PageConstants.LeafCellOverflowFlag;
+            pos = Varint.Write(destination, encodedPayloadSize);
         }
 
         BinaryPrimitives.WriteInt64LittleEndian(destination.Slice(pos, 8), key);
         payload.CopyTo(destination[(pos + 8)..]);
     }
 
-    private static bool TryReplaceLeafPayloadInPlace(SlottedPage sp, int index, ReadOnlySpan<byte> payload)
+    private static bool TryReplaceLeafPayloadInPlace(
+        SlottedPage sp,
+        int index,
+        ReadOnlySpan<byte> payload,
+        bool payloadIsOverflow)
     {
         byte[] page = sp.Buffer;
         int offset = sp.GetCellOffset(index);
-        ulong payloadSize = ReadVarintFast(page.AsSpan(offset), out int headerBytes);
-        int existingPayloadLength = checked((int)payloadSize - 8);
-        if (existingPayloadLength != payload.Length)
+        ulong encodedPayloadSize = ReadVarintFast(page.AsSpan(offset), out int headerBytes);
+        bool existingPayloadIsOverflow =
+            (encodedPayloadSize & PageConstants.LeafCellOverflowFlag) != 0;
+        int existingPayloadLength = checked(
+            (int)(encodedPayloadSize & PageConstants.CellPayloadSizeMask) - 8);
+        if (existingPayloadLength != payload.Length ||
+            existingPayloadIsOverflow != payloadIsOverflow)
             return false;
 
         payload.CopyTo(page.AsSpan(offset + headerBytes + 8, existingPayloadLength));
         return true;
+    }
+
+    private static bool RequiresOverflow(ReadOnlySpan<byte> payload)
+        => payload.Length > OverflowPageStore.MaxInlineBTreePayloadLength;
+
+    private async ValueTask<byte[]> WriteOverflowPayloadAsync(
+        ReadOnlyMemory<byte> payload,
+        CancellationToken ct)
+    {
+        OverflowPageReference reference = await OverflowPageStore.WriteAsync(_pager, payload, ct);
+        return BTreeOverflowReferenceCodec.Encode(reference);
+    }
+
+    internal async ValueTask<ReadOnlyMemory<byte>> ResolveStoredPayloadAsync(
+        ReadOnlyMemory<byte> storedPayload,
+        bool storedPayloadIsOverflow,
+        CancellationToken ct)
+    {
+        if (!storedPayloadIsOverflow)
+            return storedPayload;
+
+        OverflowPageReference reference = BTreeOverflowReferenceCodec.Decode(storedPayload.Span);
+        return await OverflowPageStore.ReadAsync(_pager, reference, ct);
+    }
+
+    private async ValueTask<ReadOnlyMemory<byte>> ResolveStoredPayloadAsync(
+        ReadOnlyMemory<byte> storedPayload,
+        bool storedPayloadIsOverflow,
+        WalSnapshot snapshot,
+        CancellationToken ct)
+    {
+        if (!storedPayloadIsOverflow)
+            return storedPayload;
+
+        OverflowPageReference reference = BTreeOverflowReferenceCodec.Decode(storedPayload.Span);
+        return await OverflowPageStore.ReadAsync(_pager, reference, snapshot, ct);
+    }
+
+    private static byte[]? CopyOverflowReference(SlottedPage sp, int index)
+        => IsLeafPayloadOverflow(sp, index)
+            ? ReadLeafPayloadMemory(sp, index).ToArray()
+            : null;
+
+    private async ValueTask ReclaimOverflowAsync(
+        ReadOnlyMemory<byte> overflowReference,
+        CancellationToken ct)
+    {
+        OverflowPageReference reference = BTreeOverflowReferenceCodec.Decode(overflowReference.Span);
+        await OverflowPageStore.ReclaimAsync(_pager, reference, ct);
+    }
+
+    private async ValueTask SafeReclaimOverflowAsync(ReadOnlyMemory<byte> overflowReference)
+    {
+        try
+        {
+            await ReclaimOverflowAsync(overflowReference, CancellationToken.None);
+        }
+        catch
+        {
+            // Preserve the original storage failure.
+        }
     }
 
     internal static long ReadLeafKey(SlottedPage sp, int index)
@@ -1786,8 +2144,9 @@ public sealed class BTree
     {
         byte[] page = sp.Buffer;
         int offset = sp.GetCellOffset(index);
-        ulong payloadSize = ReadVarintFast(page.AsSpan(offset), out int headerBytes);
-        int payloadLength = (int)payloadSize - 8;
+        ulong encodedPayloadSize = ReadVarintFast(page.AsSpan(offset), out int headerBytes);
+        int payloadLength = checked(
+            (int)(encodedPayloadSize & PageConstants.CellPayloadSizeMask) - 8);
         return page.AsMemory(offset + headerBytes + 8, payloadLength);
     }
 
@@ -1795,9 +2154,24 @@ public sealed class BTree
     {
         ReadOnlyMemory<byte> page = sp.Buffer;
         int offset = sp.GetCellOffset(index);
-        ulong payloadSize = ReadVarintFast(page.Span[offset..], out int headerBytes);
-        int payloadLength = (int)payloadSize - 8;
+        ulong encodedPayloadSize = ReadVarintFast(page.Span[offset..], out int headerBytes);
+        int payloadLength = checked(
+            (int)(encodedPayloadSize & PageConstants.CellPayloadSizeMask) - 8);
         return page.Slice(offset + headerBytes + 8, payloadLength);
+    }
+
+    internal static bool IsLeafPayloadOverflow(SlottedPage sp, int index)
+    {
+        int offset = sp.GetCellOffset(index);
+        ulong encodedPayloadSize = ReadVarintFast(sp.Buffer.AsSpan(offset), out _);
+        return (encodedPayloadSize & PageConstants.LeafCellOverflowFlag) != 0;
+    }
+
+    internal static bool IsLeafPayloadOverflow(ReadOnlySlottedPage sp, int index)
+    {
+        int offset = sp.GetCellOffset(index);
+        ulong encodedPayloadSize = ReadVarintFast(sp.Buffer.Span[offset..], out _);
+        return (encodedPayloadSize & PageConstants.LeafCellOverflowFlag) != 0;
     }
 
     private static long ReadInteriorCellKey(ReadOnlySpan<byte> cell)
@@ -1855,8 +2229,10 @@ public sealed class BTree
 
     private static int GetCellTotalSize(byte[] page, ushort offset)
     {
-        ulong payloadSize = ReadVarintFast(page.AsSpan(offset), out int headerBytes);
-        return checked(headerBytes + (int)payloadSize);
+        ulong encodedPayloadSize = ReadVarintFast(page.AsSpan(offset), out int headerBytes);
+        int payloadSize = checked(
+            (int)(encodedPayloadSize & PageConstants.CellPayloadSizeMask));
+        return checked(headerBytes + payloadSize);
     }
 
     private void EnterTraversal(uint pageId, long key, List<uint> traversalPath, HashSet<uint> traversalSet)
@@ -2461,7 +2837,16 @@ public sealed class BTree
             foreach (uint childPageId in childPageIds)
                 await ReclaimPageAsync(childPageId, visited, ct);
         }
-        else if (sp.PageType != PageConstants.PageTypeLeaf)
+        else if (sp.PageType == PageConstants.PageTypeLeaf)
+        {
+            for (int i = 0; i < sp.CellCount; i++)
+            {
+                ReadOnlyMemory<byte> storedPayload = ReadLeafPayloadMemory(sp, i);
+                if (IsLeafPayloadOverflow(sp, i))
+                    await ReclaimOverflowAsync(storedPayload, ct);
+            }
+        }
+        else
         {
             throw new CSharpDbException(
                 ErrorCode.CorruptDatabase,

--- a/src/CSharpDB.Storage/BTree/BTreeCursor.cs
+++ b/src/CSharpDB.Storage/BTree/BTreeCursor.cs
@@ -59,7 +59,7 @@ public sealed class BTreeCursor : IAsyncDisposable
             _initialized = true;
         }
 
-        _currentIndex++;
+        int candidateIndex = _currentIndex + 1;
 
         while (true)
         {
@@ -72,16 +72,23 @@ public sealed class BTreeCursor : IAsyncDisposable
 
             var sp = await GetCurrentLeafAsync(ct);
 
-            if (_currentIndex < sp.CellCount)
+            if (candidateIndex < sp.CellCount)
             {
-                CurrentKey = BTree.ReadLeafKey(sp, _currentIndex);
-                CurrentValue = BTree.ReadLeafPayloadMemory(sp, _currentIndex);
+                long key = BTree.ReadLeafKey(sp, candidateIndex);
+                ReadOnlyMemory<byte> value = await _tree.ResolveStoredPayloadAsync(
+                    BTree.ReadLeafPayloadMemory(sp, candidateIndex),
+                    BTree.IsLeafPayloadOverflow(sp, candidateIndex),
+                    ct);
+                _currentIndex = candidateIndex;
+                CurrentKey = key;
+                CurrentValue = value;
                 return true;
             }
 
             // Move to next leaf
             _currentPageId = sp.RightChildOrNextLeaf;
-            _currentIndex = 0;
+            _currentIndex = -1;
+            candidateIndex = 0;
             ResetCurrentLeaf(clearPrefetch: false);
         }
     }
@@ -94,8 +101,10 @@ public sealed class BTreeCursor : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        _initialized = true;
+        _initialized = false;
         _eof = false;
+        _currentPageId = PageConstants.NullPageId;
+        _currentIndex = -1;
         ResetCurrentLeaf(clearPrefetch: true);
 
         uint pageId = _tree.RootPageId;
@@ -111,28 +120,31 @@ public sealed class BTreeCursor : IAsyncDisposable
                 if (i < sp.CellCount)
                 {
                     long key = BTree.ReadLeafKey(sp, i);
+                    ReadOnlyMemory<byte> value = await _tree.ResolveStoredPayloadAsync(
+                        BTree.ReadLeafPayloadMemory(sp, i),
+                        BTree.IsLeafPayloadOverflow(sp, i),
+                        ct);
                     _currentPageId = pageId;
                     _currentIndex = i;
                     _currentLeafPage = page;
                     _currentLeaf = sp;
                     _currentLeafLoaded = true;
                     ScheduleLeafPrefetch(sp.RightChildOrNextLeaf);
+                    _initialized = true;
                     CurrentKey = key;
-                    CurrentValue = BTree.ReadLeafPayloadMemory(sp, i);
+                    CurrentValue = value;
                     return true;
                 }
 
                 uint nextLeaf = sp.RightChildOrNextLeaf;
                 if (nextLeaf == PageConstants.NullPageId)
                 {
+                    _initialized = true;
                     _eof = true;
                     return false;
                 }
 
-                _currentPageId = nextLeaf;
-                _currentIndex = -1;
-                ResetCurrentLeaf(clearPrefetch: true);
-                return await MoveNextAsync(ct);
+                pageId = nextLeaf;
             }
             else
             {

--- a/src/CSharpDB.Storage/BTree/BTreeOverflowReferenceCodec.cs
+++ b/src/CSharpDB.Storage/BTree/BTreeOverflowReferenceCodec.cs
@@ -1,0 +1,59 @@
+using System.Buffers.Binary;
+using CSharpDB.Primitives;
+
+namespace CSharpDB.Storage.BTrees;
+
+/// <summary>
+/// Encodes an external B+tree payload. This marker is intentionally distinct
+/// from index overflow references, whose lifecycle is owned by an index adapter.
+/// </summary>
+internal static class BTreeOverflowReferenceCodec
+{
+    private static ReadOnlySpan<byte> MagicBytes => "CSDBBOV1"u8;
+
+    internal const int EncodedLength = 16;
+
+    internal static bool IsEncoded(ReadOnlySpan<byte> payload)
+        => payload.Length == EncodedLength &&
+           payload[..MagicBytes.Length].SequenceEqual(MagicBytes);
+
+    internal static byte[] Encode(OverflowPageReference reference)
+    {
+        if (reference.FirstPageId == PageConstants.NullPageId)
+            throw new ArgumentOutOfRangeException(nameof(reference), "Overflow references must point at a real page.");
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(reference.PayloadLength);
+
+        byte[] encoded = GC.AllocateUninitializedArray<byte>(EncodedLength);
+        MagicBytes.CopyTo(encoded);
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            encoded.AsSpan(MagicBytes.Length, sizeof(uint)),
+            reference.FirstPageId);
+        BinaryPrimitives.WriteInt32LittleEndian(
+            encoded.AsSpan(MagicBytes.Length + sizeof(uint), sizeof(int)),
+            reference.PayloadLength);
+        return encoded;
+    }
+
+    internal static OverflowPageReference Decode(ReadOnlySpan<byte> payload)
+    {
+        if (!IsEncoded(payload))
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                "Payload is not a B+tree overflow reference.");
+        }
+
+        uint firstPageId = BinaryPrimitives.ReadUInt32LittleEndian(
+            payload.Slice(MagicBytes.Length, sizeof(uint)));
+        int payloadLength = BinaryPrimitives.ReadInt32LittleEndian(
+            payload.Slice(MagicBytes.Length + sizeof(uint), sizeof(int)));
+        if (firstPageId == PageConstants.NullPageId || payloadLength <= 0)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                "B+tree overflow reference does not point to a valid payload.");
+        }
+
+        return new OverflowPageReference(firstPageId, payloadLength);
+    }
+}

--- a/src/CSharpDB.Storage/Paging/OverflowPageStore.cs
+++ b/src/CSharpDB.Storage/Paging/OverflowPageStore.cs
@@ -1,0 +1,305 @@
+using System.Buffers.Binary;
+using CSharpDB.Primitives;
+using CSharpDB.Storage.Serialization;
+using CSharpDB.Storage.Wal;
+
+namespace CSharpDB.Storage.Paging;
+
+internal readonly record struct OverflowPageReference(uint FirstPageId, int PayloadLength);
+
+/// <summary>
+/// Stores payload bytes in linked overflow pages. Reference encoding is deliberately
+/// left to the owning data structure so different owners cannot decode or reclaim
+/// each other's chains accidentally.
+/// </summary>
+internal static class OverflowPageStore
+{
+    private readonly record struct ValidatedOverflowChunk(PageReadBuffer Page, ushort ChunkLength);
+
+    internal static int MaxInlineBTreePayloadLength { get; } = ComputeMaxInlineBTreePayloadLength();
+
+    private static int PayloadBytesPerPage => PageConstants.PageSize - PageConstants.OverflowPageHeaderSize;
+
+    internal static async ValueTask<OverflowPageReference> WriteAsync(
+        Pager pager,
+        ReadOnlyMemory<byte> payload,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(pager);
+        if (payload.IsEmpty)
+            throw new ArgumentException("Overflow payloads cannot be empty.", nameof(payload));
+
+        var allocatedPages = new List<uint>();
+        try
+        {
+            uint firstPageId = PageConstants.NullPageId;
+            uint previousPageId = PageConstants.NullPageId;
+            int offset = 0;
+
+            while (offset < payload.Length)
+            {
+                uint pageId = await pager.AllocatePageAsync(ct);
+                allocatedPages.Add(pageId);
+                if (firstPageId == PageConstants.NullPageId)
+                    firstPageId = pageId;
+
+                byte[] page = await pager.GetPageAsync(pageId, ct);
+                page.AsSpan().Clear();
+                page[PageConstants.PageTypeOffset] = PageConstants.PageTypeOverflow;
+
+                int chunkLength = Math.Min(PayloadBytesPerPage, payload.Length - offset);
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    page.AsSpan(PageConstants.OverflowNextOffset, sizeof(uint)),
+                    PageConstants.NullPageId);
+                BinaryPrimitives.WriteUInt16LittleEndian(
+                    page.AsSpan(PageConstants.OverflowChunkLengthOffset, sizeof(ushort)),
+                    checked((ushort)chunkLength));
+                payload.Span.Slice(offset, chunkLength)
+                    .CopyTo(page.AsSpan(PageConstants.OverflowPageHeaderSize, chunkLength));
+                await pager.MarkDirtyAsync(pageId, ct);
+
+                if (previousPageId != PageConstants.NullPageId)
+                {
+                    byte[] previousPage = await pager.GetPageAsync(previousPageId, ct);
+                    BinaryPrimitives.WriteUInt32LittleEndian(
+                        previousPage.AsSpan(PageConstants.OverflowNextOffset, sizeof(uint)),
+                        pageId);
+                    await pager.MarkDirtyAsync(previousPageId, ct);
+                }
+
+                previousPageId = pageId;
+                offset += chunkLength;
+            }
+
+            return new OverflowPageReference(firstPageId, payload.Length);
+        }
+        catch
+        {
+            foreach (uint pageId in allocatedPages)
+            {
+                try
+                {
+                    await pager.FreePageAsync(pageId, CancellationToken.None);
+                }
+                catch
+                {
+                    // Preserve the original storage failure.
+                }
+            }
+
+            throw;
+        }
+    }
+
+    internal static ValueTask<byte[]> ReadAsync(
+        Pager pager,
+        OverflowPageReference reference,
+        CancellationToken ct = default)
+        => ReadCoreAsync(pager, reference, snapshot: null, ct);
+
+    internal static ValueTask<byte[]> ReadAsync(
+        Pager pager,
+        OverflowPageReference reference,
+        WalSnapshot snapshot,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        return ReadCoreAsync(pager, reference, snapshot, ct);
+    }
+
+    private static async ValueTask<byte[]> ReadCoreAsync(
+        Pager pager,
+        OverflowPageReference reference,
+        WalSnapshot? snapshot,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(pager);
+        uint pageCount = pager.PageCount;
+        ValidateReference(reference, pageCount);
+
+        var visitedPages = new HashSet<uint>();
+        var chunks = new List<ValidatedOverflowChunk>();
+        uint pageId = reference.FirstPageId;
+        int validatedBytes = 0;
+
+        while (pageId != PageConstants.NullPageId)
+        {
+            ValidatePageId(pageId, pageCount);
+            if (!visitedPages.Add(pageId))
+            {
+                throw new CSharpDbException(
+                    ErrorCode.CorruptDatabase,
+                    $"Overflow chain contains a cycle at page {pageId}.");
+            }
+
+            PageReadBuffer page = snapshot is null
+                ? await pager.GetPageReadAsync(pageId, ct)
+                : await pager.GetSnapshotPageReadAsync(pageId, snapshot, ct);
+            ReadOnlySpan<byte> pageSpan = page.Memory.Span;
+            ValidateOverflowPage(pageId, pageSpan);
+
+            ushort chunkLength = BinaryPrimitives.ReadUInt16LittleEndian(
+                pageSpan.Slice(PageConstants.OverflowChunkLengthOffset, sizeof(ushort)));
+            if (chunkLength == 0 ||
+                chunkLength > PayloadBytesPerPage ||
+                chunkLength > reference.PayloadLength - validatedBytes)
+            {
+                throw new CSharpDbException(
+                    ErrorCode.CorruptDatabase,
+                    $"Overflow page {pageId} has invalid chunk length {chunkLength}.");
+            }
+
+            chunks.Add(new ValidatedOverflowChunk(page, chunkLength));
+            validatedBytes += chunkLength;
+
+            pageId = BinaryPrimitives.ReadUInt32LittleEndian(
+                pageSpan.Slice(PageConstants.OverflowNextOffset, sizeof(uint)));
+            if (pageId != PageConstants.NullPageId)
+                ValidatePageId(pageId, pageCount);
+        }
+
+        if (validatedBytes != reference.PayloadLength)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Overflow chain ended after {validatedBytes} bytes; expected {reference.PayloadLength}.");
+        }
+
+        byte[] payload = GC.AllocateUninitializedArray<byte>(reference.PayloadLength);
+        int written = 0;
+        foreach (ValidatedOverflowChunk chunk in chunks)
+        {
+            chunk.Page.Memory.Span
+                .Slice(PageConstants.OverflowPageHeaderSize, chunk.ChunkLength)
+                .CopyTo(payload.AsSpan(written, chunk.ChunkLength));
+            written += chunk.ChunkLength;
+        }
+
+        return payload;
+    }
+
+    internal static async ValueTask ReclaimAsync(
+        Pager pager,
+        OverflowPageReference reference,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(pager);
+        uint pageCount = pager.PageCount;
+        ValidateReference(reference, pageCount);
+
+        uint pageId = reference.FirstPageId;
+        var visitedPages = new HashSet<uint>();
+        var chainPages = new List<uint>();
+        int validatedBytes = 0;
+
+        while (pageId != PageConstants.NullPageId)
+        {
+            ValidatePageId(pageId, pageCount);
+            if (!visitedPages.Add(pageId))
+            {
+                throw new CSharpDbException(
+                    ErrorCode.CorruptDatabase,
+                    $"Overflow reclaim encountered a cycle at page {pageId}.");
+            }
+
+            byte[] page = await pager.GetPageAsync(pageId, ct);
+            ValidateOverflowPage(pageId, page);
+            ushort chunkLength = BinaryPrimitives.ReadUInt16LittleEndian(
+                page.AsSpan(PageConstants.OverflowChunkLengthOffset, sizeof(ushort)));
+            if (chunkLength == 0 ||
+                chunkLength > PayloadBytesPerPage ||
+                chunkLength > reference.PayloadLength - validatedBytes)
+            {
+                throw new CSharpDbException(
+                    ErrorCode.CorruptDatabase,
+                    $"Overflow page {pageId} has invalid chunk length {chunkLength}.");
+            }
+
+            validatedBytes += chunkLength;
+            chainPages.Add(pageId);
+
+            uint nextPageId = BinaryPrimitives.ReadUInt32LittleEndian(
+                page.AsSpan(PageConstants.OverflowNextOffset, sizeof(uint)));
+            if (nextPageId != PageConstants.NullPageId)
+                ValidatePageId(nextPageId, pageCount);
+
+            pageId = nextPageId;
+        }
+
+        if (validatedBytes != reference.PayloadLength)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Overflow chain ended after {validatedBytes} bytes; expected {reference.PayloadLength}.");
+        }
+
+        ct.ThrowIfCancellationRequested();
+        foreach (uint chainPageId in chainPages)
+            await pager.FreePageAsync(chainPageId, CancellationToken.None);
+    }
+
+    private static void ValidateReference(OverflowPageReference reference, uint pageCount)
+    {
+        if (reference.FirstPageId == PageConstants.NullPageId || reference.PayloadLength <= 0)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                "Overflow reference does not point to a valid payload.");
+        }
+
+        ValidatePageId(reference.FirstPageId, pageCount);
+
+        long maximumPayloadLength = Math.Max(0L, (long)pageCount - 1) * PayloadBytesPerPage;
+        if (reference.PayloadLength > maximumPayloadLength)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Overflow payload length {reference.PayloadLength} exceeds the maximum " +
+                $"possible length {maximumPayloadLength} for a {pageCount}-page database.");
+        }
+    }
+
+    private static void ValidatePageId(uint pageId, uint pageCount)
+    {
+        if (pageId == PageConstants.NullPageId || pageId >= pageCount)
+        {
+            string validRange = pageCount > 1 ? $"1..{pageCount - 1}" : "empty";
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Overflow chain references page {pageId}, outside the valid page range {validRange}.");
+        }
+    }
+
+    private static void ValidateOverflowPage(uint pageId, ReadOnlySpan<byte> page)
+    {
+        if (page.Length < PageConstants.PageSize)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Overflow page {pageId} is shorter than the configured page size.");
+        }
+
+        if (page[PageConstants.PageTypeOffset] != PageConstants.PageTypeOverflow)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Overflow page {pageId} has unexpected page type 0x{page[PageConstants.PageTypeOffset]:X2}.");
+        }
+    }
+
+    private static int ComputeMaxInlineBTreePayloadLength()
+    {
+        int maxLeafCellLength = PageConstants.PageSize -
+            PageConstants.SlottedPageHeaderSize -
+            PageConstants.CellPointerSize;
+        for (int payloadLength = maxLeafCellLength; payloadLength >= 0; payloadLength--)
+        {
+            int payloadPart = sizeof(long) + payloadLength;
+            int leafCellLength = Varint.SizeOf((ulong)payloadPart) + payloadPart;
+            if (leafCellLength <= maxLeafCellLength)
+                return payloadLength;
+        }
+
+        return 0;
+    }
+}

--- a/src/CSharpDB.Storage/Paging/PageConstants.cs
+++ b/src/CSharpDB.Storage/Paging/PageConstants.cs
@@ -7,7 +7,8 @@ public static class PageConstants
 
     // Magic bytes: "CSDB"
     public static readonly byte[] MagicBytes = "CSDB"u8.ToArray();
-    public const int FormatVersion = 1;
+    public const int MinimumSupportedFormatVersion = 1;
+    public const int FormatVersion = 2;
 
     // File header layout offsets (within page 0)
     public const int MagicOffset = 0;           // 4 bytes
@@ -27,6 +28,8 @@ public static class PageConstants
     public const int NextLeafOffset = 5;         // 4 bytes (uint32) — next leaf for leaf pages (reuses offset since interior uses RightChild)
     public const int SlottedPageHeaderSize = 9;  // total header before cell pointer array
     public const int CellPointerSize = 2;        // each cell pointer is 2 bytes (ushort offset within page)
+    public const ulong LeafCellOverflowFlag = 1UL << 63; // high bit of the encoded leaf payload size
+    public const ulong CellPayloadSizeMask = ~LeafCellOverflowFlag;
     public const int OverflowNextOffset = 1;     // 4 bytes (uint32) — next overflow page, 0 = end of chain
     public const int OverflowChunkLengthOffset = 5; // 2 bytes (ushort) — payload bytes stored on this overflow page
     public const int OverflowPageHeaderSize = 7; // total header before overflow payload bytes

--- a/src/CSharpDB.Storage/Paging/Pager.cs
+++ b/src/CSharpDB.Storage/Paging/Pager.cs
@@ -130,6 +130,7 @@ public sealed class Pager : IAsyncDisposable, IDisposable
     private uint _schemaRootPage;
     private uint _freelistHead;
     private uint _changeCounter;
+    private int _baseFormatVersion;
 
     public uint PageCount
     {
@@ -543,6 +544,7 @@ public sealed class Pager : IAsyncDisposable, IDisposable
         await _device.SetLengthAsync(PageConstants.PageSize, ct);
         await _device.WriteAsync(0, page0, ct);
         await _device.FlushAsync(ct);
+        Volatile.Write(ref _baseFormatVersion, PageConstants.FormatVersion);
         _buffers.SetCached(0, page0);
         RefreshPageReadProviderMapping();
         if (!_wal.IsOpen)
@@ -552,25 +554,27 @@ public sealed class Pager : IAsyncDisposable, IDisposable
     private async ValueTask ReadFileHeaderAsync(CancellationToken ct = default)
     {
         var header = _fileHeaderBuffer;
-        await _device.ReadAsync(0, header, ct);
-
-        // Validate magic
-        if (header[0] != PageConstants.MagicBytes[0] ||
-            header[1] != PageConstants.MagicBytes[1] ||
-            header[2] != PageConstants.MagicBytes[2] ||
-            header[3] != PageConstants.MagicBytes[3])
+        int bytesRead = await _device.ReadAsync(0, header, ct);
+        if (bytesRead != header.Length)
         {
-            throw new CSharpDbException(ErrorCode.CorruptDatabase, "Invalid database file (bad magic bytes).");
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Database file header is truncated (expected {header.Length} bytes, read {bytesRead}).");
         }
 
-        int version = BitConverter.ToInt32(header, PageConstants.VersionOffset);
-        if (version != PageConstants.FormatVersion)
-            throw new CSharpDbException(ErrorCode.CorruptDatabase, $"Unsupported format version {version}.");
+        int version = ReadFileHeaderFrom(header);
+        Volatile.Write(ref _baseFormatVersion, version);
+    }
 
-        PageCount = BitConverter.ToUInt32(header, PageConstants.PageCountOffset);
-        SchemaRootPage = BitConverter.ToUInt32(header, PageConstants.SchemaRootPageOffset);
-        FreelistHead = BitConverter.ToUInt32(header, PageConstants.FreelistHeadOffset);
-        ChangeCounter = BitConverter.ToUInt32(header, PageConstants.ChangeCounterOffset);
+    private async ValueTask EnsureBaseHeaderUsesCurrentFormatAsync(CancellationToken ct)
+    {
+        if (Volatile.Read(ref _baseFormatVersion) == PageConstants.FormatVersion)
+            return;
+
+        byte[] versionBytes = BitConverter.GetBytes(PageConstants.FormatVersion);
+        await _device.WriteAsync(PageConstants.VersionOffset, versionBytes, ct);
+        await _device.FlushAsync(ct);
+        Volatile.Write(ref _baseFormatVersion, PageConstants.FormatVersion);
     }
 
     private void WriteFileHeaderTo(Span<byte> page0)
@@ -777,13 +781,35 @@ public sealed class Pager : IAsyncDisposable, IDisposable
 
             tx.CommitStarted = true;
             _ambientTransaction.Value = null;
-            return BeginExplicitCommitAsync(tx, ct);
+            ValueTask formatGate = EnsureBaseHeaderUsesCurrentFormatAsync(ct);
+            return formatGate.IsCompletedSuccessfully
+                ? BeginExplicitCommitAsync(tx, ct)
+                : CompleteFormatGateAndBeginExplicitCommitAsync(tx, formatGate, ct);
         }
 
         if (_transactions is null || !_transactions.InTransaction)
             throw new CSharpDbException(ErrorCode.Unknown, "No active transaction to commit.");
 
         return BeginLegacyCommitAsync(ct);
+    }
+
+    private async ValueTask<PagerCommitResult> CompleteFormatGateAndBeginExplicitCommitAsync(
+        PagerTransactionState tx,
+        ValueTask formatGate,
+        CancellationToken ct)
+    {
+        try
+        {
+            await formatGate;
+        }
+        catch
+        {
+            tx.Completed = true;
+            tx.ReleaseSnapshot();
+            throw;
+        }
+
+        return await BeginExplicitCommitAsync(tx, ct);
     }
 
     public async ValueTask RollbackAsync(CancellationToken ct = default)
@@ -1430,6 +1456,7 @@ public sealed class Pager : IAsyncDisposable, IDisposable
     {
         try
         {
+            await EnsureBaseHeaderUsesCurrentFormatAsync(ct);
             ChangeCounter++;
 
             byte[] page0 = await GetPageAsync(0, ct);
@@ -1443,8 +1470,8 @@ public sealed class Pager : IAsyncDisposable, IDisposable
         }
         catch
         {
-            await RollbackAsync(ct);
-            await ResetPagerStateFromCommittedStorageAsync(ct);
+            await RollbackAsync(CancellationToken.None);
+            await ResetPagerStateFromCommittedStorageAsync(CancellationToken.None);
             throw;
         }
     }
@@ -2229,12 +2256,41 @@ public sealed class Pager : IAsyncDisposable, IDisposable
         }
     }
 
-    private void ReadFileHeaderFrom(byte[] page0)
+    private int ReadFileHeaderFrom(ReadOnlySpan<byte> page0)
     {
-        PageCount = BitConverter.ToUInt32(page0, PageConstants.PageCountOffset);
-        SchemaRootPage = BitConverter.ToUInt32(page0, PageConstants.SchemaRootPageOffset);
-        FreelistHead = BitConverter.ToUInt32(page0, PageConstants.FreelistHeadOffset);
-        ChangeCounter = BitConverter.ToUInt32(page0, PageConstants.ChangeCounterOffset);
+        if (page0.Length < PageConstants.FileHeaderSize)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Database file header is truncated (expected at least {PageConstants.FileHeaderSize} bytes, read {page0.Length}).");
+        }
+
+        if (!page0.Slice(PageConstants.MagicOffset, PageConstants.MagicBytes.Length)
+            .SequenceEqual(PageConstants.MagicBytes))
+        {
+            throw new CSharpDbException(ErrorCode.CorruptDatabase, "Invalid database file (bad magic bytes).");
+        }
+
+        int version = BitConverter.ToInt32(page0.Slice(PageConstants.VersionOffset, sizeof(int)));
+        if (version < PageConstants.MinimumSupportedFormatVersion ||
+            version > PageConstants.FormatVersion)
+        {
+            throw new CSharpDbException(ErrorCode.CorruptDatabase, $"Unsupported format version {version}.");
+        }
+
+        int pageSize = BitConverter.ToInt32(page0.Slice(PageConstants.PageSizeOffset, sizeof(int)));
+        if (pageSize != PageConstants.PageSize)
+        {
+            throw new CSharpDbException(
+                ErrorCode.CorruptDatabase,
+                $"Unsupported database page size {pageSize}; expected {PageConstants.PageSize}.");
+        }
+
+        PageCount = BitConverter.ToUInt32(page0.Slice(PageConstants.PageCountOffset, sizeof(uint)));
+        SchemaRootPage = BitConverter.ToUInt32(page0.Slice(PageConstants.SchemaRootPageOffset, sizeof(uint)));
+        FreelistHead = BitConverter.ToUInt32(page0.Slice(PageConstants.FreelistHeadOffset, sizeof(uint)));
+        ChangeCounter = BitConverter.ToUInt32(page0.Slice(PageConstants.ChangeCounterOffset, sizeof(uint)));
+        return version;
     }
 
     private async ValueTask ResetPagerStateFromCommittedStorageAsync(CancellationToken ct)
@@ -2296,6 +2352,7 @@ public sealed class Pager : IAsyncDisposable, IDisposable
             }
 
             await CheckpointAsync(ct);
+            await ReadFileHeaderAsync(ct);
         }
     }
 

--- a/src/CSharpDB.Storage/Paging/ReadOnlySlottedPage.cs
+++ b/src/CSharpDB.Storage/Paging/ReadOnlySlottedPage.cs
@@ -39,8 +39,9 @@ internal readonly struct ReadOnlySlottedPage
     {
         ushort offset = GetCellOffset(index);
         var cellData = _data.Slice(offset).Span;
-        ulong cellSize = Varint.Read(cellData, out int headerBytes);
-        int totalSize = headerBytes + (int)cellSize;
+        ulong encodedCellSize = Varint.Read(cellData, out int headerBytes);
+        int cellSize = checked((int)(encodedCellSize & PageConstants.CellPayloadSizeMask));
+        int totalSize = headerBytes + cellSize;
         return _data.Slice(offset, totalSize);
     }
 }

--- a/src/CSharpDB.Storage/Paging/SlottedPage.cs
+++ b/src/CSharpDB.Storage/Paging/SlottedPage.cs
@@ -66,16 +66,18 @@ public struct SlottedPage
         ushort offset = GetCellOffset(index);
         // Read cell size from the cell header (first varint)
         var cellData = Span[offset..];
-        ulong cellSize = Varint.Read(cellData, out int headerBytes);
-        return Span[offset..(offset + headerBytes + (int)cellSize)];
+        ulong encodedCellSize = Varint.Read(cellData, out int headerBytes);
+        int cellSize = checked((int)(encodedCellSize & PageConstants.CellPayloadSizeMask));
+        return Span[offset..(offset + headerBytes + cellSize)];
     }
 
     public ReadOnlyMemory<byte> GetCellMemory(int index)
     {
         ushort offset = GetCellOffset(index);
         var cellData = _data.AsSpan(offset);
-        ulong cellSize = Varint.Read(cellData, out int headerBytes);
-        int totalSize = headerBytes + (int)cellSize;
+        ulong encodedCellSize = Varint.Read(cellData, out int headerBytes);
+        int cellSize = checked((int)(encodedCellSize & PageConstants.CellPayloadSizeMask));
+        int totalSize = headerBytes + cellSize;
         return _data.AsMemory(offset, totalSize);
     }
 
@@ -191,8 +193,9 @@ public struct SlottedPage
     private int GetCellTotalSize(ushort offset)
     {
         var cellData = Span[offset..];
-        ulong payloadSize = Varint.Read(cellData, out int headerBytes);
-        return headerBytes + (int)payloadSize;
+        ulong encodedPayloadSize = Varint.Read(cellData, out int headerBytes);
+        int payloadSize = checked((int)(encodedPayloadSize & PageConstants.CellPayloadSizeMask));
+        return headerBytes + payloadSize;
     }
 
     private static void SortByOffsetDescending(Span<CellMove> moves)

--- a/tests/CSharpDB.Benchmarks/Micro/BTreeCursorBenchmarks.cs
+++ b/tests/CSharpDB.Benchmarks/Micro/BTreeCursorBenchmarks.cs
@@ -104,6 +104,7 @@ public class BTreeCursorBenchmarks
                 await buildTree.InsertAsync(key, payload);
             }
 
+            _rootPageId = buildTree.RootPageId;
             await buildPager.CommitAsync();
             await buildPager.CheckpointAsync();
         }

--- a/tests/CSharpDB.Tests/BTreeOverflowTests.cs
+++ b/tests/CSharpDB.Tests/BTreeOverflowTests.cs
@@ -1,0 +1,317 @@
+using System.Buffers.Binary;
+using System.Text;
+using CSharpDB.Primitives;
+using CSharpDB.Storage.BTrees;
+using CSharpDB.Storage.Checkpointing;
+using CSharpDB.Storage.Device;
+using CSharpDB.Storage.Paging;
+using CSharpDB.Storage.Wal;
+
+namespace CSharpDB.Tests;
+
+[Collection("StorageConcurrency")]
+public sealed class BTreeOverflowTests
+{
+    [Fact]
+    public async Task OversizedPayload_PointReadCursorReplaceDeleteAndReuse_RoundTrips()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await using var pager = await CreatePagerAsync(ct);
+        await pager.InitializeNewDatabaseAsync(ct);
+        await pager.RecoverAsync(ct);
+        await pager.BeginTransactionAsync(ct);
+
+        uint rootPageId = await BTree.CreateNewAsync(pager, ct);
+        var tree = new BTree(pager, rootPageId);
+        byte[] oversized = CreatePayload(20_000, seed: 17);
+
+        await tree.InsertAsync(1, oversized, ct);
+        await tree.InsertAsync(2, "inline"u8.ToArray(), ct);
+        uint pageCountWithOverflow = pager.PageCount;
+
+        Assert.False(tree.TryFindCachedMemory(1, out _));
+        Assert.Equal(oversized, await tree.FindAsync(1, ct));
+
+        await using (var cursor = tree.CreateCursor())
+        {
+            Assert.True(await cursor.SeekAsync(1, ct));
+            Assert.Equal(oversized, cursor.CurrentValue.ToArray());
+            Assert.True(await cursor.MoveNextAsync(ct));
+            Assert.Equal(2, cursor.CurrentKey);
+            Assert.Equal("inline"u8.ToArray(), cursor.CurrentValue.ToArray());
+        }
+
+        Assert.True(await tree.ReplaceAsync(1, "now inline"u8.ToArray(), ct));
+        Assert.Equal("now inline"u8.ToArray(), await tree.FindAsync(1, ct));
+
+        // Reclaimed overflow pages are reused instead of extending the database.
+        byte[] secondOversized = CreatePayload(20_000, seed: 91);
+        await tree.InsertAsync(3, secondOversized, ct);
+        Assert.Equal(pageCountWithOverflow, pager.PageCount);
+        Assert.Equal(secondOversized, await tree.FindAsync(3, ct));
+
+        Assert.True(await tree.DeleteAsync(3, ct));
+        Assert.Null(await tree.FindAsync(3, ct));
+
+        await pager.CommitAsync(ct);
+    }
+
+    [Fact]
+    public async Task InlinePayloadMatchingOverflowMarker_IsNotMisclassifiedAndRoundTripsVerbatim()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await using var pager = await CreatePagerAsync(ct);
+        await pager.InitializeNewDatabaseAsync(ct);
+        await pager.RecoverAsync(ct);
+        await pager.BeginTransactionAsync(ct);
+
+        uint rootPageId = await BTree.CreateNewAsync(pager, ct);
+        var tree = new BTree(pager, rootPageId);
+        byte[] markerShapedPayload = new byte[16];
+        Encoding.ASCII.GetBytes("CSDBBOV1").CopyTo(markerShapedPayload, 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(markerShapedPayload.AsSpan(8), rootPageId);
+        BinaryPrimitives.WriteInt32LittleEndian(markerShapedPayload.AsSpan(12), 1);
+        uint pageCountBeforeInsert = pager.PageCount;
+
+        await tree.InsertAsync(1, markerShapedPayload, ct);
+
+        // The marker is ordinary inline data. Only the leaf-cell flag identifies an
+        // overflow reference, so no overflow page should be allocated for this value.
+        Assert.Equal(pageCountBeforeInsert, pager.PageCount);
+        Assert.Equal(markerShapedPayload, await tree.FindAsync(1, ct));
+        await using var cursor = tree.CreateCursor();
+        Assert.True(await cursor.MoveNextAsync(ct));
+        Assert.Equal(markerShapedPayload, cursor.CurrentValue.ToArray());
+
+        await pager.CommitAsync(ct);
+    }
+
+    [Fact]
+    public async Task FormatVersion1InlineMarkerPayload_ReopensWithoutMisclassification()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var device = new MemoryStorageDevice();
+        uint rootPageId;
+        byte[] markerShapedPayload = new byte[16];
+        Encoding.ASCII.GetBytes("CSDBBOV1").CopyTo(markerShapedPayload, 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(markerShapedPayload.AsSpan(8), 1);
+        BinaryPrimitives.WriteInt32LittleEndian(markerShapedPayload.AsSpan(12), 1);
+
+        await using (var pager = await CreatePagerAsync(device, ct))
+        {
+            await pager.InitializeNewDatabaseAsync(ct);
+            await pager.RecoverAsync(ct);
+            await pager.BeginTransactionAsync(ct);
+            rootPageId = await BTree.CreateNewAsync(pager, ct);
+            var tree = new BTree(pager, rootPageId);
+            await tree.InsertAsync(1, markerShapedPayload, ct);
+            await pager.CommitAsync(ct);
+            await pager.CheckpointAsync(ct);
+        }
+
+        var legacyImage = new byte[checked((int)device.Length)];
+        Assert.Equal(legacyImage.Length, await device.ReadAsync(0, legacyImage, ct));
+        BinaryPrimitives.WriteInt32LittleEndian(
+            legacyImage.AsSpan(PageConstants.VersionOffset),
+            PageConstants.MinimumSupportedFormatVersion);
+
+        var reopenedDevice = new MemoryStorageDevice(legacyImage);
+        await using var reopenedPager = await CreatePagerAsync(reopenedDevice, ct);
+        await reopenedPager.RecoverAsync(ct);
+        var reopenedTree = new BTree(reopenedPager, rootPageId);
+
+        Assert.Equal(markerShapedPayload, await reopenedTree.FindAsync(1, ct));
+        await using var cursor = reopenedTree.CreateCursor();
+        Assert.True(await cursor.MoveNextAsync(ct));
+        Assert.Equal(markerShapedPayload, cursor.CurrentValue.ToArray());
+
+        byte[] baseHeader = new byte[PageConstants.FileHeaderSize];
+        Assert.Equal(baseHeader.Length, await reopenedDevice.ReadAsync(0, baseHeader, ct));
+        Assert.Equal(
+            PageConstants.MinimumSupportedFormatVersion,
+            BinaryPrimitives.ReadInt32LittleEndian(baseHeader.AsSpan(PageConstants.VersionOffset)));
+
+        await reopenedPager.BeginTransactionAsync(ct);
+        using (var canceledCommit = new CancellationTokenSource())
+        {
+            canceledCommit.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await reopenedPager.CommitAsync(canceledCommit.Token));
+        }
+
+        // A failed format-gate flush must roll back and release the legacy writer lock.
+        await reopenedPager.BeginTransactionAsync(ct);
+        byte[] oversized = CreatePayload(8_000, seed: 73);
+        await reopenedTree.InsertAsync(2, oversized, ct);
+        await reopenedPager.CommitAsync(ct);
+
+        Assert.Equal(baseHeader.Length, await reopenedDevice.ReadAsync(0, baseHeader, ct));
+        Assert.Equal(
+            PageConstants.FormatVersion,
+            BinaryPrimitives.ReadInt32LittleEndian(baseHeader.AsSpan(PageConstants.VersionOffset)));
+        Assert.Equal(oversized, await reopenedTree.FindAsync(2, ct));
+    }
+
+    [Fact]
+    public async Task MaximumInlinePayloadBoundary_UsesOverflowOnlyAboveTheLimit()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await using var pager = await CreatePagerAsync(ct);
+        await pager.InitializeNewDatabaseAsync(ct);
+        await pager.RecoverAsync(ct);
+        await pager.BeginTransactionAsync(ct);
+
+        uint rootPageId = await BTree.CreateNewAsync(pager, ct);
+        var tree = new BTree(pager, rootPageId);
+        int inlineLimit = OverflowPageStore.MaxInlineBTreePayloadLength;
+        byte[] atLimit = CreatePayload(inlineLimit, seed: 41);
+        byte[] aboveLimit = CreatePayload(inlineLimit + 1, seed: 42);
+        uint pageCountBeforeInsert = pager.PageCount;
+
+        await tree.InsertAsync(1, atLimit, ct);
+
+        Assert.Equal(pageCountBeforeInsert, pager.PageCount);
+        Assert.Equal(atLimit, await tree.FindAsync(1, ct));
+
+        Assert.True(await tree.DeleteAsync(1, ct));
+        await tree.InsertAsync(2, aboveLimit, ct);
+
+        Assert.True(pager.PageCount > pageCountBeforeInsert);
+        Assert.Equal(aboveLimit, await tree.FindAsync(2, ct));
+
+        await using var cursor = tree.CreateCursor();
+        Assert.True(await cursor.MoveNextAsync(ct));
+        Assert.Equal(2, cursor.CurrentKey);
+        Assert.Equal(aboveLimit, cursor.CurrentValue.ToArray());
+        Assert.False(await cursor.MoveNextAsync(ct));
+
+        await pager.CommitAsync(ct);
+    }
+
+    [Fact]
+    public async Task RejectedOversizedWrites_DoNotAllocateOverflowPages()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await using var pager = await CreatePagerAsync(ct);
+        await pager.InitializeNewDatabaseAsync(ct);
+        await pager.RecoverAsync(ct);
+        await pager.BeginTransactionAsync(ct);
+
+        uint rootPageId = await BTree.CreateNewAsync(pager, ct);
+        var tree = new BTree(pager, rootPageId);
+        byte[] oversized = CreatePayload(8_000, seed: 19);
+        uint initialPageCount = pager.PageCount;
+
+        Assert.False(await tree.ReplaceAsync(404, oversized, ct));
+        Assert.Equal(initialPageCount, pager.PageCount);
+
+        await tree.InsertAsync(1, oversized, ct);
+        uint insertedPageCount = pager.PageCount;
+        CSharpDbException duplicate = await Assert.ThrowsAsync<CSharpDbException>(
+            async () => await tree.InsertAsync(1, oversized, ct));
+        Assert.Equal(ErrorCode.DuplicateKey, duplicate.Code);
+        Assert.Equal(insertedPageCount, pager.PageCount);
+
+        await pager.CommitAsync(ct);
+    }
+
+    [Fact]
+    public async Task ManyOversizedPayloads_SplitLeavesAndCursorReturnsEveryRow()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var device = new MemoryStorageDevice();
+        await using var pager = await CreatePagerAsync(device, ct);
+        await pager.InitializeNewDatabaseAsync(ct);
+        await pager.RecoverAsync(ct);
+        await pager.BeginTransactionAsync(ct);
+
+        uint rootPageId = await BTree.CreateNewAsync(pager, ct);
+        var tree = new BTree(pager, rootPageId);
+        const int rowCount = 180;
+
+        for (int key = 0; key < rowCount; key++)
+            await tree.InsertAsync(key, CreatePayload(5_000 + (key % 17), key), ct);
+
+        byte[] rootPage = await pager.GetPageAsync(tree.RootPageId, ct);
+        Assert.Equal(PageConstants.PageTypeInterior, rootPage[PageConstants.PageTypeOffset]);
+
+        foreach (int key in new[] { 0, rowCount / 2, rowCount - 1 })
+        {
+            Assert.Equal(
+                CreatePayload(5_000 + (key % 17), key),
+                await tree.FindAsync(key, ct));
+        }
+
+        await using var cursor = tree.CreateCursor();
+        int expectedKey = 0;
+        while (await cursor.MoveNextAsync(ct))
+        {
+            Assert.Equal(expectedKey, cursor.CurrentKey);
+            Assert.Equal(
+                CreatePayload(5_000 + (expectedKey % 17), expectedKey),
+                cursor.CurrentValue.ToArray());
+            expectedKey++;
+        }
+
+        Assert.Equal(rowCount, expectedKey);
+        await pager.CommitAsync(ct);
+        await pager.CheckpointAsync(ct);
+
+        byte[] databaseImage = new byte[checked((int)device.Length)];
+        Assert.Equal(databaseImage.Length, await device.ReadAsync(0, databaseImage, ct));
+        await using var reopenedPager = await CreatePagerAsync(new MemoryStorageDevice(databaseImage), ct);
+        await reopenedPager.RecoverAsync(ct);
+        var reopenedTree = new BTree(reopenedPager, tree.RootPageId);
+
+        foreach (int key in new[] { 0, rowCount / 2, rowCount - 1 })
+        {
+            Assert.Equal(
+                CreatePayload(5_000 + (key % 17), key),
+                await reopenedTree.FindAsync(key, ct));
+        }
+
+        await using var reopenedCursor = reopenedTree.CreateCursor();
+        expectedKey = 0;
+        while (await reopenedCursor.MoveNextAsync(ct))
+        {
+            Assert.Equal(expectedKey, reopenedCursor.CurrentKey);
+            Assert.Equal(
+                CreatePayload(5_000 + (expectedKey % 17), expectedKey),
+                reopenedCursor.CurrentValue.ToArray());
+            expectedKey++;
+        }
+
+        Assert.Equal(rowCount, expectedKey);
+    }
+
+    private static byte[] CreatePayload(int length, int seed)
+    {
+        var payload = new byte[length];
+        for (int i = 0; i < payload.Length; i++)
+            payload[i] = (byte)((i * 31 + seed) & 0xFF);
+        return payload;
+    }
+
+    private static async ValueTask<Pager> CreatePagerAsync(CancellationToken ct)
+    {
+        return await CreatePagerAsync(new MemoryStorageDevice(), ct);
+    }
+
+    private static async ValueTask<Pager> CreatePagerAsync(
+        MemoryStorageDevice device,
+        CancellationToken ct)
+    {
+        var walIndex = new WalIndex();
+        var wal = new MemoryWriteAheadLog(walIndex);
+        return await Pager.CreateAsync(
+            device,
+            wal,
+            walIndex,
+            new PagerOptions
+            {
+                CheckpointPolicy = new FrameCountCheckpointPolicy(1_000_000),
+                MaxCachedPages = 32,
+            },
+            ct);
+    }
+}

--- a/tests/CSharpDB.Tests/CollectionTests.cs
+++ b/tests/CSharpDB.Tests/CollectionTests.cs
@@ -39,6 +39,10 @@ public class CollectionTests : IAsyncLifetime
     // Test models
     private record User(string Name, int Age, string Email);
     private record Product(string Sku, string Title, decimal Price);
+    private sealed class FailingDocument
+    {
+        public string Value => throw new InvalidOperationException("Serialization failed as requested.");
+    }
 
     // ===== Tier 1: Basic CRUD =====
 
@@ -161,18 +165,41 @@ public class CollectionTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Put_ModerateDocument()
+    public async Task Put_LargeDocumentSpansOverflowPages()
     {
-        var users = await _db.GetCollectionAsync<User>("users", TestContext.Current.CancellationToken);
-        // Keep within B+tree page size (4096 bytes). JSON overhead + RecordEncoder ~ 100 bytes.
-        string longEmail = new string('x', 500) + "@example.com";
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var users = await _db.GetCollectionAsync<User>("users", ct);
+        string longEmail = new string('x', 12_000) + "@example.com";
         var bigUser = new User("ModerateDoc", 99, longEmail);
 
-        await users.PutAsync("big:1", bigUser, TestContext.Current.CancellationToken);
-        var result = await users.GetAsync("big:1", TestContext.Current.CancellationToken);
+        await users.PutAsync("big:1", bigUser, ct);
+        var result = await users.GetAsync("big:1", ct);
 
         Assert.NotNull(result);
         Assert.Equal(longEmail, result!.Email);
+
+        var scanned = new List<KeyValuePair<string, User>>();
+        await foreach (var item in users.ScanAsync(ct))
+            scanned.Add(item);
+        Assert.Single(scanned);
+        Assert.Equal(longEmail, scanned[0].Value.Email);
+
+        string updatedEmail = string.Concat(Enumerable.Repeat("é漢", 2_500)) + "@example.com";
+        await users.PutAsync("big:1", new User("UpdatedDoc", 100, updatedEmail), ct);
+        await users.PutAsync("small:2", new User("SmallDoc", 1, "small@example.com"), ct);
+
+        var updated = await users.GetAsync("big:1", ct);
+        Assert.NotNull(updated);
+        Assert.Equal(updatedEmail, updated!.Email);
+        Assert.Equal(2, await users.CountAsync(ct));
+
+        await _db.DisposeAsync();
+        _db = await Database.OpenAsync(_dbPath, ct);
+        var reopenedUsers = await _db.GetCollectionAsync<User>("users", ct);
+        var reopened = await reopenedUsers.GetAsync("big:1", ct);
+        Assert.NotNull(reopened);
+        Assert.Equal(updatedEmail, reopened!.Email);
+        Assert.Equal(2, await reopenedUsers.CountAsync(ct));
     }
 
     [Fact]
@@ -397,6 +424,26 @@ public class CollectionTests : IAsyncLifetime
         var cachedAgain = await _db.GetCollectionAsync<User>("users", timeoutCts.Token);
         Assert.Same(cached, cachedAgain);
         Assert.Equal(1, await cachedAgain.CountAsync(timeoutCts.Token));
+    }
+
+    [Fact]
+    public async Task FailedImplicitPut_ReleasesWriteGate()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var failing = await _db.GetCollectionAsync<FailingDocument>("failing", ct);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await failing.PutAsync("bad:1", new FailingDocument(), ct));
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(5));
+
+        var users = await _db.GetCollectionAsync<User>("after_failure", timeoutCts.Token);
+        await users.PutAsync(
+            "u:1",
+            new User("Recovered", 1, "recovered@example.com"),
+            timeoutCts.Token);
+        Assert.NotNull(await users.GetAsync("u:1", timeoutCts.Token));
     }
 
     // ===== Persistence across reopen =====

--- a/tests/CSharpDB.Tests/IntegrationTests.cs
+++ b/tests/CSharpDB.Tests/IntegrationTests.cs
@@ -181,6 +181,102 @@ public class IntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task LargeText_SpansOverflowPages_AcrossCrudAndReopen()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        string initialText = new('x', 10_000);
+        string updatedText = string.Concat(Enumerable.Repeat("é漢", 3_000));
+
+        await _db.ExecuteAsync(
+            "CREATE TABLE large_text_rows (id INTEGER PRIMARY KEY, body TEXT)",
+            ct);
+        await _db.ExecuteAsync(
+            $"INSERT INTO large_text_rows VALUES (1, '{initialText}')",
+            ct);
+        await _db.ExecuteAsync(
+            "INSERT INTO large_text_rows VALUES (2, 'inline')",
+            ct);
+
+        // Primary-key lookup exercises the WAL snapshot point-read path.
+        await using (var lookup = await _db.ExecuteAsync(
+            "SELECT body FROM large_text_rows WHERE id = 1",
+            ct))
+        {
+            var rows = await lookup.ToListAsync(ct);
+            Assert.Single(rows);
+            Assert.Equal(initialText, rows[0][0].AsText);
+        }
+
+        // A table scan resolves the same external payload through BTreeCursor.
+        await using (var scan = await _db.ExecuteAsync(
+            "SELECT id, body FROM large_text_rows ORDER BY id",
+            ct))
+        {
+            var rows = await scan.ToListAsync(ct);
+            Assert.Equal(2, rows.Count);
+            Assert.Equal(initialText, rows[0][1].AsText);
+            Assert.Equal("inline", rows[1][1].AsText);
+        }
+
+        string rolledBackText = new('r', 12_000);
+        await _db.BeginTransactionAsync(ct);
+        try
+        {
+            await _db.ExecuteAsync(
+                $"UPDATE large_text_rows SET body = '{rolledBackText}' WHERE id = 1",
+                ct);
+            await _db.ExecuteAsync(
+                $"INSERT INTO large_text_rows VALUES (3, '{rolledBackText}')",
+                ct);
+            await _db.ExecuteAsync("DELETE FROM large_text_rows WHERE id = 2", ct);
+            await _db.RollbackAsync(ct);
+        }
+        catch
+        {
+            await _db.RollbackAsync(CancellationToken.None);
+            throw;
+        }
+
+        await using (var afterRollback = await _db.ExecuteAsync(
+            "SELECT id, body FROM large_text_rows ORDER BY id",
+            ct))
+        {
+            var rows = await afterRollback.ToListAsync(ct);
+            Assert.Equal(2, rows.Count);
+            Assert.Equal(initialText, rows[0][1].AsText);
+            Assert.Equal("inline", rows[1][1].AsText);
+        }
+
+        await _db.ExecuteAsync(
+            "UPDATE large_text_rows SET body = 'temporarily inline' WHERE id = 1",
+            ct);
+        await _db.ExecuteAsync(
+            $"UPDATE large_text_rows SET body = '{updatedText}' WHERE id = 1",
+            ct);
+        await _db.ExecuteAsync(
+            "UPDATE large_text_rows SET body = 'small again' WHERE id = 2",
+            ct);
+
+        await _db.DisposeAsync();
+        _db = await Database.OpenAsync(_dbPath, ct);
+
+        await using (var reopened = await _db.ExecuteAsync(
+            "SELECT body FROM large_text_rows WHERE id = 1",
+            ct))
+        {
+            var rows = await reopened.ToListAsync(ct);
+            Assert.Single(rows);
+            Assert.Equal(updatedText, rows[0][0].AsText);
+        }
+
+        await _db.ExecuteAsync("DELETE FROM large_text_rows WHERE id = 1", ct);
+        await using var deleted = await _db.ExecuteAsync(
+            "SELECT body FROM large_text_rows WHERE id = 1",
+            ct);
+        Assert.Empty(await deleted.ToListAsync(ct));
+    }
+
+    [Fact]
     public async Task Persistence_PrimaryKeyLookupManyRows_AcrossReopen()
     {
         await _db.ExecuteAsync("CREATE TABLE persist_big (id INTEGER PRIMARY KEY, val INTEGER)", TestContext.Current.CancellationToken);

--- a/tests/CSharpDB.Tests/StorageDiagnosticsTests.cs
+++ b/tests/CSharpDB.Tests/StorageDiagnosticsTests.cs
@@ -53,6 +53,101 @@ public sealed class StorageDiagnosticsTests
     }
 
     [Fact]
+    public async Task DatabaseInspector_InspectPageAsync_InteriorOverflowFlagReportsError()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string dbPath = NewTempDbPath();
+
+        try
+        {
+            var databaseBytes = new byte[PageConstants.PageSize * 2];
+            int pageBase = PageConstants.PageSize;
+            ulong encodedPayloadSize = PageConstants.LeafCellOverflowFlag | 12UL;
+            int cellOffset = PageConstants.PageSize - Varint.SizeOf(encodedPayloadSize) - 12;
+
+            databaseBytes[pageBase + PageConstants.PageTypeOffset] = PageConstants.PageTypeInterior;
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                databaseBytes.AsSpan(pageBase + PageConstants.CellCountOffset, 2),
+                1);
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                databaseBytes.AsSpan(pageBase + PageConstants.FreeSpaceStartOffset, 2),
+                checked((ushort)cellOffset));
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                databaseBytes.AsSpan(pageBase + PageConstants.SlottedPageHeaderSize, 2),
+                checked((ushort)cellOffset));
+
+            int headerBytes = Varint.Write(
+                databaseBytes.AsSpan(pageBase + cellOffset),
+                encodedPayloadSize);
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                databaseBytes.AsSpan(pageBase + cellOffset + headerBytes, 4),
+                PageConstants.NullPageId);
+            BinaryPrimitives.WriteInt64LittleEndian(
+                databaseBytes.AsSpan(pageBase + cellOffset + headerBytes + 4, 8),
+                42);
+
+            await File.WriteAllBytesAsync(dbPath, databaseBytes, ct);
+
+            PageInspectReport report = await DatabaseInspector.InspectPageAsync(
+                dbPath,
+                pageId: 1,
+                includeHex: false,
+                ct);
+
+            Assert.Contains(
+                report.Issues,
+                issue => issue.Code == "INTERIOR_CELL_OVERFLOW_FLAG_INVALID" &&
+                         issue.Severity == InspectSeverity.Error);
+        }
+        finally
+        {
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
+    [Fact]
+    public async Task DatabaseInspector_FormatVersionOne_RemainsSupported()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string dbPath = NewTempDbPath();
+
+        try
+        {
+            var databaseBytes = new byte[PageConstants.PageSize];
+            PageConstants.MagicBytes.CopyTo(databaseBytes, PageConstants.MagicOffset);
+            BinaryPrimitives.WriteInt32LittleEndian(
+                databaseBytes.AsSpan(PageConstants.VersionOffset, 4),
+                PageConstants.MinimumSupportedFormatVersion);
+            BinaryPrimitives.WriteInt32LittleEndian(
+                databaseBytes.AsSpan(PageConstants.PageSizeOffset, 4),
+                PageConstants.PageSize);
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                databaseBytes.AsSpan(PageConstants.PageCountOffset, 4),
+                1);
+
+            int pageBase = PageConstants.FileHeaderSize;
+            databaseBytes[pageBase + PageConstants.PageTypeOffset] = PageConstants.PageTypeLeaf;
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                databaseBytes.AsSpan(pageBase + PageConstants.FreeSpaceStartOffset, 2),
+                PageConstants.PageSize);
+
+            await File.WriteAllBytesAsync(dbPath, databaseBytes, ct);
+
+            DatabaseInspectReport report = await DatabaseInspector.InspectAsync(dbPath, ct: ct);
+
+            Assert.Equal(PageConstants.MinimumSupportedFormatVersion, report.Header.Version);
+            Assert.True(report.Header.VersionValid);
+            Assert.DoesNotContain(report.Issues, issue => issue.Code == "DB_HEADER_BAD_VERSION");
+        }
+        finally
+        {
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
+    [Fact]
     public async Task StorageInspectors_EmptyDatabase_DoNotWarnOnStatsCatalogSentinels()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -69,6 +164,76 @@ public sealed class StorageDiagnosticsTests
 
             Assert.DoesNotContain(dbReport.Issues, i => i.Code == "CATALOG_TABLE_SCHEMA_DECODE_FAILED");
             Assert.DoesNotContain(indexReport.Issues, i => i.Code == "CATALOG_TABLE_SCHEMA_DECODE_FAILED");
+        }
+        finally
+        {
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
+    [Fact]
+    public async Task DatabaseInspector_LargeRowOverflowPages_AreParsedAsHealthy()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string dbPath = NewTempDbPath();
+
+        try
+        {
+            await using (var db = await Database.OpenAsync(dbPath, ct))
+            {
+                await db.ExecuteAsync("CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)", ct);
+                await db.ExecuteAsync(
+                    $"INSERT INTO docs VALUES (1, '{new string('x', 10_000)}')",
+                    ct);
+            }
+
+            DatabaseInspectReport report = await DatabaseInspector.InspectAsync(dbPath, ct: ct);
+
+            Assert.True(report.PageTypeHistogram.TryGetValue("overflow", out int overflowPageCount));
+            Assert.True(overflowPageCount >= 3);
+            Assert.DoesNotContain(report.Issues, issue => issue.Severity == InspectSeverity.Error);
+        }
+        finally
+        {
+            DeleteIfExists(dbPath);
+            DeleteIfExists(dbPath + ".wal");
+        }
+    }
+
+    [Fact]
+    public async Task DatabaseInspector_OverflowChainOutsideDatabaseReportsError()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        string dbPath = NewTempDbPath();
+
+        try
+        {
+            await using (var db = await Database.OpenAsync(dbPath, ct))
+            {
+                await db.ExecuteAsync("CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)", ct);
+                await db.ExecuteAsync(
+                    $"INSERT INTO docs VALUES (1, '{new string('x', 10_000)}')",
+                    ct);
+            }
+
+            byte[] databaseBytes = await File.ReadAllBytesAsync(dbPath, ct);
+            int physicalPageCount = databaseBytes.Length / PageConstants.PageSize;
+            int overflowPageId = Enumerable.Range(1, physicalPageCount - 1)
+                .First(pageId =>
+                    databaseBytes[pageId * PageConstants.PageSize + PageConstants.PageTypeOffset] ==
+                    PageConstants.PageTypeOverflow);
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                databaseBytes.AsSpan(
+                    overflowPageId * PageConstants.PageSize + PageConstants.OverflowNextOffset,
+                    sizeof(uint)),
+                uint.MaxValue);
+            await File.WriteAllBytesAsync(dbPath, databaseBytes, ct);
+
+            DatabaseInspectReport report = await DatabaseInspector.InspectAsync(dbPath, ct: ct);
+
+            Assert.Contains(report.Issues, issue => issue.Code == "OVERFLOW_NEXT_PAGE_OOB");
+            Assert.Contains(report.Issues, issue => issue.Code == "OVERFLOW_CHAIN_PAGE_OOB");
         }
         finally
         {


### PR DESCRIPTION
## Summary

This release combines the large-value B-tree fix with native Windows file and folder dialogs for the Desktop Admin.

This release fixes the 4 KiB page-size failure that prevented SQL rows, B-tree values, and Collection documents larger than the 4,075-byte maximum inline payload from being stored. Oversized B-tree payloads now live in validated linked overflow pages while the leaf cell retains a tagged 16-byte reference.

Overflow-backed values are integrated across point and snapshot reads, cursors, inserts, replacements, deletes, rollback, tree splits, checkpoints, database reopen, and safe page reclamation. The change also extends storage diagnostics to validate complete overflow chains, preserves format-v1 read compatibility with a durable format-v2 write gate, fixes a failed implicit Collection write-scope leak, and corrects the cursor benchmark setup so it retains the root page produced after B-tree splits.

The Desktop Admin now uses native Open, Save, and Select Folder dialogs across 12 local-path workflows: opening or creating databases, selecting code-module workspaces, compare/deploy archives, pipeline inputs and outputs, backup/restore and migration backup paths, import/export paths, and table archives. Manual path entry remains available for browser-hosted and relative-path workflows, and native Browse controls are hidden unless that browser tab has the WebView2 bridge.

The desktop bridge correlates requests and responses, validates the WebView origin before opening a dialog and again before returning a selected path, rejects malformed or overlapping requests, and treats cancellation as a normal no-selection result. Desktop host discovery now supports packaged, conventional Debug/Release, RID-specific, publish, and custom artifacts layouts without falling back from Release to a stale Debug host.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

None linked.

## Testing

Validation performed for the version4.0.3 branch:

- [x] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Commands run successfully:

```powershell
dotnet build src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj -c Debug --artifacts-path .artifacts/admin-picker-p3-debug
dotnet build src/CSharpDB.Admin.Desktop/CSharpDB.Admin.Desktop.csproj -c Release --artifacts-path .artifacts/admin-picker-p3-release
dotnet build CSharpDB.slnx -c Release --artifacts-path .artifacts/admin-picker-p3-solution
dotnet test CSharpDB.slnx -c Release --no-build --artifacts-path .artifacts/admin-picker-p3-solution --verbosity minimal
node --check src/CSharpDB.Admin/wwwroot/js/interop.js
.\scripts\Publish-CSharpDbAdminStorePackage.ps1 -Version 4.0.3 -OutputRoot artifacts/admin-store-dialog-signed
.\scripts\Publish-CSharpDbAdminStorePackage.ps1 -Version 4.0.3 -OutputRoot artifacts/admin-store-dialog-p3-unsigned -SkipSigning
Add-AppxPackage -Register artifacts/admin-store-dialog-p3-unsigned/stage/AppxManifest.xml -ForceApplicationShutdown
dotnet run -c Release --project tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj -- --micro --filter "*RecordSizeBenchmarks*"
dotnet run -c Release --project tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj -- --micro --filter "*PointLookupBenchmarks.SelectByPrimaryKey" "*InsertBenchmarks.SingleInsert" "*BTreeCursorBenchmarks*" --join
```

Latest validation:

- Release solution build passed with 0 errors. The 12 warnings are existing NU1903 advisories for `Microsoft.OpenApi` and `SQLitePCLRaw.lib.e_sqlite3`.
- Full Release solution test run passed: **2,127 passed, 0 failed** across 11 test assemblies, including **1,375 passed** in `CSharpDB.Tests`.
- Focused overflow coverage includes the exact 4,075-byte inline / 4,076-byte overflow boundary; 10–20 KB SQL, Collection, and direct B-tree values; CRUD; snapshot and cursor reads; rollback; leaf splits; checkpoints and reopen; reclaimed-page reuse; rejected writes; format migration and cancellation; malformed references; out-of-range pages; cycles; and length mismatches.
- Desktop Admin Debug and Release builds passed with 0 warnings and 0 errors, and the desktop JavaScript syntax check passed.
- A JavaScript capability harness verified that a normal browser has neither bridge availability nor the desktop marker, while WebView2 has both. The CSS gate hides all 11 generic native-picker buttons when the marker is absent.
- Isolated Release non-RID and `win-x64` publish layouts launched the correct Admin host. The native Open Database dialog was manually opened and cancelled successfully in a Debug desktop smoke test.
- Signed Store package generation completed at `artifacts/admin-store-dialog-signed/packages/csharpdb-studio-v4.0.3-win-x64.msix`, with matching final JavaScript and CSS assets verified in the package stage.
- The exact v4.0.3 stage registered in Windows Development Mode with package status `Ok`. Packaged native dialogs for Open Database, Select Code Modules Workspace, and Save Table Export opened with the expected controls and canceled cleanly; the app and temporary registration were then removed.

BenchmarkDotNet same-machine comparisons against the pre-change `HEAD` found no measurable steady-state regression for existing inline workloads. The table shows geometric-mean deltas across each benchmark's configured parameter sets:

| Existing inline workload | Current vs. baseline |
|---|---:|
| Durable inserts | 1.6% faster |
| SQL primary-key reads | 2.4% faster |
| B-tree full scans | 1.0% faster |
| Cursor seek + 1,024 rows | 1.1% slower |

For the new approximately 6 KB overflow-row workload:

| Operation | Mean | Throughput | Allocated |
|---|---:|---:|---:|
| Durable insert | 2.365 ms | 423 ops/sec | 93,083 B |
| Hot primary-key read | 4.595 microseconds | 218K ops/sec | 19,368 B |

The overflow insert was approximately 4.4% slower than the small-row durable insert. Overflow reads were approximately 9.7 times slower than tiny inline reads because the overflow pages must be fetched and the payload reassembled. The baseline cannot complete the large-row benchmark because setup fails with the original leaf-split error.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- Existing format-v1 databases remain readable without modification. Before a write can commit, the base header is durably upgraded to format v2 so an older reader cannot accept a file whose WAL may contain tagged overflow references. A later failure may leave the header at v2 even when that write does not commit.
- Once the header is upgraded, the database requires a CSharpDB version that understands format v2. Back up before upgrading when rollback to an older binary may be required.
- Only encoded B-tree payloads above 4,075 bytes use overflow pages; existing inline payloads keep their normal representation.
- Overflow chains are validated completely before reads allocate the output buffer or reclamation frees any page.
- The steady-state benchmarks do not include the one-time format-v1 to format-v2 header flush.
- The cursor benchmark now records the final root page after seeding. Without that correction, its seek case starts from a stale leaf and does not measure a valid root-based seek.
- Native path selection is a Desktop Admin capability. Browser-hosted sessions retain editable path fields and the title-bar prompt fallback; generic Browse controls are hidden when no trusted desktop bridge is present.
- The WebView bridge only accepts requests from the active loopback Admin origin and revalidates that origin before returning generic filesystem paths after a dialog closes.
- The desktop host honors `CSHARPDB_ADMIN_EXE` first, then resolves the Admin executable from supported packaged, build, RID, publish, and custom artifacts layouts for the active build configuration.
- The signed artifact uses the existing `CN=MaxAkbar` local test certificate. The certificate was deliberately not added to a trusted store, so Windows reports the expected untrusted-root chain status; the packaged UI smoke test used Development Mode registration instead of changing machine trust.
