### PR TITLE
Fix deterministic local release qualification

### DIFF
--- a/src/CSharpDB.Migration/MigrationRejectArtifactPublication.cs
+++ b/src/CSharpDB.Migration/MigrationRejectArtifactPublication.cs
@@ -23,6 +23,7 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
     private const int UnixWouldBlockDarwin = 35;
     private const int LockExclusive = 2;
     private const int LockNonBlocking = 4;
+    private const int LockUnlock = 8;
     private const uint RenameNoReplace = 1;
     private const uint DarwinRenameExclusiveFlag = 4;
 
@@ -43,7 +44,7 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
     private readonly SafeFileHandle? _unixParent;
     private bool _published;
     private bool _temporaryRemoved;
-    private bool _disposed;
+    private int _disposeStarted;
 
     private MigrationRejectArtifactPublication(
         string destinationPath,
@@ -121,6 +122,8 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
             }
             catch
             {
+                if (unixParent is not null)
+                    ReleaseUnixClaimLock(stream.SafeFileHandle);
                 stream.Dispose();
                 throw;
             }
@@ -204,7 +207,7 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
-        if (_disposed)
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
             return ValueTask.CompletedTask;
 
         try
@@ -214,9 +217,12 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
         }
         finally
         {
-            _disposed = true;
             try
             {
+                // The claim flock was acquired outside SafeFileHandle, so the
+                // runtime cannot proactively unlock it if close is interrupted.
+                if (_unixParent is not null)
+                    ReleaseUnixClaimLock(Stream.SafeFileHandle);
                 Stream.Dispose();
             }
             finally
@@ -1000,11 +1006,12 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
         }
 
         SafeFileHandle handle = WrapUnixDescriptor(descriptor);
+        bool claimLocked = false;
         try
         {
             RequireUnixTemporaryIdentity(parent, temporaryLeaf, handle);
             int lockResult = UnixFlock(
-                Descriptor(handle),
+                handle,
                 LockExclusive | LockNonBlocking);
             if (lockResult != 0)
             {
@@ -1014,6 +1021,7 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
                     : "The reject-artifact temporary claim could not be locked.";
                 throw new IOException(message, new Win32Exception(lockError));
             }
+            claimLocked = true;
 
             ValidateUnixRegularPrivateFile(handle, validateExtendedAcl: false);
             RemoveUnixExtendedAcl(handle);
@@ -1037,6 +1045,8 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
         }
         finally
         {
+            if (claimLocked && handle is not null)
+                ReleaseUnixClaimLock(handle);
             handle?.Dispose();
         }
     }
@@ -1465,6 +1475,12 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
     private static int Descriptor(SafeFileHandle handle) =>
         checked((int)handle.DangerousGetHandle());
 
+    private static void ReleaseUnixClaimLock(SafeFileHandle handle)
+    {
+        if (!handle.IsClosed && !handle.IsInvalid)
+            _ = UnixFlock(handle, LockUnlock);
+    }
+
     private static bool TryGetAttributes(string path, out FileAttributes attributes)
     {
         try
@@ -1484,7 +1500,8 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
         }
     }
 
-    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+    private void ThrowIfDisposed() =>
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposeStarted) != 0, this);
 
     private enum PublishStatus
     {
@@ -1665,7 +1682,7 @@ internal sealed class MigrationRejectArtifactPublication : IAsyncDisposable
         uint mode);
 
     [DllImport("libc", EntryPoint = "flock", SetLastError = true)]
-    private static extern int UnixFlock(int descriptor, int operation);
+    private static extern int UnixFlock(SafeFileHandle handle, int operation);
 
     [DllImport("libc", EntryPoint = "fchmod", SetLastError = true)]
     private static extern int UnixChangeMode(int descriptor, uint mode);

--- a/tests/CSharpDB.Benchmarks/scripts/Test-PreviousReleasePerformance.ps1
+++ b/tests/CSharpDB.Benchmarks/scripts/Test-PreviousReleasePerformance.ps1
@@ -849,6 +849,16 @@ $environmentMonitorSha256 = ''
 $environmentMonitorSampleCount = 0
 $originalNuGetPackages = $env:NUGET_PACKAGES
 $originalDotnetCliHome = $env:DOTNET_CLI_HOME
