### PR TITLE
Fix LiteDB snapshot writer detection

### DIFF
--- a/src/CSharpDB.Migration.LiteDb/LiteDbRetainedSnapshot.cs
+++ b/src/CSharpDB.Migration.LiteDb/LiteDbRetainedSnapshot.cs
@@ -114,7 +114,7 @@ public sealed class LiteDbRetainedSnapshot
                 sourcePath,
                 FileMode.Open,
                 FileAccess.Read,
-                FileShare.Read,
+                FileShare.None,
                 CopyBufferBytes,
                 FileOptions.Asynchronous |
                 FileOptions.SequentialScan))


### PR DESCRIPTION
## What changed

- open the LiteDB source snapshot with `FileShare.None`
- hold that exclusive read handle for the complete byte-for-byte copy

## Why

The v4.3.0 Release workflow failed its build-and-test gate on Ubuntu and macOS in `LiteDbRetainedSnapshotTests.CaptureRejectsWriterOversizeEncryptionAndCollisions`. Windows correctly rejected the active LiteDB writer, but Unix allowed the snapshot's `FileShare.Read` handle to open concurrently.

The snapshot API promises an offline/quiesced capture. Using `FileShare.None` makes writer detection and snapshot isolation consistent across supported operating systems.

## User impact

LiteDB retained snapshots now fail closed when another process or connection has the source database open, including on Linux and macOS. Callers must close active LiteDB connections before creating the offline snapshot.

## Validation

- reproduced the original behavior under Ubuntu:
  - `FileShare.Read`: opened while the LiteDB writer was active
  - `FileShare.None`: correctly rejected while the writer was active
- focused failing regression: 1/1 passed
- complete `CSharpDB.Migration.LiteDb.Tests` suite: 22/22 passed
- `git diff --check`

## Release recovery

The failed `v4.3.0` tag still points to the original failing commit. After this fix is merged, publish a new patch release or explicitly replace that tag before rerunning the Release workflow.
