### PR TITLE
Guard release tags with exact durable qualification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,31 +19,19 @@ jobs:
       statuses: read
 
     steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v7
+
       - name: Require a successful matching-commit local performance status
-        shell: bash
+        shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          PERFORMANCE_STATUS_CONTEXT: csharpdb/local-durable-performance
           EXPECTED_STATUS_CREATOR: ${{ vars.LOCAL_DURABLE_ATTESTOR || github.repository_owner }}
         run: |
-          set -euo pipefail
-          status_record="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/statuses?per_page=100" \
-            --jq '([.[] | select(.context == "csharpdb/local-durable-performance")][0] // {}) | [.state // "", .creator.login // "", .description // ""] | @tsv')"
-          IFS=$'\t' read -r state creator description <<< "$status_record"
-          if [[ "$state" != "success" ]]; then
-            echo "::error::Commit ${GITHUB_SHA} has no successful ${PERFORMANCE_STATUS_CONTEXT} status. Run Test-LocalDurablePerformance.ps1 successfully before creating the release tag."
-            exit 1
-          fi
-          if [[ "${creator,,}" != "${EXPECTED_STATUS_CREATOR,,}" ]]; then
-            echo "::error::The ${PERFORMANCE_STATUS_CONTEXT} status was created by ${creator}, not the configured attestor ${EXPECTED_STATUS_CREATOR}."
-            exit 1
-          fi
-          attestation_pattern='^policy=durable-v2; baseline=[0-9a-f]{40}; reports=[0-9A-F]{8}/[0-9A-F]{8}$'
-          if [[ ! "$description" =~ $attestation_pattern ]]; then
-            echo "::error::The ${PERFORMANCE_STATUS_CONTEXT} status does not contain a canonical durable-v2 attestation."
-            exit 1
-          fi
+          ./scripts/Test-LocalDurableStatus.ps1 `
+            -Commit '${{ github.sha }}' `
+            -GitHubRepository '${{ github.repository }}' `
+            -ExpectedCreator $env:EXPECTED_STATUS_CREATOR
 
   build-and-test:
     name: Qualify release source

--- a/scripts/Publish-ReleaseTag.ps1
+++ b/scripts/Publish-ReleaseTag.ps1
@@ -1,0 +1,322 @@
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$')]
+    [string] $Version,
+
+    [switch] $ConfirmDedicatedFixedSsd,
+
+    [ValidatePattern('^$|^[^/\s]+/[^/\s]+$')]
+    [string] $GitHubRepository = '',
+
+    [string] $ExpectedStatusCreator = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$statusVerifier = Join-Path $PSScriptRoot 'Test-LocalDurableStatus.ps1'
+$localQualification = Join-Path `
+    $repositoryRoot `
+    'tests/CSharpDB.Benchmarks/scripts/Test-LocalDurablePerformance.ps1'
+$tagValidator = Join-Path $PSScriptRoot 'Test-ReleaseTag.ps1'
+$releaseVersion = $Version.TrimStart('v')
+$releaseTag = "v$releaseVersion"
+
+foreach ($requiredScript in $statusVerifier, $localQualification, $tagValidator) {
+    if (-not (Test-Path -LiteralPath $requiredScript -PathType Leaf)) {
+        throw "Required release script was not found: $requiredScript"
+    }
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory)]
+        [string[]] $Arguments,
+
+        [Parameter(Mandatory)]
+        [string] $FailureMessage
+    )
+
+    $output = @(& git -C $repositoryRoot @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        $details = ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+        if ([string]::IsNullOrWhiteSpace($details)) {
+            throw $FailureMessage
+        }
+        throw "$FailureMessage$([Environment]::NewLine)$details"
+    }
+
+    return ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+}
+
+function Resolve-GitCommitOrNull {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Ref
+    )
+
+    $output = @(& git -C $repositoryRoot rev-parse --verify "$Ref`^{commit}" 2>$null)
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        return $null
+    }
+
+    $resolved = (($output | ForEach-Object { [string] $_ }) -join '').Trim()
+    if ($resolved -cnotmatch '^[0-9a-f]{40}$') {
+        throw "Git ref '$Ref' did not resolve to a canonical commit SHA."
+    }
+    return $resolved
+}
+
+function Resolve-RemoteTagCommitOrNull {
+    param(
+        [Parameter(Mandatory)]
+        [string] $TagName
+    )
+
+    $output = Invoke-Git `
+        -Arguments @(
+            'ls-remote',
+            '--tags',
+            'origin',
+            "refs/tags/$TagName",
+            "refs/tags/$TagName`^{}") `
+        -FailureMessage "Could not inspect remote release tag '$TagName'."
+    if ([string]::IsNullOrWhiteSpace($output)) {
+        return $null
+    }
+
+    $records = @(
+        $output -split "`r?`n" |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            ForEach-Object {
+                if ($_ -cnotmatch '^(?<sha>[0-9a-f]{40})\s+(?<ref>refs/tags/.+)$') {
+                    throw "Remote tag query returned an invalid record: $_"
+                }
+                [pscustomobject]@{
+                    Sha = $Matches.sha
+                    Ref = $Matches.ref
+                }
+            }
+    )
+    $peeledRef = "refs/tags/$TagName`^{}"
+    $peeled = @($records | Where-Object { $_.Ref -ceq $peeledRef })
+    if ($peeled.Count -gt 1) {
+        throw "Remote release tag '$TagName' returned multiple peeled commits."
+    }
+    if ($peeled.Count -eq 1) {
+        return [string] $peeled[0].Sha
+    }
+
+    $directRef = "refs/tags/$TagName"
+    $direct = @($records | Where-Object { $_.Ref -ceq $directRef })
+    if ($direct.Count -ne 1) {
+        throw "Remote release tag '$TagName' did not resolve unambiguously."
+    }
+    return [string] $direct[0].Sha
+}
+
+function Invoke-StatusVerifier {
+    & $statusVerifier `
+        -Commit $headCommit `
+        -GitHubRepository $GitHubRepository `
+        -ExpectedCreator $ExpectedStatusCreator
+}
+
+function Get-ExactCurrentMainCommit {
+    $workingTreeChanges = Invoke-Git `
+        -Arguments @('status', '--porcelain=v1', '--untracked-files=all') `
+        -FailureMessage 'Could not inspect the repository worktree.'
+    if (-not [string]::IsNullOrWhiteSpace($workingTreeChanges)) {
+        throw 'Release tagging requires a clean repository worktree.'
+    }
+
+    $currentBranch = (Invoke-Git `
+        -Arguments @('branch', '--show-current') `
+        -FailureMessage 'Could not determine the current branch.').Trim()
+    if ($currentBranch -cne 'main') {
+        throw "Release tagging must run from branch 'main'; current branch is '$currentBranch'."
+    }
+
+    Invoke-Git `
+        -Arguments @(
+            'fetch',
+            '--quiet',
+            'origin',
+            '+refs/heads/main:refs/remotes/origin/main') `
+        -FailureMessage "Could not refresh 'origin/main'." |
+        Out-Null
+
+    $localMainCommit = (Invoke-Git `
+        -Arguments @('rev-parse', '--verify', 'HEAD^{commit}') `
+        -FailureMessage 'Could not resolve the current HEAD commit.').Trim()
+    $remoteMainCommit = (Invoke-Git `
+        -Arguments @('rev-parse', '--verify', 'origin/main^{commit}') `
+        -FailureMessage "Could not resolve 'origin/main'.").Trim()
+    if ($localMainCommit -cne $remoteMainCommit) {
+        throw (
+            "Release tagging requires local main to equal origin/main exactly. " +
+            "Local HEAD is $localMainCommit; origin/main is $remoteMainCommit.")
+    }
+
+    return $localMainCommit
+}
+
+$headCommit = Get-ExactCurrentMainCommit
+
+$buildPropsPath = Join-Path $repositoryRoot 'src/Directory.Build.props'
+if (-not (Test-Path -LiteralPath $buildPropsPath -PathType Leaf)) {
+    throw "Shared package properties were not found at '$buildPropsPath'."
+}
+[xml] $buildProps = [IO.File]::ReadAllText($buildPropsPath)
+$versionNodes = @($buildProps.SelectNodes('/Project/PropertyGroup/Version'))
+if ($versionNodes.Count -ne 1) {
+    throw "Expected exactly one Version property in '$buildPropsPath'; found $($versionNodes.Count)."
+}
+$packageVersion = $versionNodes[0].InnerText.Trim()
+if ($packageVersion -cne $releaseVersion) {
+    throw (
+        "Release tag version '$releaseVersion' does not match package version " +
+        "'$packageVersion' in '$buildPropsPath'.")
+}
+
+if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw 'GitHub CLI (gh) is required to publish a release tag.'
+}
+if ([string]::IsNullOrWhiteSpace($GitHubRepository)) {
+    $repositoryOutput = @(
+        & gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>&1
+    )
+    if ($LASTEXITCODE -ne 0) {
+        $details = ($repositoryOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+        throw "Could not resolve the GitHub repository. $details"
+    }
+    $GitHubRepository = (($repositoryOutput | ForEach-Object { [string] $_ }) -join '').Trim()
+}
+if ($GitHubRepository -cnotmatch '^[^/\s]+/[^/\s]+$') {
+    throw "GitHubRepository must use the owner/name form: $GitHubRepository"
+}
+
+if ([string]::IsNullOrWhiteSpace($ExpectedStatusCreator)) {
+    $variableOutput = @(
+        & gh variable get LOCAL_DURABLE_ATTESTOR --repo $GitHubRepository 2>&1
+    )
+    $variableExitCode = $LASTEXITCODE
+    if ($variableExitCode -eq 0) {
+        $ExpectedStatusCreator =
+            (($variableOutput | ForEach-Object { [string] $_ }) -join '').Trim()
+    }
+    else {
+        $variableFailure =
+            ($variableOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+        if ($variableFailure -notmatch '(?i)(HTTP\s+404|not\s+found)') {
+            throw (
+                "Could not resolve the LOCAL_DURABLE_ATTESTOR repository variable. " +
+                $variableFailure)
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($ExpectedStatusCreator)) {
+        $ExpectedStatusCreator = $GitHubRepository.Split('/', 2)[0]
+    }
+}
+else {
+    $ExpectedStatusCreator = $ExpectedStatusCreator.Trim()
+}
+
+$hasReusableStatus = $false
+try {
+    Invoke-StatusVerifier
+    $hasReusableStatus = $true
+    Write-Host "Reusing the existing canonical durable-v2 status for exact commit $headCommit."
+}
+catch {
+    Write-Host "Exact commit $headCommit has no reusable durable-v2 status: $($_.Exception.Message)"
+}
+
+if (-not $hasReusableStatus) {
+    if (-not $ConfirmDedicatedFixedSsd) {
+        throw (
+            "Commit $headCommit does not have a reusable canonical durable-v2 status. " +
+            'Rerun with -ConfirmDedicatedFixedSsd on the idle dedicated fixed-SSD Windows machine.')
+    }
+
+    & $localQualification `
+        -CandidateRef $headCommit `
+        -ConfirmDedicatedFixedSsd `
+        -GitHubRepository $GitHubRepository
+
+    Invoke-StatusVerifier
+}
+
+$currentMainCommit = Get-ExactCurrentMainCommit
+if ($currentMainCommit -cne $headCommit) {
+    throw (
+        "The exact main commit changed during release qualification. Qualified $headCommit, " +
+        "but current main is $currentMainCommit. Restart release tagging for the current commit.")
+}
+
+$localTagCommit = Resolve-GitCommitOrNull -Ref "refs/tags/$releaseTag"
+if ($null -ne $localTagCommit -and $localTagCommit -cne $headCommit) {
+    throw (
+        "Local release tag '$releaseTag' points to $localTagCommit, not exact release " +
+        "commit $headCommit.")
+}
+
+$remoteTagCommit = Resolve-RemoteTagCommitOrNull -TagName $releaseTag
+if ($null -ne $remoteTagCommit -and $remoteTagCommit -cne $headCommit) {
+    throw (
+        "Remote release tag '$releaseTag' points to $remoteTagCommit, not exact release " +
+        "commit $headCommit.")
+}
+
+if ($null -eq $localTagCommit) {
+    if ($null -ne $remoteTagCommit) {
+        Invoke-Git `
+            -Arguments @(
+                'fetch',
+                '--quiet',
+                'origin',
+                "refs/tags/$releaseTag`:refs/tags/$releaseTag") `
+            -FailureMessage "Could not fetch existing remote release tag '$releaseTag'." |
+            Out-Null
+    }
+    else {
+        Invoke-Git `
+            -Arguments @('tag', $releaseTag, $headCommit) `
+            -FailureMessage "Could not create local release tag '$releaseTag'." |
+            Out-Null
+    }
+
+    $localTagCommit = Resolve-GitCommitOrNull -Ref "refs/tags/$releaseTag"
+    if ($localTagCommit -cne $headCommit) {
+        throw "Local release tag '$releaseTag' was not created at exact commit $headCommit."
+    }
+}
+else {
+    Write-Host "Reusing local release tag '$releaseTag' at exact commit $headCommit."
+}
+
+& $tagValidator -Version $releaseTag -TagCommit $headCommit
+
+if ($null -eq $remoteTagCommit) {
+    Invoke-Git `
+        -Arguments @(
+            'push',
+            'origin',
+            "refs/tags/$releaseTag`:refs/tags/$releaseTag") `
+        -FailureMessage "Could not push release tag '$releaseTag'." |
+        Out-Null
+
+    $remoteTagCommit = Resolve-RemoteTagCommitOrNull -TagName $releaseTag
+    if ($remoteTagCommit -cne $headCommit) {
+        throw "Remote release tag '$releaseTag' was not published at exact commit $headCommit."
+    }
+    Write-Host "Published release tag '$releaseTag' at exact commit $headCommit."
+}
+else {
+    Write-Host "Remote release tag '$releaseTag' already points to exact commit $headCommit."
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,9 +12,11 @@ and are included in daemon release archives.
 
 The release and local workflow notes are grouped by audience:
 
-- Release maintainers use `scripts/Publish-CSharpDbDaemonRelease.ps1` directly
-  for local packaging checks. The GitHub Release workflow also uses this script
-  when a `v*` tag is pushed.
+- Release maintainers use `scripts/Publish-ReleaseTag.ps1` to qualify the exact
+  merged `main` commit and publish its release tag. They can use
+  `scripts/Publish-CSharpDbDaemonRelease.ps1` directly for local packaging
+  checks. The GitHub Release workflow also uses the daemon publisher after the
+  guarded `v*` tag is pushed.
 - Store release maintainers use
   `scripts/Publish-CSharpDbAdminStorePackage.ps1` on Windows to produce the
   CSharpDB Studio MSIX and `.msixupload` artifacts for Partner Center.
@@ -134,9 +136,8 @@ Get-ChildItem artifacts\daemon-release-local\archives
 Get-Content artifacts\daemon-release-local\archives\SHA256SUMS.txt
 ```
 
-5. After the pull request is merged, update local `main`, qualify the exact merge
-   commit on the dedicated fixed-SSD Windows machine, then create and push the
-   tag.
+5. After the pull request is merged, update local `main`, then run the canonical
+   release-tag publisher on the dedicated fixed-SSD Windows machine.
 
 ```powershell
 git switch main
@@ -145,33 +146,54 @@ $Version = (Read-Host 'Release version without the v prefix').Trim()
 if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
   throw 'Enter a semantic release version in major.minor.patch form.'
 }