+$originalDotnetCliWorkloadUpdateNotifyDisable =
+    $env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
+$originalDotnetSkipWorkloadIntegrityCheck =
+    $env:DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK
+$originalDotnetGenerateAspNetCertificate =
+    $env:DOTNET_GENERATE_ASPNET_CERTIFICATE
+$originalDotnetAddGlobalToolsToPath =
+    $env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH
+$originalDotnetNoLogo = $env:DOTNET_NOLOGO
+$originalDotnetCliTelemetryOptOut = $env:DOTNET_CLI_TELEMETRY_OPTOUT
 
 function Write-ExecutionEvent {
     param(
@@ -1842,9 +1852,9 @@ function Start-LocalEnvironmentMonitor {
         [void] $startInfo.ArgumentList.Add([string] $argument)
     }
 
-    $environmentMonitorProcess = [Diagnostics.Process]::new()
-    $environmentMonitorProcess.StartInfo = $startInfo
-    if (-not $environmentMonitorProcess.Start()) {
+    $script:environmentMonitorProcess = [Diagnostics.Process]::new()
+    $script:environmentMonitorProcess.StartInfo = $startInfo
+    if (-not $script:environmentMonitorProcess.Start()) {
         throw 'Could not start the local performance environment monitor.'
     }
 
@@ -1864,14 +1874,15 @@ function Start-LocalEnvironmentMonitor {
     }
 
     $readyText = [IO.File]::ReadAllText($environmentMonitorReadyPath).Trim()
+    $parsedReadyUtc = [DateTimeOffset]::MinValue
     if (-not [DateTimeOffset]::TryParse(
         $readyText,
         [Globalization.CultureInfo]::InvariantCulture,
         [Globalization.DateTimeStyles]::RoundtripKind,
-        [ref] $environmentMonitorReadyUtc)) {
+        [ref] $parsedReadyUtc)) {
         throw "Environment monitor ready signal contains an invalid UTC timestamp: $readyText"
     }
-    $environmentMonitorReadyUtc = $environmentMonitorReadyUtc.ToUniversalTime()
+    $script:environmentMonitorReadyUtc = $parsedReadyUtc.ToUniversalTime()
     Write-Host (
         'Durable-v3 external environment monitor ready at ' +
         $environmentMonitorReadyUtc.ToString('O'))
@@ -2128,8 +2139,8 @@ function Stop-AndAuditLocalEnvironmentMonitor {
             $summaryLines.Add("CoveredMeasurementIntervals=$($measurementBegins.Count)")
         }
 
-        $environmentMonitorSampleCount = $rows.Count
-        $environmentMonitorSha256 = (Get-FileHash `
+        $script:environmentMonitorSampleCount = $rows.Count
+        $script:environmentMonitorSha256 = (Get-FileHash `
                 -LiteralPath $environmentMonitorCsvPath `
                 -Algorithm SHA256).Hash.ToLowerInvariant()
         $summaryLines.Add('Result=PASS')
@@ -2150,12 +2161,12 @@ function Stop-AndAuditLocalEnvironmentMonitor {
                 $environmentMonitorProcess.Kill($true)
                 $environmentMonitorProcess.WaitForExit()
             }
-            $environmentMonitorStopped =
+            $script:environmentMonitorStopped =
                 $null -ne $environmentMonitorProcess -and
                 $environmentMonitorProcess.HasExited
         }
         catch {
-            $environmentMonitorStopped = $false
+            $script:environmentMonitorStopped = $false
             if ($null -eq $auditFailure) {
                 $auditFailure = $_
                 $summaryLines.Add('Result=FAIL')
@@ -3396,6 +3407,13 @@ function Invoke-ReleaseCoreSample {
 try {
     $env:NUGET_PACKAGES = Join-Path $outputRoot '.nuget-packages'
     $env:DOTNET_CLI_HOME = Join-Path $outputRoot '.dotnet-home'
+    # A fresh CLI home must not initiate workload maintenance or mutate user state.
+    $env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE = 'true'
+    $env:DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK = 'true'
+    $env:DOTNET_GENERATE_ASPNET_CERTIFICATE = 'false'
+    $env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH = 'false'
+    $env:DOTNET_NOLOGO = 'true'
+    $env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'
     New-Item -ItemType Directory -Path $env:NUGET_PACKAGES -Force | Out-Null
     New-Item -ItemType Directory -Path $env:DOTNET_CLI_HOME -Force | Out-Null
     New-Item -ItemType Directory -Path $logRoot -Force | Out-Null
@@ -4237,6 +4255,54 @@ finally {
     }
     else {
         $env:DOTNET_CLI_HOME = $originalDotnetCliHome
+    }
+    if ($null -eq $originalDotnetCliWorkloadUpdateNotifyDisable) {
+        Remove-Item `
+            Env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE `
+            -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE =
+            $originalDotnetCliWorkloadUpdateNotifyDisable
+    }
+    if ($null -eq $originalDotnetSkipWorkloadIntegrityCheck) {
+        Remove-Item `
+            Env:DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK `
+            -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK =
+            $originalDotnetSkipWorkloadIntegrityCheck
+    }
+    if ($null -eq $originalDotnetGenerateAspNetCertificate) {
+        Remove-Item `
+            Env:DOTNET_GENERATE_ASPNET_CERTIFICATE `
+            -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:DOTNET_GENERATE_ASPNET_CERTIFICATE =
+            $originalDotnetGenerateAspNetCertificate
+    }
+    if ($null -eq $originalDotnetAddGlobalToolsToPath) {
+        Remove-Item `
+            Env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH `
+            -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH =
+            $originalDotnetAddGlobalToolsToPath
+    }
+    if ($null -eq $originalDotnetNoLogo) {
+        Remove-Item Env:DOTNET_NOLOGO -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:DOTNET_NOLOGO = $originalDotnetNoLogo
+    }
+    if ($null -eq $originalDotnetCliTelemetryOptOut) {
+        Remove-Item Env:DOTNET_CLI_TELEMETRY_OPTOUT -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:DOTNET_CLI_TELEMETRY_OPTOUT = $originalDotnetCliTelemetryOptOut
     }
 }
 

--- a/tests/CSharpDB.Daemon.Tests/LocalPerformanceEnvironmentMonitorTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/LocalPerformanceEnvironmentMonitorTests.cs
@@ -38,6 +38,59 @@ public sealed class LocalPerformanceEnvironmentMonitorTests
     }
 
     [Fact]
+    public async Task DurableRunner_StartMonitorRetainsStateAcrossFunctionScope()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        string temporaryRoot = CreateTemporaryRoot();
+        try
+        {
+            string harnessPath = Path.Combine(temporaryRoot, "monitor-start-scope-harness.ps1");
+            File.WriteAllText(harnessPath, MonitorStartScopeHarness);
+            ProcessStartInfo startInfo = CreatePwshStartInfo();
+            foreach (string argument in new[]
+            {
+                "-File",
+                harnessPath,
+                "-RunnerPath",
+                Path.Combine(
+                    FindRepoRoot(),
+                    "tests",
+                    "CSharpDB.Benchmarks",
+                    "scripts",
+                    "Test-PreviousReleasePerformance.ps1"),
+                "-MonitorPath",
+                Path.Combine(
+                    FindRepoRoot(),
+                    "tests",
+                    "CSharpDB.Benchmarks",
+                    "scripts",
+                    "Watch-LocalPerformanceEnvironment.ps1"),
+                "-EvidenceRoot",
+                Path.Combine(temporaryRoot, "evidence"),
+            })
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using Process process = Process.Start(startInfo) ??
+                throw new InvalidOperationException("Could not start monitor scope harness.");
+            using CancellationTokenSource timeout = new(TimeSpan.FromSeconds(45));
+            await process.WaitForExitAsync(timeout.Token);
+            string stdout = await process.StandardOutput.ReadToEndAsync(timeout.Token);
+            string stderr = await process.StandardError.ReadToEndAsync(timeout.Token);
+
+            Assert.True(process.ExitCode == 0, stdout + Environment.NewLine + stderr);
+            Assert.Contains("Monitor start scope: PASS", stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
+    [Fact]
     public async Task WindowsMonitor_ProducesTimestampedCsvAndStopsBySignal()
     {
         if (!OperatingSystem.IsWindows())
@@ -176,10 +229,11 @@ public sealed class LocalPerformanceEnvironmentMonitorTests
     }
 
     [Theory]
+    [InlineData("success", "Monitor audit scope: PASS")]
     [InlineData("stale", "The latest environment monitor sample is stale")]
     [InlineData("discontinuous", "Environment monitor coverage is discontinuous")]
     [InlineData("final-coverage", "Environment monitor stopped before the final recorded measurement ended")]
-    public async Task DurableRunner_MonitorAuditRejectsInvalidCoverage(
+    public async Task DurableRunner_MonitorAuditValidatesCoverageAndState(
         string scenario,
         string expectedDiagnostic)
     {
@@ -533,6 +587,89 @@ public sealed class LocalPerformanceEnvironmentMonitorTests
         int ConsecutiveBusySamples,
         bool Contaminated);
 
+    private const string MonitorStartScopeHarness = """
+        param(
+            [Parameter(Mandatory)][string] $RunnerPath,
+            [Parameter(Mandatory)][string] $MonitorPath,
+            [Parameter(Mandatory)][string] $EvidenceRoot)
+
+        $ErrorActionPreference = 'Stop'
+        New-Item -ItemType Directory -Path $EvidenceRoot -Force | Out-Null
+        $tokens = $null
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $RunnerPath,
+            [ref] $tokens,
+            [ref] $parseErrors)
+        if ($parseErrors.Count -ne 0) {
+            throw "Runner parse failed: $($parseErrors -join '; ')"
+        }
+        $functionAst = $ast.Find(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                    $node.Name -ceq 'Start-LocalEnvironmentMonitor'
+            },
+            $true)
+        if ($null -eq $functionAst) {
+            throw 'Runner function not found: Start-LocalEnvironmentMonitor'
+        }
+        Invoke-Expression $functionAst.Extent.Text
+
+        $MonitorLocalEnvironment = $true
+        $EnvironmentMonitorScript = $MonitorPath
+        $MonitorSampleIntervalMilliseconds = 250
+        $MaxExternalCpuPercent = 100
+        $MaxExternalCpuCoreEquivalent = 64
+        $MaxExternalIoBytesPerSecond = [long]::MaxValue
+        $RequiredConsecutiveBusySamples = 60
+        $ProhibitedExternalProcessNames = 'process-name-that-does-not-exist'
+        $environmentMonitorProcess = $null
+        $environmentMonitorReadyUtc = [DateTimeOffset]::MinValue
+        $environmentMonitorCsvPath = Join-Path $EvidenceRoot 'monitor.csv'
+        $environmentMonitorReadyPath = Join-Path $EvidenceRoot 'monitor.ready'
+        $environmentMonitorStopPath = Join-Path $EvidenceRoot 'monitor.stop'
+        $environmentMonitorStdoutPath = Join-Path $EvidenceRoot 'monitor.stdout.log'
+        $environmentMonitorStderrPath = Join-Path $EvidenceRoot 'monitor.stderr.log'
+        $environmentMonitorSummaryPath = Join-Path $EvidenceRoot 'monitor-summary.txt'
+
+        try {
+            Start-LocalEnvironmentMonitor
+            if ($null -eq $environmentMonitorProcess) {
+                throw 'Monitor process state did not escape the start function scope.'
+            }
+            if ($environmentMonitorReadyUtc -eq [DateTimeOffset]::MinValue) {
+                throw 'Monitor ready time did not escape the start function scope.'
+            }
+            if ($environmentMonitorProcess.HasExited) {
+                $stderr = $environmentMonitorProcess.StandardError.ReadToEnd()
+                throw "Monitor exited immediately after startup. $stderr"
+            }
+
+            [IO.File]::WriteAllText(
+                $environmentMonitorStopPath,
+                [DateTimeOffset]::UtcNow.ToString('O'))
+            if (-not $environmentMonitorProcess.WaitForExit(30000)) {
+                throw 'Monitor did not stop within 30 seconds.'
+            }
+            $stdout = $environmentMonitorProcess.StandardOutput.ReadToEnd()
+            $stderr = $environmentMonitorProcess.StandardError.ReadToEnd()
+            if ($environmentMonitorProcess.ExitCode -ne 0) {
+                throw "Monitor exited with code $($environmentMonitorProcess.ExitCode). $stderr"
+            }
+            Write-Output 'Monitor start scope: PASS'
+        }
+        finally {
+            if ($null -ne $environmentMonitorProcess) {
+                if (-not $environmentMonitorProcess.HasExited) {
+                    $environmentMonitorProcess.Kill($true)
+                    $environmentMonitorProcess.WaitForExit()
+                }
+                $environmentMonitorProcess.Dispose()
+            }
+        }
+        """;
+
     private const string MonitorGateHarness = """
         param([Parameter(Mandatory)][string] $MonitorPath)
 
@@ -763,7 +900,17 @@ public sealed class LocalPerformanceEnvironmentMonitorTests
         }
 
         $environmentMonitorReadyUtc = [DateTimeOffset]::UtcNow.AddSeconds(-20)
+        $expectSuccess = $false
         switch ($Scenario) {
+            'success' {
+                [IO.File]::WriteAllLines(
+                    $environmentMonitorCsvPath,
+                    @(
+                        $header,
+                        (New-MonitorRow $environmentMonitorReadyUtc.AddSeconds(1)),
+                        (New-MonitorRow $environmentMonitorReadyUtc.AddSeconds(2))))
+                $expectSuccess = $true
+            }
             'stale' {
                 [IO.File]::WriteAllLines(
                     $environmentMonitorCsvPath,
@@ -808,6 +955,21 @@ public sealed class LocalPerformanceEnvironmentMonitorTests
                 $expected = 'Environment monitor stopped before the final recorded measurement ended'
             }
             default { throw "Unknown scenario: $Scenario" }
+        }
+
+        if ($expectSuccess) {
+            Stop-AndAuditLocalEnvironmentMonitor
+            if (-not $environmentMonitorStopped) {
+                throw 'Monitor stopped state did not escape the audit function scope.'
+            }
+            if ($environmentMonitorSampleCount -ne 2) {
+                throw 'Monitor sample count did not escape the audit function scope.'
+            }
+            if ([string]::IsNullOrWhiteSpace($environmentMonitorSha256)) {
+                throw 'Monitor digest did not escape the audit function scope.'
+            }
+            Write-Output 'Monitor audit scope: PASS'
+            exit 0
         }
 
         try {

--- a/tests/CSharpDB.Daemon.Tests/PreviousReleasePairedRunnerScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/PreviousReleasePairedRunnerScriptTests.cs
@@ -1265,11 +1265,13 @@ public sealed class PreviousReleasePairedRunnerScriptTests
             string fakeToolRoot = Path.Combine(temporaryRoot, "fake-tools");
             CreatePairedFakeDotnetTool(fakeToolRoot);
             string invocationLog = Path.Combine(temporaryRoot, "fake-dotnet.log");
+            string environmentLog = Path.Combine(temporaryRoot, "fake-dotnet-environment.log");
             Dictionary<string, string> environment = new()
             {
                 ["PATH"] = fakeToolRoot + Path.PathSeparator +
                     (Environment.GetEnvironmentVariable("PATH") ?? string.Empty),
                 ["FAKE_DOTNET_LOG"] = invocationLog,
+                ["FAKE_DOTNET_ENV_LOG"] = environmentLog,
                 ["FAKE_DOTNET_FAIL_ON_RUN"] = "4",
             };
             string evidence = Path.Combine(temporaryRoot, "failed-paired-evidence");
@@ -1283,6 +1285,12 @@ public sealed class PreviousReleasePairedRunnerScriptTests
 
                 $env:NUGET_PACKAGES = 'sentinel-nuget-packages'
                 $env:DOTNET_CLI_HOME = 'sentinel-dotnet-home'
+                $env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE = 'sentinel-workload-update'
+                $env:DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK = 'sentinel-workload-integrity'
+                $env:DOTNET_GENERATE_ASPNET_CERTIFICATE = 'sentinel-certificate'
+                $env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH = 'sentinel-tools-path'
+                $env:DOTNET_NOLOGO = 'sentinel-logo'
+                $env:DOTNET_CLI_TELEMETRY_OPTOUT = 'sentinel-telemetry'
                 try {
                     & $RunnerScript `
                         -PreviousRef v4.3.0 `
@@ -1297,6 +1305,14 @@ public sealed class PreviousReleasePairedRunnerScriptTests
                     Write-Output "RUNNER_ERROR=$($_.Exception.Message)"
                     Write-Output "NUGET_PACKAGES_AFTER=$env:NUGET_PACKAGES"
                     Write-Output "DOTNET_CLI_HOME_AFTER=$env:DOTNET_CLI_HOME"
+                    Write-Output (
+                        'DOTNET_FIRST_USE_AFTER=' +
+                        "$env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE|" +
+                        "$env:DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK|" +
+                        "$env:DOTNET_GENERATE_ASPNET_CERTIFICATE|" +
+                        "$env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH|" +
+                        "$env:DOTNET_NOLOGO|" +
+                        "$env:DOTNET_CLI_TELEMETRY_OPTOUT")
                     exit 17
                 }
 
@@ -1323,6 +1339,16 @@ public sealed class PreviousReleasePairedRunnerScriptTests
             Assert.Contains(
                 "DOTNET_CLI_HOME_AFTER=sentinel-dotnet-home",
                 result.CombinedOutput);
+            Assert.Contains(
+                "DOTNET_FIRST_USE_AFTER=" +
+                "sentinel-workload-update|sentinel-workload-integrity|" +
+                "sentinel-certificate|sentinel-tools-path|sentinel-logo|sentinel-telemetry",
+                result.CombinedOutput);
+            string[] dotnetEnvironments = File.ReadAllLines(environmentLog);
+            Assert.NotEmpty(dotnetEnvironments);
+            Assert.All(
+                dotnetEnvironments,
+                value => Assert.Equal("true|true|false|false|true|true", value));
             string[] runs = File.ReadLines(invocationLog)
                 .Where(line => line.Contains("|run|", StringComparison.Ordinal))
                 .ToArray();
@@ -1944,6 +1970,17 @@ public sealed class PreviousReleasePairedRunnerScriptTests
             """
             $ErrorActionPreference = 'Stop'
             $CommandArgs = @($args)
+            if (-not [string]::IsNullOrWhiteSpace($env:FAKE_DOTNET_ENV_LOG)) {
+                Add-Content `
+                    -LiteralPath $env:FAKE_DOTNET_ENV_LOG `
+                    -Value (
+                        "$env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE|" +
+                        "$env:DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK|" +
+                        "$env:DOTNET_GENERATE_ASPNET_CERTIFICATE|" +
+                        "$env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH|" +
+                        "$env:DOTNET_NOLOGO|" +
+                        "$env:DOTNET_CLI_TELEMETRY_OPTOUT")
+            }
             if ($CommandArgs.Count -eq 1 -and $CommandArgs[0] -eq '--version') {
                 Write-Output '10.0.203'
                 exit 0

--- a/tests/CSharpDB.Migration.Tests/MigrationRejectArtifactWriterTests.cs
+++ b/tests/CSharpDB.Migration.Tests/MigrationRejectArtifactWriterTests.cs
@@ -8,6 +8,7 @@ using System.Security.Principal;
 using System.Text;
 using CSharpDB.Migration.Validation;
 using CSharpDB.Primitives;
+using Microsoft.Win32.SafeHandles;
 
 namespace CSharpDB.Migration.Tests;
 
@@ -141,6 +142,72 @@ public sealed class MigrationRejectArtifactWriterTests
         }
         finally
         {
+            DeleteRoot(root);
+        }
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ReleasesUnixClaimLockBeforeClosingHandle()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        string root = CreateRoot();
+        MigrationRejectArtifactPublication? publication = null;
+        SafeFileHandle? retainedHandle = null;
+        SafeFileHandle? competingHandle = null;
+        bool competingLockHeld = false;
+        try
+        {
+            string outputPath = Path.Combine(root, "rejects.jsonl");
+            byte[] expected = "released-lock\n"u8.ToArray();
+            publication = await MigrationRejectArtifactPublication.OpenAsync(
+                outputPath,
+                "sha256:" + new string('a', 64),
+                maximumBytes: 1_024,
+                TestContext.Current.CancellationToken);
+            await publication.Stream.WriteAsync(
+                expected,
+                TestContext.Current.CancellationToken);
+            await publication.FlushAsync(TestContext.Current.CancellationToken);
+            Assert.False(await publication.PublishOrReuseAsync(
+                TestContext.Current.CancellationToken));
+
+            int duplicateDescriptor = UnixDuplicate(checked(
+                (int)publication.Stream.SafeFileHandle.DangerousGetHandle()));
+            Assert.True(
+                duplicateDescriptor >= 0,
+                $"dup failed with errno {Marshal.GetLastPInvokeError()}.");
+            retainedHandle = new SafeFileHandle(
+                new IntPtr(duplicateDescriptor),
+                ownsHandle: true);
+
+            await publication.DisposeAsync();
+            publication = null;
+
+            Assert.False(retainedHandle.IsClosed);
+            competingHandle = File.OpenHandle(
+                outputPath,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.ReadWrite | FileShare.Delete);
+            int lockResult = UnixFlock(
+                competingHandle,
+                LockExclusive | LockNonBlocking);
+            Assert.True(
+                lockResult == 0,
+                $"A separately opened descriptor could not claim the released lock; " +
+                $"errno {Marshal.GetLastPInvokeError()}.");
+            competingLockHeld = true;
+        }
+        finally
+        {
+            if (publication is not null)
+                await publication.DisposeAsync();
+            if (competingLockHeld && competingHandle is not null)
+                _ = UnixFlock(competingHandle, LockUnlock);
+            competingHandle?.Dispose();
+            retainedHandle?.Dispose();
             DeleteRoot(root);
         }
     }
@@ -1465,6 +1532,16 @@ public sealed class MigrationRejectArtifactWriterTests
     private static extern int UnixCreateHardLink(
         [MarshalAs(UnmanagedType.LPUTF8Str)] string existingPath,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string linkPath);
+
+    [DllImport("libc", EntryPoint = "dup", SetLastError = true)]
+    private static extern int UnixDuplicate(int descriptor);
+
+    [DllImport("libc", EntryPoint = "flock", SetLastError = true)]
+    private static extern int UnixFlock(SafeFileHandle handle, int operation);
+
+    private const int LockExclusive = 2;
+    private const int LockNonBlocking = 4;
+    private const int LockUnlock = 8;
 
     private sealed record OutcomeSpec(
         int AcceptedRows,


### PR DESCRIPTION
## Summary

Fix the deterministic release path at both points exposed by the failed qualification runs and CI:

- Prevent an isolated .NET CLI home from triggering workload maintenance or installer activity before the first `dotnet` invocation.
- Preserve the Windows environment monitor's process and closeout state across PowerShell function boundaries.
- Explicitly release the Unix reject-artifact `flock` before closing its descriptor, including initialization-failure cleanup.
- Pin the native file handle during `flock` calls and make disposal single-entry so concurrent disposal cannot act on a reused descriptor.
- Add a deterministic Unix regression that retains a duplicated descriptor and verifies a separately opened descriptor can acquire the released lock.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance
- [ ] Tests only

## Related Issues

N/A.

## Testing

- [x] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Validation performed:

- `dotnet build CSharpDB.slnx -c Release --no-restore --verbosity minimal` — succeeded with 0 warnings and 0 errors.
- Full `CSharpDB.Migration.Tests` project in Release — 501/501 passed.
- Full `CSharpDB.Daemon.Tests` project — 164/164 passed.
- Focused release-runner and monitor regression set — 11/11 passed.
- Fresh isolated CLI-home benchmark-project build with the new controls — no workload-advertising sentinel and no new Windows Installer event.
- PowerShell parser and `git diff --check` — passed.
- Independent review of the Unix cleanup, handle lifetime, concurrency guard, and regression test — no blocking findings.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

The prior macOS failure was a real Unix lock-lifetime defect: the lock was acquired through a native `flock`, so .NET's `SafeFileHandle` did not know to proactively unlock it if `close` was interrupted. This change explicitly unlocks before close rather than hiding the failure with retries.

No release tag or GitHub Release exists. After this PR merges and all checks pass, the exact merged commit still requires one fresh canonical durable-v3 local qualification before the publisher may create `v4.4.0`.