### PR TITLE
Add Admin desktop release archive

### DIFF
--- a/.github/workflows/admin-store-package.yml
+++ b/.github/workflows/admin-store-package.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -37,7 +37,7 @@ jobs:
           .\scripts\Publish-CSharpDbAdminStorePackage.ps1 @arguments
 
       - name: Upload Store package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: csharpdb-studio-store-package
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -121,10 +121,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -162,7 +162,7 @@ jobs:
             Select-String "csharpdb_"
 
       - name: Upload native library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.rid }}
           path: src/CSharpDB.Native/bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.lib }}
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload C header (once)
         if: matrix.rid == 'linux-x64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-header
           path: src/CSharpDB.Native/csharpdb.h
@@ -183,10 +183,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -236,7 +236,7 @@ jobs:
         run: ./scripts/Test-EfCoreNuGetPackage.ps1 -FeedPath artifacts/nuget
 
       - name: Upload NuGet artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
           path: artifacts/nuget/*.nupkg

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/perf-guardrails.yml
+++ b/.github/workflows/perf-guardrails.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Perf Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-guardrails-${{ github.run_id }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -73,10 +73,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -190,7 +190,7 @@ jobs:
             )
 
       - name: Upload NuGet artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
           path: artifacts/nuget/*.nupkg
@@ -216,10 +216,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -257,7 +257,7 @@ jobs:
             Select-String "csharpdb_"
 
       - name: Upload native library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.rid }}
           path: src/CSharpDB.Native/bin/Release/net10.0/${{ matrix.rid }}/publish/${{ matrix.lib }}
@@ -265,7 +265,7 @@ jobs:
 
       - name: Upload C header (once)
         if: matrix.rid == 'linux-x64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-header
           path: src/CSharpDB.Native/csharpdb.h
@@ -294,10 +294,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -444,7 +444,7 @@ jobs:
           $process.WaitForExit()
 
       - name: Upload daemon archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: daemon-${{ matrix.rid }}
           path: |
@@ -459,10 +459,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
@@ -500,7 +500,7 @@ jobs:
           }
 
       - name: Upload Admin desktop archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: admin-desktop-win-x64
           path: |
@@ -517,30 +517,30 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download NuGet artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nuget-packages
           path: artifacts/nuget
 
       - name: Download native artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: native-*
           path: artifacts/native
           merge-multiple: true
 
       - name: Download daemon artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: daemon-*
           path: artifacts/daemon
           merge-multiple: true
 
       - name: Download Admin desktop artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: admin-desktop-win-x64
           path: artifacts/admin-desktop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,9 +452,65 @@ jobs:
             artifacts/daemon-release/archives/*.tar.gz
           if-no-files-found: error
 
+  admin-desktop-archive:
+    name: Admin Desktop Archive (win-x64)
+    needs: build-and-test
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Publish Admin desktop archive
+        shell: pwsh
+        run: ./scripts/Publish-CSharpDbAdminRelease.ps1 -Runtime win-x64 -OutputRoot artifacts/admin-release
+
+      - name: Verify Admin desktop archive
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = $env:GITHUB_REF_NAME -replace '^v', ''
+          $archiveName = "csharpdb-admin-desktop-v$version-win-x64.zip"
+          $archivePath = Join-Path 'artifacts/admin-release/archives' $archiveName
+          $checksumPath = 'artifacts/admin-release/archives/ADMIN-SHA256SUMS.txt'
+
+          if (-not (Test-Path -LiteralPath $archivePath -PathType Leaf)) {
+            throw "Expected Admin desktop archive was not created: $archivePath"
+          }
+
+          if (-not (Select-String -Path $checksumPath -Pattern ([regex]::Escape($archiveName)) -Quiet)) {
+            throw "Admin checksum file does not contain $archiveName."
+          }
+
+          $extractRoot = Join-Path $env:RUNNER_TEMP 'csharpdb-admin-desktop-extract'
+          Expand-Archive -LiteralPath $archivePath -DestinationPath $extractRoot -Force
+
+          foreach ($requiredPath in @(
+              (Join-Path $extractRoot 'CSharpDB.Admin.Desktop.exe'),
+              (Join-Path $extractRoot 'admin/CSharpDB.Admin.exe'),
+              (Join-Path $extractRoot 'admin/wwwroot/help/index.html'))) {
+            if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+              throw "Required Admin desktop release file is missing: $requiredPath"
+            }
+          }
+
+      - name: Upload Admin desktop archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-desktop-win-x64
+          path: |
+            artifacts/admin-release/archives/*.zip
+            artifacts/admin-release/archives/ADMIN-SHA256SUMS.txt
+          if-no-files-found: error
+
   create-release:
     name: Create GitHub Release
-    needs: [publish-nuget, native-aot, daemon-archives]
+    needs: [publish-nuget, native-aot, daemon-archives, admin-desktop-archive]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -482,6 +538,12 @@ jobs:
           pattern: daemon-*
           path: artifacts/daemon
           merge-multiple: true
+
+      - name: Download Admin desktop artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: admin-desktop-win-x64
+          path: artifacts/admin-desktop
 
       - name: Generate daemon checksums
         shell: bash
@@ -525,6 +587,7 @@ jobs:
             artifacts/nuget/*.nupkg
             artifacts/native/*
             artifacts/daemon/*
+            artifacts/admin-desktop/*
 
       - name: Create release (auto-generated notes)
         if: steps.notes.outputs.has_notes == 'false'
@@ -536,3 +599,4 @@ jobs:
             artifacts/nuget/*.nupkg
             artifacts/native/*
             artifacts/daemon/*
+            artifacts/admin-desktop/*

--- a/scripts/Publish-CSharpDbAdminRelease.ps1
+++ b/scripts/Publish-CSharpDbAdminRelease.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+Publishes the portable CSharpDB Admin desktop release archive.
+
+.DESCRIPTION
+Publishes the WPF/WebView2 desktop shell and the CSharpDB.Admin web host as
+self-contained Windows applications. The Admin host is placed in the desktop
+shell's private admin folder, and the complete runnable layout is packaged as
+a ZIP for GitHub Releases.
+
+.PARAMETER Version
+The release version used in the archive name. When omitted, the script derives
+it from a v-prefixed GITHUB_REF_NAME, then falls back to 0.0.0-local.
+
+.PARAMETER Runtime
+The Windows runtime identifier to publish. Defaults to win-x64.
+
+.PARAMETER Configuration
+The build configuration passed to dotnet publish. Defaults to Release.
+
+.PARAMETER OutputRoot
+The output root. Defaults to artifacts/admin-release.
+
+.PARAMETER NoRestore
+Passes --no-restore to dotnet publish.
+
+.EXAMPLE
+.\scripts\Publish-CSharpDbAdminRelease.ps1 -Version 4.3.0
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$Version,
+    [ValidateSet('win-x64')]
+    [string]$Runtime = 'win-x64',
+    [string]$Configuration = 'Release',
+    [string]$OutputRoot,
+    [switch]$NoRestore
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Resolve-Version {
+    param([string]$RequestedVersion)
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedVersion)) {
+        return $RequestedVersion.Trim().TrimStart('v')
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_REF_NAME) -and $env:GITHUB_REF_NAME.StartsWith('v')) {
+        return $env:GITHUB_REF_NAME.Substring(1)
+    }
+
+    return '0.0.0-local'
+}
+
+function Invoke-AdminPublish {
+    param(
+        [string]$ProjectPath,
+        [string]$Destination,
+        [string]$RuntimeIdentifier,
+        [string]$BuildConfiguration,
+        [switch]$SkipRestore
+    )
+
+    $arguments = @(
+        'publish', $ProjectPath,
+        '--configuration', $BuildConfiguration,
+        '--runtime', $RuntimeIdentifier,
+        '--self-contained', 'true',
+        '--output', $Destination,
+        '-p:PublishSingleFile=false'
+    )
+
+    if ($SkipRestore.IsPresent) {
+        $arguments += '--no-restore'
+    }
+
+    & dotnet @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish failed for $ProjectPath with exit code $LASTEXITCODE."
+    }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$releaseVersion = Resolve-Version -RequestedVersion $Version
+
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = Join-Path $repoRoot 'artifacts\admin-release'
+}
+elseif (-not [System.IO.Path]::IsPathRooted($OutputRoot)) {
+    $OutputRoot = Join-Path $repoRoot $OutputRoot
+}
+
+$adminProject = Join-Path $repoRoot 'src\CSharpDB.Admin\CSharpDB.Admin.csproj'
+$desktopProject = Join-Path $repoRoot 'src\CSharpDB.Admin.Desktop\CSharpDB.Admin.Desktop.csproj'
+$publishRoot = Join-Path $OutputRoot 'publish'
+$adminPublish = Join-Path $publishRoot 'admin'
+$desktopPublish = Join-Path $publishRoot 'desktop'
+$archiveRoot = Join-Path $OutputRoot 'archives'
+$archiveName = "csharpdb-admin-desktop-v$releaseVersion-$Runtime.zip"
+$archivePath = Join-Path $archiveRoot $archiveName
+
+foreach ($projectPath in @($adminProject, $desktopProject)) {
+    if (-not (Test-Path -LiteralPath $projectPath -PathType Leaf)) {
+        throw "Required project was not found: $projectPath"
+    }
+}
+
+if ($PSCmdlet.ShouldProcess($Runtime, "Publish $archiveName")) {
+    if (Test-Path -LiteralPath $OutputRoot) {
+        Remove-Item -LiteralPath $OutputRoot -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $adminPublish, $desktopPublish, $archiveRoot -Force | Out-Null
+
+    Write-Host 'Publishing CSharpDB.Admin...'
+    Invoke-AdminPublish -ProjectPath $adminProject -Destination $adminPublish -RuntimeIdentifier $Runtime -BuildConfiguration $Configuration -SkipRestore:$NoRestore
+
+    Write-Host 'Publishing CSharpDB.Admin.Desktop...'
+    Invoke-AdminPublish -ProjectPath $desktopProject -Destination $desktopPublish -RuntimeIdentifier $Runtime -BuildConfiguration $Configuration -SkipRestore:$NoRestore
+
+    if (-not (Test-Path -LiteralPath (Join-Path $adminPublish 'CSharpDB.Admin.exe') -PathType Leaf)) {
+        throw 'The published Admin host executable was not created.'
+    }
+
+    if (-not (Test-Path -LiteralPath (Join-Path $adminPublish 'wwwroot\help\index.html') -PathType Leaf)) {
+        throw 'The published Admin host does not contain its help files.'
+    }
+
+    if (-not (Test-Path -LiteralPath (Join-Path $desktopPublish 'CSharpDB.Admin.Desktop.exe') -PathType Leaf)) {
+        throw 'The published desktop executable was not created.'
+    }
+
+    Copy-Item -LiteralPath $adminPublish -Destination (Join-Path $desktopPublish 'admin') -Recurse -Force
+    Compress-Archive -Path (Join-Path $desktopPublish '*') -DestinationPath $archivePath -Force
+
+    $hash = Get-FileHash -LiteralPath $archivePath -Algorithm SHA256
+    $checksumPath = Join-Path $archiveRoot 'ADMIN-SHA256SUMS.txt'
+    Set-Content -LiteralPath $checksumPath -Value "$($hash.Hash.ToLowerInvariant())  $archiveName" -Encoding ASCII
+
+    Write-Host 'CSharpDB Admin desktop release archive complete.'
+    Write-Host "  Archive:  $archivePath"
+    Write-Host "  Checksum: $checksumPath"
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -285,6 +285,23 @@ The package identity starts as `MaxAkbar.CSharpDBStudio` with publisher
 `CN=MaxAkbar`; associate the package with Partner Center before submission so
 the final Store identity and publisher are applied.
 
+### `Publish-CSharpDbAdminRelease.ps1`
+
+Use this to create the portable Windows Admin desktop archive published with a
+GitHub Release. It publishes `CSharpDB.Admin.Desktop.exe` and the self-contained
+`CSharpDB.Admin` host, places the host under the shell's required `admin/`
+folder, and creates:
+
+`csharpdb-admin-desktop-v{version}-win-x64.zip`
+
+The archive can be extracted anywhere and launched with
+`CSharpDB.Admin.Desktop.exe`. A matching entry is written to
+`ADMIN-SHA256SUMS.txt`.
+
+```powershell
+.\scripts\Publish-CSharpDbAdminRelease.ps1 -Version 4.3.0
+```
+
 ## Daemon Service Installers
 
 Release archives include OS service assets under `service/`:


### PR DESCRIPTION
## What changed

- add a Windows x64 release job for `CSharpDB.Admin.Desktop`
- publish the self-contained `CSharpDB.Admin` host inside the required `admin/` folder
- attach the portable ZIP and its dedicated SHA-256 checksum file to tagged GitHub releases
- verify the desktop executable, Admin executable, and published help content before upload
- document local creation of the portable archive
- update GitHub-maintained actions across all workflows to Node.js 24-native majors:
  - `actions/checkout@v7`
  - `actions/setup-dotnet@v6`
  - `actions/upload-artifact@v7`
  - `actions/download-artifact@v8`

## Why

Tagged releases currently publish NuGet packages, native libraries, and daemon archives, but not the Admin desktop application. This adds a portable desktop distribution to the same release path.

GitHub now forces Node.js 20-based actions to run on Node.js 24 and emits deprecation warnings. Updating the action majors removes that compatibility warning before Node.js 20 support is fully removed.

## User impact

Future `v*` releases will include `csharpdb-admin-desktop-v{version}-win-x64.zip`. Users can extract it and launch `CSharpDB.Admin.Desktop.exe`; the bundled Admin host is started from the archive's private `admin/` directory.

Repository workflows now use action releases that natively target Node.js 24.

## Validation

- parsed the new PowerShell release script successfully
- completed a real self-contained `win-x64` publish locally
- verified the generated 125.9 MiB ZIP contains 690 entries, including:
  - `CSharpDB.Admin.Desktop.exe`
  - `admin/CSharpDB.Admin.exe`
  - `admin/wwwroot/help/index.html`
- parsed all five GitHub Actions workflow YAML files successfully
- confirmed no targeted Node.js 20-era `@v4` action references remain
- `git diff --check`