-$Tag = "v$Version"
-$TagCommit = (git rev-parse 'HEAD^{commit}').Trim()
 
-.\tests\CSharpDB.Benchmarks\scripts\Test-LocalDurablePerformance.ps1 `
-  -CandidateRef $TagCommit `
+.\scripts\Publish-ReleaseTag.ps1 `
+  -Version $Version `
   -ConfirmDedicatedFixedSsd
-
-git tag $Tag $TagCommit
-
-.\scripts\Test-ReleaseTag.ps1 `
-  -Version $Tag `
-  -TagCommit $TagCommit
-
-git push origin $Tag
 ```
 
-The local wrapper forces durable mode and runs the ten durable SQL/collection
-single and batch write rows in two sequential balanced paired passes. On an idle
-fixed-SSD machine they normally take 75-100 minutes total. It pins the candidate
-and previous commits, retains hash-verified raw evidence and a Markdown summary
-outside the repository, creates no repository JSON, and publishes the
-`csharpdb/local-durable-performance` status only after both passes succeed. The
-release workflow requires that matching-commit status, completes both clean
-functional passes on Windows, Linux, and macOS, and runs the 18 persistent-read
-and in-memory performance rows on hosted Windows runners. It then
-publishes the daemon archives for
-`win-x64`, `linux-x64`, and `osx-arm64`, smoke-starts each extracted binary,
+`Publish-ReleaseTag.ps1` is the only supported way to create a release tag. Do
+not create release tags in the GitHub UI or with raw `git tag` / `git push`
+commands; those paths bypass the preflight and cause the fail-closed Release
+workflow to reject the tag. The publisher requires a clean, checked-out `main`,
+fetches `origin/main`, and requires local `HEAD` to equal that remote commit. It
+also validates the requested version and requires a canonical
+`csharpdb/local-durable-performance` success status from the configured attestor
+on that exact SHA before it creates or pushes the tag.
+
+When that exact commit already has a valid status, the publisher reuses it and
+does not rerun the benchmarks. Otherwise `-ConfirmDedicatedFixedSsd` authorizes
+the publisher to run the local durable wrapper. That wrapper forces durable mode
+and runs the ten durable SQL/collection single and batch write rows in two
+sequential balanced paired passes. On an idle fixed-SSD machine this normally
+takes 75–100 minutes total. It pins the candidate and previous commits, retains
+hash-verified raw evidence and a Markdown summary outside the repository,
+creates no repository JSON, and publishes the status only after both passes
+succeed. Without a reusable status or the confirmation switch, the publisher
+stops before creating a tag and explains how to run the required qualification.
+
+The wrapper's Windows quiescence preflight refuses to start while `msiexec` is
+active or Windows reports a pending restart, including pending file-renames. It
+also audits Windows Installer transactions after each pass. Installer activity
+during either pass, or a pending-restart condition detected afterward,
+contaminates the evidence and prevents qualification. Contamination after pass 1
+stops the run before pass 2. Finish application or .NET workload installers,
+restart Windows when requested, and begin a new clean run rather than reusing
+contaminated evidence.
+
+The command is idempotent for the same version and exact commit: it safely
+reuses a valid status and an existing local or remote tag that already points to
+that commit. It rejects a same-named tag that points elsewhere. Optional
+`-GitHubRepository owner/name` and `-ExpectedStatusCreator login` arguments are
+available when repository discovery or the configured attestor must be supplied
+explicitly.
+
+The Release workflow remains a fail-closed backstop. It independently requires
+the matching-commit status, completes both clean functional passes on Windows,
+Linux, and macOS, and runs the 18 persistent-read and in-memory performance rows
+on hosted Windows runners before publishing. It then publishes the daemon
+archives for `win-x64`, `linux-x64`, and `osx-arm64`, smoke-starts each extracted
+binary,
 calls the daemon REST `/api/info` endpoint, verifies a gRPC `GetInfoAsync`
 client call, combines checksums, and attaches everything to the GitHub Release.
 

--- a/scripts/Test-LocalDurableStatus.ps1
+++ b/scripts/Test-LocalDurableStatus.ps1
@@ -1,0 +1,83 @@
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $Commit,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[^/\s]+/[^/\s]+$')]
+    [string] $GitHubRepository,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $ExpectedCreator
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$statusContext = 'csharpdb/local-durable-performance'
+$canonicalAttestationPattern =
+    '^policy=durable-v2; baseline=[0-9a-f]{40}; reports=[0-9A-F]{8}/[0-9A-F]{8}$'
+$commitSha = $Commit.ToLowerInvariant()
+$expectedCreatorLogin = $ExpectedCreator.Trim()
+
+if ([string]::IsNullOrWhiteSpace($expectedCreatorLogin)) {
+    throw 'ExpectedCreator cannot be empty or whitespace.'
+}
+if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw 'GitHub CLI (gh) is required to verify the local durable performance status.'
+}
+
+$apiPath = "repos/$GitHubRepository/commits/$commitSha/statuses?per_page=100"
+$apiOutput = @(& gh api $apiPath 2>&1)
+if ($LASTEXITCODE -ne 0) {
+    $details = ($apiOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+    throw "Could not read GitHub statuses for commit $commitSha. $details"
+}
+
+try {
+    $statuses = @(($apiOutput -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20)
+}
+catch {
+    throw "GitHub returned invalid status JSON for commit $commitSha. $($_.Exception.Message)"
+}
+
+$matchingStatuses = @(
+    $statuses |
+        Where-Object { [string] $_.context -ceq $statusContext } |
+        Sort-Object -Property @(
+            @{ Expression = { [DateTimeOffset] $_.created_at }; Descending = $true },
+            @{ Expression = { [Int64] $_.id }; Descending = $true }
+        )
+)
+if ($matchingStatuses.Count -eq 0) {
+    throw "Commit $commitSha has no $statusContext status."
+}
+
+$latestStatus = $matchingStatuses[0]
+$state = [string] $latestStatus.state
+if ($state -cne 'success') {
+    throw (
+        "Latest $statusContext status for commit $commitSha is '$state', not 'success'.")
+}
+
+$creator = [string] $latestStatus.creator.login
+if (-not $creator.Equals($expectedCreatorLogin, [StringComparison]::OrdinalIgnoreCase)) {
+    throw (
+        "Latest $statusContext status for commit $commitSha was created by '$creator', " +
+        "not expected creator '$expectedCreatorLogin'.")
+}
+
+$description = [string] $latestStatus.description
+if ($description -cnotmatch $canonicalAttestationPattern) {
+    throw (
+        "Latest $statusContext status for commit $commitSha does not contain a canonical " +
+        'durable-v2 attestation.')
+}
+
+Write-Host (
+    "Verified canonical durable-v2 status for exact commit $commitSha " +
+    "from $creator.")

--- a/tests/CSharpDB.Benchmarks/README.md
+++ b/tests/CSharpDB.Benchmarks/README.md
@@ -441,26 +441,52 @@ Run the balanced release-core benchmark suite:
 dotnet run -c Release --project .\tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.csproj -- --release-core --repeat 3 --repro
 ```
 
-Qualify durable-write performance against the previous release on one idle,
-fixed-SSD Windows machine before creating the release tag:
+After the release pull request is merged, update local `main` and use the
+canonical publisher on one idle, fixed-SSD Windows machine. This command owns
+both exact-commit durable qualification and release-tag publication:
 
 ```powershell
 git switch main
 git pull --ff-only
-$CandidateCommit = (git rev-parse 'HEAD^{commit}').Trim()
+$Version = (Read-Host 'Release version without the v prefix').Trim()
 
-pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Test-LocalDurablePerformance.ps1 `
-  -CandidateRef $CandidateCommit `
+.\scripts\Publish-ReleaseTag.ps1 `
+  -Version $Version `
   -ConfirmDedicatedFixedSsd
 ```
 
-The repository must be clean because both revisions are built from committed
-source. The wrapper resolves the candidate to one immutable commit. When
-`-PreviousRef` is omitted, the nearest prior semantic release reachable from
-that candidate is discovered during pass 1 and pinned for pass 2. The previous
-revision must be an ancestor of the candidate, and generated evidence is written
-to a unique temporary directory outside the repository unless `-OutputPath`
-selects another absent or empty external directory.
+Do not create a release tag in the GitHub UI or with raw `git tag` / `git push`
+commands. Those paths bypass the release preflight and the fail-closed Release
+workflow will reject the tag. `Publish-ReleaseTag.ps1` requires a clean,
+checked-out `main`, fetches `origin/main`, requires local `HEAD` to equal that
+remote commit, validates the version, and requires a canonical
+`csharpdb/local-durable-performance` success status from the configured attestor
+on that exact SHA.
+
+If that exact commit already has a valid status, the publisher reuses it without
+rerunning the benchmarks. If it does not, the confirmation switch permits the
+publisher to run `Test-LocalDurablePerformance.ps1`; this normally takes about
+75–100 minutes on an idle fixed-SSD machine. Without a reusable status or
+`-ConfirmDedicatedFixedSsd`, it stops before creating a tag and tells the
+operator how to qualify the commit. The publisher is idempotent for the same
+version and exact commit: an existing local or remote tag at that commit is
+reused, while a same-named tag at another commit is rejected.
+
+During a new qualification, the repository must remain clean because both
+revisions are built from committed source. The wrapper resolves the candidate to
+one immutable commit. It discovers the nearest prior semantic release reachable
+from that candidate during pass 1 and pins it for pass 2. The previous revision
+must be an ancestor of the candidate, and generated evidence is written to a
+unique temporary directory outside the repository.
+
+The Windows quiescence preflight refuses to start while `msiexec` is active or
+Windows reports a pending restart, including pending file-renames. The wrapper
+also audits Windows Installer transactions after each pass. New installer
+activity or a pending-restart condition detected afterward contaminates that
+timing evidence and prevents qualification. Contamination after pass 1 stops the
+run before pass 2. Finish application or .NET workload installers, restart
+Windows when requested, and begin a new clean run instead of reusing
+contaminated evidence.
 
 The local release gate runs only `master-table-durable-writes`: ten durable SQL
 and collection single/batch write rows from file-backed, hybrid incremental-
@@ -486,13 +512,13 @@ previous-release worktree so both engines run the same harness. Candidate and
 previous root build inputs are hashed and reported separately because they
 remain revision-specific, and both revisions are built once per pass.
 
-With `-RepeatCount 3`, each pass runs three pairs in each order: six adjacent
-pairs and twelve logical invocations. Every logical invocation performs one
-unrecorded warmup followed by one recorded sample. Each pass retains all six raw
+With the canonical repeat count of three, each pass runs three pairs in each
+order: six adjacent pairs and twelve logical invocations. Every logical
+invocation performs one unrecorded warmup followed by one recorded sample. Each
+pass retains all six raw
 CSVs and the recomputed aggregate for each revision, the pair manifest, and the
 paired comparison report. Copied evidence is hash-checked before the source
-result is removed. Both passes normally complete in about 75-100 minutes total
-on an idle fixed-SSD machine.
+result is removed.
 
 The comparer requires exact schema and row-name parity across raw and aggregate
 evidence, positive gate metrics, at least 100 retained latency observations per
@@ -525,7 +551,8 @@ with permission to create commit statuses is therefore required. The
 cannot qualify a release. The release workflow accepts the status only from the
 login configured in the `LOCAL_DURABLE_ATTESTOR` repository variable, or from
 the repository owner when that variable is unset, and requires a canonical
-`durable-v2` policy attestation.
+`durable-v2` policy attestation. This check remains a fail-closed backstop; it
+does not replace the preflight performed by `Publish-ReleaseTag.ps1`.
 
 The existing scheduled perf-guardrail workflow remains report-only and includes
 the durable SQL batching baseline plus its configured micro and diagnostic

--- a/tests/CSharpDB.Benchmarks/scripts/Test-LocalDurablePerformance.ps1
+++ b/tests/CSharpDB.Benchmarks/scripts/Test-LocalDurablePerformance.ps1
@@ -140,6 +140,113 @@ function Invoke-GitHubStatus {
     }
 }
 
+function Get-PendingRestartReasons {
+    $reasons = [Collections.Generic.List[string]]::new()
+
+    if (Test-Path -LiteralPath `
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') {
+        $reasons.Add('Component Based Servicing reports a pending restart')
+    }
+    if (Test-Path -LiteralPath `
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') {
+        $reasons.Add('Windows Update reports a pending restart')
+    }
+
+    try {
+        $pendingFileRenames = @(
+            (Get-ItemProperty `
+                -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' `
+                -Name PendingFileRenameOperations `
+                -ErrorAction SilentlyContinue).PendingFileRenameOperations
+        )
+        if ($pendingFileRenames.Count -gt 0) {
+            $reasons.Add(
+                "Windows has $($pendingFileRenames.Count) pending file rename operation(s)")
+        }
+    }
+    catch {
+        $reasons.Add(
+            "Could not inspect pending file rename operations: $($_.Exception.Message)")
+    }
+
+    return @($reasons)
+}
+
+function Get-ActiveInstallerReasons {
+    $installerProcesses = @(
+        Get-Process -Name msiexec -ErrorAction SilentlyContinue |
+            Sort-Object Id
+    )
+    if ($installerProcesses.Count -eq 0) {
+        return @()
+    }
+
+    $processIds = ($installerProcesses | ForEach-Object { $_.Id }) -join ', '
+    return @("Windows Installer is active (msiexec process id(s): $processIds)")
+}
+
+function Get-InstallerActivityReasons {
+    param(
+        [Parameter(Mandatory)]
+        [DateTimeOffset] $SinceUtc
+    )
+
+    try {
+        $transactions = @(
+            Get-WinEvent `
+                -FilterHashtable @{
+                    LogName = 'Application'
+                    ProviderName = 'MsiInstaller'
+                    Id = 1040
+                    StartTime = $SinceUtc.LocalDateTime
+                } `
+                -ErrorAction Stop
+        )
+    }
+    catch {
+        if ($_.FullyQualifiedErrorId -like 'NoMatchingEventsFound*') {
+            return @()
+        }
+        return @(
+            "Could not inspect Windows Installer activity: $($_.Exception.Message)")
+    }
+
+    if ($transactions.Count -eq 0) {
+        return @()
+    }
+
+    $transactionDetails = @(
+        $transactions |
+            Sort-Object TimeCreated |
+            ForEach-Object {
+                $message = ($_.Message -replace '\r?\n', ' ' -replace '\s+', ' ').Trim()
+                "$($_.TimeCreated.ToUniversalTime().ToString('O')): $message"
+            }
+    )
+    return @(
+        "Windows Installer transaction(s) started during qualification: " +
+        ($transactionDetails -join ' | ')
+    )
+}
+
+function Assert-QuiescentLocalEnvironment {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Stage
+    )
+
+    $issues = @(
+        Get-PendingRestartReasons
+        Get-ActiveInstallerReasons
+    )
+    if ($issues.Count -gt 0) {
+        throw (
+            "Local durable performance qualification requires a quiescent Windows " +
+            "environment at $Stage. $($issues -join '; '). Restart the machine, " +
+            'allow installers and updates to finish, then retry.')
+    }
+}
+
 $status = Invoke-Git `
     -Arguments @('status', '--porcelain=v1', '--untracked-files=all') `
     -FailureMessage 'Could not inspect the repository worktree.'
@@ -189,6 +296,7 @@ else {
 }
 
 $statusContext = 'csharpdb/local-durable-performance'
+Assert-QuiescentLocalEnvironment -Stage 'preflight'
 if (-not $NoGitHubStatus) {
     $authOutput = @(& gh auth status 2>&1)
     if ($LASTEXITCODE -ne 0) {
@@ -240,6 +348,8 @@ try {
     Write-Host "Evidence root: $outputRoot"
 
     foreach ($qualificationPass in 1, 2) {
+        Assert-QuiescentLocalEnvironment -Stage "the start of pass $qualificationPass"
+        $passEnvironmentStartedUtc = [DateTimeOffset]::UtcNow
         $passOutput = Join-Path $outputRoot "pass-$qualificationPass"
         $parameters = @{
             CandidateRef = $candidateCommit
@@ -271,6 +381,21 @@ try {
             else {
                 Write-Warning 'Pass 2 failed.'
             }
+        }
+
+        $environmentIssues = @(
+            Get-InstallerActivityReasons -SinceUtc $passEnvironmentStartedUtc
+            Get-PendingRestartReasons
+            Get-ActiveInstallerReasons
+        )
+        if ($environmentIssues.Count -gt 0) {
+            $passFailures.Add(
+                "Pass $qualificationPass environment contamination: " +
+                ($environmentIssues -join '; '))
+            Write-Warning (
+                "Pass $qualificationPass detected installer or pending-restart activity; " +
+                'remaining passes will not run.')
+            break
         }
 
         if ($qualificationPass -eq 1 -and [string]::IsNullOrWhiteSpace($previousCommit)) {

--- a/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
@@ -220,18 +220,17 @@ public sealed class DaemonPackagingAssetsTests
             normalized);
         Assert.DoesNotContain("previous_release_ref:", normalized);
         Assert.Contains("verify-local-durable-performance:", normalized);
-        Assert.Contains("csharpdb/local-durable-performance", normalized);
         Assert.Contains("statuses: read", normalized);
         Assert.Contains("LOCAL_DURABLE_ATTESTOR", normalized);
         Assert.Contains("github.repository_owner", normalized);
-        Assert.Contains("policy=durable-v2", normalized);
+        Assert.Contains("- name: Checkout exact release source", normalized);
+        Assert.Contains("uses: actions/checkout@v7", normalized);
         Assert.Contains(
-            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/statuses?per_page=100",
+            "./scripts/Test-LocalDurableStatus.ps1",
             normalized);
-        Assert.Contains("[0] // {}", normalized);
-        Assert.Contains("$state\" != \"success", normalized);
-        Assert.Contains("${creator,,}", normalized);
-        Assert.Contains("attestation_pattern", normalized);
+        Assert.Contains("-Commit '${{ github.sha }}'", normalized);
+        Assert.Contains("-GitHubRepository '${{ github.repository }}'", normalized);
+        Assert.Contains("-ExpectedCreator $env:EXPECTED_STATUS_CREATOR", normalized);
         Assert.Equal(
             5,
             System.Text.RegularExpressions.Regex.Matches(

--- a/tests/CSharpDB.Daemon.Tests/PreviousReleasePerformanceScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/PreviousReleasePerformanceScriptTests.cs
@@ -772,14 +772,39 @@ public sealed class PreviousReleasePerformanceScriptTests
             Directory.CreateDirectory(scriptRoot);
 
             string repositoryRoot = FindRepoRoot();
-            File.Copy(
-                Path.Combine(
-                    repositoryRoot,
-                    "tests",
-                    "CSharpDB.Benchmarks",
-                    "scripts",
-                    "Test-LocalDurablePerformance.ps1"),
-                Path.Combine(scriptRoot, "Test-LocalDurablePerformance.ps1"));
+            string localDurableWrapper = File.ReadAllText(Path.Combine(
+                repositoryRoot,
+                "tests",
+                "CSharpDB.Benchmarks",
+                "scripts",
+                "Test-LocalDurablePerformance.ps1"));
+            const string environmentGuardInsertionPoint = "$status = Invoke-Git `";
+            Assert.Contains(environmentGuardInsertionPoint, localDurableWrapper);
+            localDurableWrapper = localDurableWrapper.Replace(
+                environmentGuardInsertionPoint,
+                """
+                # Test-only environment probes keep this wrapper test independent of the host.
+                function Get-PendingRestartReasons {
+                    if ($env:FAKE_PENDING_RESTART -eq '1') {
+                        return @('Simulated pending restart')
+                    }
+                    return @()
+                }
+                function Get-ActiveInstallerReasons { return @() }
+                function Get-InstallerActivityReasons {
+                    param([DateTimeOffset] $SinceUtc)
+                    if ($env:FAKE_INSTALLER_ACTIVITY -eq '1') {
+                        return @('Simulated MsiInstaller event 1040')
+                    }
+                    return @()
+                }
+
+                $status = Invoke-Git `
+                """,
+                StringComparison.Ordinal);
+            File.WriteAllText(
+                Path.Combine(scriptRoot, "Test-LocalDurablePerformance.ps1"),
+                localDurableWrapper);
             File.WriteAllText(
                 Path.Combine(scriptRoot, "Test-PreviousReleasePerformance.ps1"),
                 """
@@ -939,6 +964,91 @@ public sealed class PreviousReleasePerformanceScriptTests
             Assert.Contains("context=csharpdb/local-durable-performance", githubCalls[2]);
             Assert.Contains("description=policy=durable-v2", githubCalls[2]);
             Assert.Contains($"baseline={previousCommit}", githubCalls[2]);
+
+            string pendingRestartLog = Path.Combine(
+                temporaryRoot,
+                "pending-restart.log");
+            string pendingRestartGitHubLog = Path.Combine(
+                temporaryRoot,
+                "pending-restart-github.log");
+            ProcessResult pendingRestart = await RunProcessWithEnvironmentAsync(
+                "pwsh",
+                new Dictionary<string, string>
+                {
+                    ["FAKE_PREVIOUS_COMMIT"] = previousCommit,
+                    ["FAKE_LOCAL_DURABLE_LOG"] = pendingRestartLog,
+                    ["FAKE_GH_LOG"] = pendingRestartGitHubLog,
+                    ["FAKE_PENDING_RESTART"] = "1",
+                    ["PATH"] = fakeGitHubRoot + Path.PathSeparator +
+                        (Environment.GetEnvironmentVariable("PATH") ?? string.Empty),
+                },
+                "-NoLogo",
+                "-NoProfile",
+                "-File",
+                Path.Combine(scriptRoot, "Test-LocalDurablePerformance.ps1"),
+                "-CandidateRef",
+                "HEAD",
+                "-OutputPath",
+                Path.Combine(temporaryRoot, "pending-restart-evidence"),
+                "-ConfirmDedicatedFixedSsd",
+                "-GitHubRepository",
+                "example/csharpdb");
+
+            Assert.NotEqual(0, pendingRestart.ExitCode);
+            AssertDiagnosticContains("Simulated pending restart", pendingRestart.CombinedOutput);
+            AssertDiagnosticContains(
+                "Restart the machine, allow installers and updates to finish, then retry",
+                pendingRestart.CombinedOutput);
+            Assert.False(File.Exists(pendingRestartLog));
+            Assert.False(File.Exists(pendingRestartGitHubLog));
+
+            string installerActivityLog = Path.Combine(
+                temporaryRoot,
+                "installer-activity.log");
+            string installerActivityGitHubLog = Path.Combine(
+                temporaryRoot,
+                "installer-activity-github.log");
+            string installerActivityEvidence = Path.Combine(
+                temporaryRoot,
+                "installer-activity-evidence");
+            ProcessResult installerActivity = await RunProcessWithEnvironmentAsync(
+                "pwsh",
+                new Dictionary<string, string>
+                {
+                    ["FAKE_PREVIOUS_COMMIT"] = previousCommit,
+                    ["FAKE_LOCAL_DURABLE_LOG"] = installerActivityLog,
+                    ["FAKE_GH_LOG"] = installerActivityGitHubLog,
+                    ["FAKE_INSTALLER_ACTIVITY"] = "1",
+                    ["PATH"] = fakeGitHubRoot + Path.PathSeparator +
+                        (Environment.GetEnvironmentVariable("PATH") ?? string.Empty),
+                },
+                "-NoLogo",
+                "-NoProfile",
+                "-File",
+                Path.Combine(scriptRoot, "Test-LocalDurablePerformance.ps1"),
+                "-CandidateRef",
+                "HEAD",
+                "-OutputPath",
+                installerActivityEvidence,
+                "-ConfirmDedicatedFixedSsd",
+                "-GitHubRepository",
+                "example/csharpdb");
+
+            Assert.NotEqual(0, installerActivity.ExitCode);
+            Assert.Single(File.ReadAllLines(installerActivityLog));
+            AssertDiagnosticContains(
+                "Pass 1 detected installer or pending-restart activity; remaining passes will not run",
+                installerActivity.CombinedOutput);
+            string installerActivitySummary = File.ReadAllText(Path.Combine(
+                installerActivityEvidence,
+                "local-durable-performance.md"));
+            Assert.Contains("- Result: **FAIL**", installerActivitySummary);
+            Assert.Contains("Simulated MsiInstaller event 1040", installerActivitySummary);
+            string[] installerActivityGitHubCalls = File.ReadAllLines(
+                installerActivityGitHubLog);
+            Assert.Equal(3, installerActivityGitHubCalls.Length);
+            Assert.Contains("state=pending", installerActivityGitHubCalls[1]);
+            Assert.Contains("state=failure", installerActivityGitHubCalls[2]);
 
             string pendingStatusFailureLog = Path.Combine(
                 temporaryRoot,

--- a/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
@@ -1,0 +1,522 @@
+using System.Diagnostics;
+
+namespace CSharpDB.Daemon.Tests;
+
+public sealed class ReleaseStatusScriptTests
+{
+    private const string CandidateCommit =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [Fact]
+    public async Task Verifier_AcceptsLatestCanonicalStatusForExactCommit()
+    {
+        string temporaryRoot = CreateTemporaryRoot();
+        try
+        {
+            string ghLog = Path.Combine(temporaryRoot, "gh.log");
+            string fakeGhRoot = CreateFakeGitHubCli(temporaryRoot);
+
+            ProcessResult result = await RunVerifierAsync(
+                fakeGhRoot,
+                ghLog,
+                scenario: "success");
+
+            Assert.True(result.ExitCode == 0, result.CombinedOutput);
+            AssertDiagnosticContains(
+                $"Verified canonical durable-v2 status for exact commit {CandidateCommit}",
+                result.CombinedOutput);
+            Assert.Equal(
+                [
+                    "api|repos/example/csharpdb/commits/" +
+                    $"{CandidateCommit}/statuses?per_page=100",
+                ],
+                File.ReadAllLines(ghLog));
+        }
+        finally
+        {
+            DeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        "missing",
+        "has no csharpdb/local-durable-performance status")]
+    [InlineData(
+        "pending",
+        "is 'pending', not 'success'")]
+    [InlineData(
+        "failure",
+        "is 'failure', not 'success'")]
+    [InlineData(
+        "wrong-creator",
+        "was created by 'UnexpectedAttestor', not expected creator 'MaxAkbar'")]
+    [InlineData(
+        "malformed",
+        "does not contain a canonical durable-v2 attestation")]
+    public async Task Verifier_RejectsMissingOrInvalidLatestExactCommitStatus(
+        string scenario,
+        string expectedDiagnostic)
+    {
+        string temporaryRoot = CreateTemporaryRoot();
+        try
+        {
+            string ghLog = Path.Combine(temporaryRoot, "gh.log");
+            string fakeGhRoot = CreateFakeGitHubCli(temporaryRoot);
+
+            ProcessResult result = await RunVerifierAsync(
+                fakeGhRoot,
+                ghLog,
+                scenario);
+
+            Assert.NotEqual(0, result.ExitCode);
+            AssertDiagnosticContains(expectedDiagnostic, result.CombinedOutput);
+
+            string[] calls = File.ReadAllLines(ghLog);
+            Assert.Single(calls);
+            Assert.Equal(
+                "api|repos/example/csharpdb/commits/" +
+                $"{CandidateCommit}/statuses?per_page=100",
+                calls[0]);
+            Assert.DoesNotContain(
+                calls,
+                call => call.Contains("parents", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Verifier_FailsClosedWhenGitHubApiFails()
+    {
+        string temporaryRoot = CreateTemporaryRoot();
+        try
+        {
+            string ghLog = Path.Combine(temporaryRoot, "gh.log");
+            string fakeGhRoot = CreateFakeGitHubCli(temporaryRoot);
+
+            ProcessResult result = await RunVerifierAsync(
+                fakeGhRoot,
+                ghLog,
+                scenario: "api-failure");
+
+            Assert.NotEqual(0, result.ExitCode);
+            AssertDiagnosticContains(
+                $"Could not read GitHub statuses for commit {CandidateCommit}",
+                result.CombinedOutput);
+            AssertDiagnosticContains(
+                "Simulated GitHub status API failure",
+                result.CombinedOutput);
+        }
+        finally
+        {
+            DeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
+    [Fact]
+    public void PublishReleaseTag_RequiresExactCleanMainStatusBeforeExactTagPush()
+    {
+        string repoRoot = FindRepoRoot();
+        string publisher = File.ReadAllText(Path.Combine(
+            repoRoot,
+            "scripts",
+            "Publish-ReleaseTag.ps1"));
+        string verifier = File.ReadAllText(Path.Combine(
+            repoRoot,
+            "scripts",
+            "Test-LocalDurableStatus.ps1"));
+
+        Assert.Contains(
+            "status', '--porcelain=v1', '--untracked-files=all",
+            publisher);
+        Assert.Contains("branch', '--show-current", publisher);
+        Assert.Contains("currentBranch -cne 'main'", publisher);
+        Assert.Contains("refs/heads/main:refs/remotes/origin/main", publisher);
+        Assert.Contains("origin/main^{commit}", publisher);
+        Assert.Contains("local main to equal origin/main exactly", publisher);
+        Assert.Contains("Test-LocalDurableStatus.ps1", publisher);
+        Assert.Contains("-Commit $headCommit", publisher);
+        Assert.Contains("exact commit $headCommit", publisher);
+        Assert.Contains("Test-LocalDurablePerformance.ps1", publisher);
+        Assert.Contains("-CandidateRef $headCommit", publisher);
+        Assert.Contains("refs/tags/$releaseTag`:refs/tags/$releaseTag", publisher);
+        Assert.DoesNotContain("--force", publisher, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("merge-base", publisher, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("merge-base", verifier, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("parents", verifier, StringComparison.OrdinalIgnoreCase);
+
+        int initialVerifier = publisher.IndexOf(
+            "Invoke-StatusVerifier",
+            publisher.IndexOf("$hasReusableStatus", StringComparison.Ordinal),
+            StringComparison.Ordinal);
+        int localTagMutation = publisher.IndexOf(
+            "'tag', $releaseTag, $headCommit",
+            StringComparison.Ordinal);
+        int exactTagPush = publisher.IndexOf(
+            "refs/tags/$releaseTag`:refs/tags/$releaseTag",
+            localTagMutation,
+            StringComparison.Ordinal);
+
+        Assert.True(initialVerifier >= 0, "The exact status must be verified.");
+        Assert.True(
+            localTagMutation > initialVerifier,
+            "The exact status must be verified before a local tag is created.");
+        Assert.True(
+            exactTagPush > localTagMutation,
+            "Only the exact validated tag may be pushed after local validation.");
+    }
+
+    [Fact]
+    public void LocalDurableWrapper_RejectsInstallerContaminationAndStopsRemainingPasses()
+    {
+        string script = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "tests",
+            "CSharpDB.Benchmarks",
+            "scripts",
+            "Test-LocalDurablePerformance.ps1"));
+
+        Assert.Contains("Component Based Servicing", script);
+        Assert.Contains("WindowsUpdate\\Auto Update\\RebootRequired", script);
+        Assert.Contains("PendingFileRenameOperations", script);
+        Assert.Contains("Get-Process -Name msiexec", script);
+        Assert.Contains("ProviderName = 'MsiInstaller'", script);
+        Assert.Contains("Id = 1040", script);
+        Assert.Contains("Assert-QuiescentLocalEnvironment -Stage 'preflight'", script);
+        Assert.Contains(
+            "Assert-QuiescentLocalEnvironment -Stage \"the start of pass $qualificationPass\"",
+            script);
+        Assert.Contains(
+            "Get-InstallerActivityReasons -SinceUtc $passEnvironmentStartedUtc",
+            script);
+        Assert.Contains("environment contamination", script);
+        Assert.Contains("remaining passes will not run", script);
+
+        int loop = script.IndexOf(
+            "foreach ($qualificationPass in 1, 2)",
+            StringComparison.Ordinal);
+        int passStartGuard = script.IndexOf(
+            "Assert-QuiescentLocalEnvironment -Stage \"the start of pass $qualificationPass\"",
+            loop,
+            StringComparison.Ordinal);
+        int comparison = script.IndexOf("& $comparisonScript @parameters", loop, StringComparison.Ordinal);
+        int installerAudit = script.IndexOf(
+            "Get-InstallerActivityReasons -SinceUtc $passEnvironmentStartedUtc",
+            comparison,
+            StringComparison.Ordinal);
+        int stopRemainingPasses = script.IndexOf("break", installerAudit, StringComparison.Ordinal);
+
+        Assert.True(loop >= 0);
+        Assert.True(passStartGuard > loop && passStartGuard < comparison);
+        Assert.True(installerAudit > comparison);
+        Assert.True(
+            stopRemainingPasses > installerAudit,
+            "Installer contamination after a pass must stop the second pass.");
+    }
+
+    private static Task<ProcessResult> RunVerifierAsync(
+        string fakeGhRoot,
+        string ghLog,
+        string scenario)
+    {
+        Dictionary<string, string> environment = new()
+        {
+            ["FAKE_GH_LOG"] = ghLog,
+            ["FAKE_GH_SCENARIO"] = scenario,
+            ["PATH"] = fakeGhRoot + Path.PathSeparator +
+                (Environment.GetEnvironmentVariable("PATH") ?? string.Empty),
+        };
+        return RunProcessAsync(
+            "pwsh",
+            environment,
+            "-NoLogo",
+            "-NoProfile",
+            "-File",
+            Path.Combine(FindRepoRoot(), "scripts", "Test-LocalDurableStatus.ps1"),
+            "-Commit",
+            CandidateCommit,
+            "-GitHubRepository",
+            "example/csharpdb",
+            "-ExpectedCreator",
+            "MaxAkbar");
+    }
+
+    private static string CreateFakeGitHubCli(string temporaryRoot)
+    {
+        string toolRoot = Directory.CreateDirectory(
+            Path.Combine(temporaryRoot, "fake-gh")).FullName;
+        File.WriteAllText(
+            Path.Combine(toolRoot, "fake-gh.ps1"),
+            """
+            param(
+                [Parameter(ValueFromRemainingArguments = $true)]
+                [string[]] $CliArguments)
+
+            Add-Content -LiteralPath $env:FAKE_GH_LOG -Value ($CliArguments -join '|')
+            if ($CliArguments.Count -lt 2 -or $CliArguments[0] -cne 'api') {
+                Write-Error "Unexpected fake gh invocation: $($CliArguments -join ' ')"
+                exit 1
+            }
+            if ($env:FAKE_GH_SCENARIO -ceq 'api-failure') {
+                Write-Error 'Simulated GitHub status API failure.'
+                exit 1
+            }
+
+            $context = 'csharpdb/local-durable-performance'
+            $canonical =
+                'policy=durable-v2; baseline=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; ' +
+                'reports=1234ABCD/5678EFAB'
+            function New-FakeStatus {
+                param(
+                    [long] $Id,
+                    [string] $CreatedAt,
+                    [string] $State,
+                    [string] $Context = $context,
+                    [string] $Creator = 'maxakbar',
+                    [string] $Description = $canonical)
+
+                [pscustomobject]@{
+                    id = $Id
+                    created_at = $CreatedAt
+                    state = $State
+                    context = $Context
+                    creator = [pscustomobject]@{ login = $Creator }
+                    description = $Description
+                }
+            }
+
+            $olderSuccess = New-FakeStatus `
+                -Id 100 `
+                -CreatedAt '2026-08-01T00:00:00Z' `
+                -State success
+            $statuses = switch ($env:FAKE_GH_SCENARIO) {
+                'success' {
+                    @(
+                        (New-FakeStatus `
+                            -Id 500 `
+                            -CreatedAt '2026-08-03T00:00:00Z' `
+                            -State failure `
+                            -Context 'unrelated/check'),
+                        $olderSuccess,
+                        (New-FakeStatus `
+                            -Id 50 `
+                            -CreatedAt '2026-07-01T00:00:00Z' `
+                            -State failure)
+                    )
+                }
+                'missing' {
+                    @(
+                        (New-FakeStatus `
+                            -Id 500 `
+                            -CreatedAt '2026-08-03T00:00:00Z' `
+                            -State success `
+                            -Context 'unrelated/check')
+                    )
+                }
+                'pending' {
+                    @(
+                        $olderSuccess,
+                        (New-FakeStatus `
+                            -Id 200 `
+                            -CreatedAt '2026-08-02T00:00:00Z' `
+                            -State pending)
+                    )
+                }
+                'failure' {
+                    @(
+                        $olderSuccess,
+                        (New-FakeStatus `
+                            -Id 200 `
+                            -CreatedAt '2026-08-02T00:00:00Z' `
+                            -State failure)
+                    )
+                }
+                'wrong-creator' {
+                    @(
+                        (New-FakeStatus `
+                            -Id 200 `
+                            -CreatedAt '2026-08-02T00:00:00Z' `
+                            -State success `
+                            -Creator 'UnexpectedAttestor')
+                    )
+                }
+                'malformed' {
+                    @(
+                        (New-FakeStatus `
+                            -Id 200 `
+                            -CreatedAt '2026-08-02T00:00:00Z' `
+                            -State success `
+                            -Description 'policy=durable-v2; baseline=not-a-sha; reports=bad')
+                    )
+                }
+                default {
+                    Write-Error "Unknown fake gh scenario: $env:FAKE_GH_SCENARIO"
+                    exit 1
+                }
+            }
+
+            ConvertTo-Json -InputObject @($statuses) -Depth 10 -Compress
+            """);
+
+        if (OperatingSystem.IsWindows())
+        {
+            File.WriteAllText(
+                Path.Combine(toolRoot, "gh.cmd"),
+                """
+                @echo off
+                pwsh -NoLogo -NoProfile -File "%~dp0fake-gh.ps1" %*
+                exit /b %ERRORLEVEL%
+                """);
+        }
+        else
+        {
+            string launcher = Path.Combine(toolRoot, "gh");
+            File.WriteAllText(
+                launcher,
+                """
+                #!/usr/bin/env sh
+                script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+                exec pwsh -NoLogo -NoProfile -File "${script_dir}/fake-gh.ps1" "$@"
+                """);
+            File.SetUnixFileMode(
+                launcher,
+                UnixFileMode.UserRead |
+                UnixFileMode.UserWrite |
+                UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead |
+                UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead |
+                UnixFileMode.OtherExecute);
+        }
+
+        return toolRoot;
+    }
+
+    private static async Task<ProcessResult> RunProcessAsync(
+        string fileName,
+        IReadOnlyDictionary<string, string> environment,
+        params string[] arguments)
+    {
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = fileName,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (string argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        foreach ((string name, string value) in environment)
+            startInfo.Environment[name] = value;
+
+        using Process process = new() { StartInfo = startInfo };
+        Assert.True(process.Start(), $"Could not start {fileName}.");
+        Task<string> standardOutput = process.StandardOutput.ReadToEndAsync();
+        Task<string> standardError = process.StandardError.ReadToEndAsync();
+        using CancellationTokenSource timeout = new(TimeSpan.FromSeconds(30));
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"{fileName} did not finish within 30 seconds.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            await standardOutput,
+            await standardError);
+    }
+
+    private static string CreateTemporaryRoot()
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            "csharpdb-release-status-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void AssertDiagnosticContains(string expected, string actual)
+    {
+        Assert.Contains(
+            NormalizeDiagnostic(expected),
+            NormalizeDiagnostic(actual),
+            StringComparison.Ordinal);
+    }
+
+    private static string NormalizeDiagnostic(string value)
+    {
+        string withoutAnsi = System.Text.RegularExpressions.Regex.Replace(
+            value,
+            "\u001b\\[[0-?]*[ -/]*[@-~]",
+            string.Empty);
+        string withoutPowerShellGutters = System.Text.RegularExpressions.Regex.Replace(
+            withoutAnsi,
+            "^[\\t ]+\\|[\\t ]?",
+            string.Empty,
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+        return System.Text.RegularExpressions.Regex.Replace(
+            withoutPowerShellGutters,
+            "\\s+",
+            " ").Trim();
+    }
+
+    private static void DeleteTemporaryRoot(string path)
+    {
+        for (int attempt = 1; attempt <= 3; attempt++)
+        {
+            try
+            {
+                foreach (string entry in Directory.EnumerateFileSystemEntries(
+                    path,
+                    "*",
+                    SearchOption.AllDirectories))
+                {
+                    File.SetAttributes(entry, FileAttributes.Normal);
+                }
+                File.SetAttributes(path, FileAttributes.Normal);
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (IOException) when (attempt < 3)
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(100));
+            }
+            catch (UnauthorizedAccessException) when (attempt < 3)
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(100));
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "CSharpDB.slnx")))
+                return directory.FullName;
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate repository root from test base directory.");
+    }
+
+    private sealed record ProcessResult(
+        int ExitCode,
+        string StandardOutput,
+        string StandardError)
+    {
+        public string CombinedOutput =>
+            StandardOutput + Environment.NewLine + StandardError;
+    }
+}


### PR DESCRIPTION
## Summary

Prevent release tags from being published before the exact merged commit has canonical local durable-performance evidence.

The previous release attempt was triggered by a tag whose commit had no successful `csharpdb/local-durable-performance` status. The Release workflow correctly failed closed, but the operator path allowed the invalid tag to be created first.

This change adds a single guarded tag publisher, shares the exact-SHA status verifier with the Release workflow, rechecks that `main` has not advanced during qualification, and rejects benchmark evidence collected while Windows Installer or a pending restart can contaminate timings.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / maintenance
- [ ] Tests only

## Related Issues

None.

## Testing

- [ ] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Validation performed:

- 29 focused release-status, packaging-contract, and local durable-wrapper tests passed.
- PowerShell syntax parsing passed for all three affected release scripts.
- Documentation links and sitemap validation passed.
- Git whitespace validation passed.
- The live status verifier accepted a known canonical exact-SHA status and rejected the failed release SHA.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

The existing release tag still needs one clean durable qualification on its exact commit after Windows is restarted. This PR prevents future premature tag publication; it does not relabel or reuse earlier benchmark evidence.

The publisher is intentionally idempotent only when an existing tag already points to the exact qualified commit. It never force-moves a release tag.