### PR TITLE
Restore release trigger and add audited v4.4.0 carry-forward

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  statuses: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish exact release tag
+    permissions:
+      contents: write
+      statuses: read
+      id-token: write
+    uses: ./.github/workflows/release.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,10 @@
-name: Release
+name: Release implementation
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
 
 permissions:
   contents: read
-  pages: write
   id-token: write
 
 jobs:
@@ -21,6 +18,8 @@ jobs:
     steps:
       - name: Checkout exact release source
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Require a successful matching-commit local performance status
         shell: pwsh
@@ -31,7 +30,8 @@ jobs:
           ./scripts/Test-LocalDurableStatus.ps1 `
             -Commit '${{ github.sha }}' `
             -GitHubRepository '${{ github.repository }}' `
-            -ExpectedCreator $env:EXPECTED_STATUS_CREATOR
+            -ExpectedCreator $env:EXPECTED_STATUS_CREATOR `
+            -ReleaseVersion '${{ github.ref_name }}'
 
   build-and-test:
     name: Qualify release source

--- a/docs/security-access-control-plan.md
+++ b/docs/security-access-control-plan.md
@@ -110,7 +110,8 @@ transport-specific security stacks:
   mode, or clearly identify and audit a single service principal for trusted
   local mode.
 - Apply installer hardening under `deploy/daemon`, and release trust changes in
-  `.github/workflows/release.yml` plus the existing packaging scripts.
+  `.github/workflows/publish-release.yml`, the reusable
+  `.github/workflows/release.yml` implementation, and the existing packaging scripts.
 
 ## Trust Boundaries And Deployment Profiles
 

--- a/scripts/Publish-DurableCarryForwardStatus.ps1
+++ b/scripts/Publish-DurableCarryForwardStatus.ps1
@@ -1,0 +1,224 @@
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('4.4.0', 'v4.4.0')]
+    [string] $Version,
+
+    [ValidatePattern('^$|^[^/\s]+/[^/\s]+$')]
+    [string] $GitHubRepository = '',
+
+    [string] $ExpectedStatusCreator = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$statusVerifier = Join-Path $PSScriptRoot 'Test-LocalDurableStatus.ps1'
+$releaseVersion = $Version.TrimStart('v')
+$carryForwardContext =
+    'csharpdb/local-durable-performance-carry-forward-v4.4.0'
+$carryForwardDescription =
+    'policy=durable-v2-carry-forward-v4.4.0; source=61e4d025; ' +
+    'success=51598901859; failed-v3=51664261883; tree=bee4859c'
+
+if (-not (Test-Path -LiteralPath $statusVerifier -PathType Leaf)) {
+    throw "Required status verifier was not found: $statusVerifier"
+}
+if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw 'GitHub CLI (gh) is required to publish the approved carry-forward status.'
+}
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory)]
+        [string[]] $Arguments,
+
+        [Parameter(Mandatory)]
+        [string] $FailureMessage
+    )
+
+    $output = @(& git -C $repositoryRoot @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        $details = ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+        if ([string]::IsNullOrWhiteSpace($details)) {
+            throw $FailureMessage
+        }
+        throw "$FailureMessage$([Environment]::NewLine)$details"
+    }
+    return ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+}
+
+function Get-ExactCurrentMainCommit {
+    $workingTreeChanges = Invoke-Git `
+        -Arguments @('status', '--porcelain=v1', '--untracked-files=all') `
+        -FailureMessage 'Could not inspect the repository worktree.'
+    if (-not [string]::IsNullOrWhiteSpace($workingTreeChanges)) {
+        throw 'Carry-forward publication requires a clean repository worktree.'
+    }
+
+    $currentBranch = (Invoke-Git `
+        -Arguments @('branch', '--show-current') `
+        -FailureMessage 'Could not determine the current branch.').Trim()
+    if ($currentBranch -cne 'main') {
+        throw (
+            "Carry-forward publication must run from branch 'main'; current branch is " +
+            "'$currentBranch'.")
+    }
+
+    Invoke-Git `
+        -Arguments @(
+            'fetch',
+            '--quiet',
+            'origin',
+            '+refs/heads/main:refs/remotes/origin/main') `
+        -FailureMessage "Could not refresh 'origin/main'." |
+        Out-Null
+
+    $localMainCommit = (Invoke-Git `
+        -Arguments @('rev-parse', '--verify', 'HEAD^{commit}') `
+        -FailureMessage 'Could not resolve the current HEAD commit.').Trim()
+    $remoteMainCommit = (Invoke-Git `
+        -Arguments @('rev-parse', '--verify', 'origin/main^{commit}') `
+        -FailureMessage "Could not resolve 'origin/main'.").Trim()
+    if ($localMainCommit -cne $remoteMainCommit) {
+        throw (
+            "Carry-forward publication requires local main to equal origin/main exactly. " +
+            "Local HEAD is $localMainCommit; origin/main is $remoteMainCommit.")
+    }
+    return $localMainCommit
+}
+
+function Invoke-StatusVerifier {
+    param(
+        [switch] $EligibilityOnly
+    )
+
+    $parameters = @{
+        Commit = $headCommit
+        GitHubRepository = $GitHubRepository
+        ExpectedCreator = $ExpectedStatusCreator
+        ReleaseVersion = $releaseVersion
+    }
+    if ($EligibilityOnly) {
+        $parameters.ValidateApprovedCarryForwardEligibility = $true
+    }
+    & $statusVerifier @parameters
+}
+
+$headCommit = Get-ExactCurrentMainCommit
+
+$buildPropsPath = Join-Path $repositoryRoot 'src/Directory.Build.props'
+[xml] $buildProps = [IO.File]::ReadAllText($buildPropsPath)
+$versionNodes = @($buildProps.SelectNodes('/Project/PropertyGroup/Version'))
+if ($versionNodes.Count -ne 1 -or
+    $versionNodes[0].InnerText.Trim() -cne $releaseVersion) {
+    throw (
+        "The approved carry-forward requires package version $releaseVersion in " +
+        "$buildPropsPath.")
+}
+
+if ([string]::IsNullOrWhiteSpace($GitHubRepository)) {
+    $repositoryOutput = @(
+        & gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>&1
+    )
+    if ($LASTEXITCODE -ne 0) {
+        $details = ($repositoryOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+        throw "Could not resolve the GitHub repository. $details"
+    }
+    $GitHubRepository = (($repositoryOutput | ForEach-Object { [string] $_ }) -join '').Trim()
+}
+if ($GitHubRepository -cnotmatch '^[^/\s]+/[^/\s]+$') {
+    throw "GitHubRepository must use the owner/name form: $GitHubRepository"
+}
+
+if ([string]::IsNullOrWhiteSpace($ExpectedStatusCreator)) {
+    $variableOutput = @(
+        & gh variable get LOCAL_DURABLE_ATTESTOR --repo $GitHubRepository 2>&1
+    )
+    $variableExitCode = $LASTEXITCODE
+    if ($variableExitCode -eq 0) {
+        $ExpectedStatusCreator =
+            (($variableOutput | ForEach-Object { [string] $_ }) -join '').Trim()
+    }
+    else {
+        $variableFailure =
+            ($variableOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+        if ($variableFailure -notmatch '(?i)(HTTP\s+404|not\s+found)') {
+            throw (
+                'Could not resolve the LOCAL_DURABLE_ATTESTOR repository variable. ' +
+                $variableFailure)
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($ExpectedStatusCreator)) {
+        $ExpectedStatusCreator = $GitHubRepository.Split('/', 2)[0]
+    }
+}
+else {
+    $ExpectedStatusCreator = $ExpectedStatusCreator.Trim()
+}
+
+$authenticatedOutput = @(& gh api user --jq '.login' 2>&1)
+if ($LASTEXITCODE -ne 0) {
+    $details = ($authenticatedOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+    throw "Could not identify the authenticated GitHub user. $details"
+}
+$authenticatedCreator =
+    (($authenticatedOutput | ForEach-Object { [string] $_ }) -join '').Trim()
+if (-not $authenticatedCreator.Equals(
+    $ExpectedStatusCreator,
+    [StringComparison]::OrdinalIgnoreCase)) {
+    throw (
+        "Authenticated GitHub user '$authenticatedCreator' is not the configured durable " +
+        "attestor '$ExpectedStatusCreator'.")
+}
+
+try {
+    Invoke-StatusVerifier
+    Write-Host (
+        "Exact commit $headCommit already has an accepted release status; no " +
+        'carry-forward status was added.')
+    return
+}
+catch {
+    Write-Host (
+        "Exact commit $headCommit does not yet have an accepted release status: " +
+        "$($_.Exception.Message)")
+}
+
+Invoke-StatusVerifier -EligibilityOnly
+
+$currentMainCommit = Get-ExactCurrentMainCommit
+if ($currentMainCommit -cne $headCommit) {
+    throw (
+        "Main changed while carry-forward eligibility was verified. Expected $headCommit; " +
+        "found $currentMainCommit.")
+}
+
+$apiPath = "repos/$GitHubRepository/statuses/$headCommit"
+$publishOutput = @(
+    & gh api `
+        --method POST `
+        $apiPath `
+        -f "state=success" `
+        -f "context=$carryForwardContext" `
+        -f "description=$carryForwardDescription" 2>&1
+)
+if ($LASTEXITCODE -ne 0) {
+    $details = ($publishOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+    throw "Could not publish the approved carry-forward status for $headCommit. $details"
+}
+
+$currentMainCommit = Get-ExactCurrentMainCommit
+if ($currentMainCommit -cne $headCommit) {
+    throw (
+        "Main changed after carry-forward publication. Attested $headCommit; current main " +
+        "is $currentMainCommit. Do not tag either commit from this invocation.")
+}
+
+Invoke-StatusVerifier
+Write-Host (
+    "Published and reverified the explicit one-time $releaseVersion carry-forward status " +
+    "for exact commit $headCommit without changing the durable-v3 failure context.")

--- a/scripts/Publish-ReleaseTag.ps1
+++ b/scripts/Publish-ReleaseTag.ps1
@@ -8,6 +8,8 @@ param(
 
     [switch] $ConfirmDedicatedFixedSsd,
 
+    [switch] $ApproveDurableV2CarryForward,
+
     [ValidatePattern('^$|^[^/\s]+/[^/\s]+$')]
     [string] $GitHubRepository = '',
 
@@ -19,6 +21,8 @@ $ErrorActionPreference = 'Stop'
 
 $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $statusVerifier = Join-Path $PSScriptRoot 'Test-LocalDurableStatus.ps1'
+$carryForwardPublisher =
+    Join-Path $PSScriptRoot 'Publish-DurableCarryForwardStatus.ps1'
 $localQualification = Join-Path `
     $repositoryRoot `
     'tests/CSharpDB.Benchmarks/scripts/Test-LocalDurablePerformance.ps1'
@@ -26,7 +30,19 @@ $tagValidator = Join-Path $PSScriptRoot 'Test-ReleaseTag.ps1'
 $releaseVersion = $Version.TrimStart('v')
 $releaseTag = "v$releaseVersion"
 
-foreach ($requiredScript in $statusVerifier, $localQualification, $tagValidator) {
+if ($ConfirmDedicatedFixedSsd -and $ApproveDurableV2CarryForward) {
+    throw (
+        '-ConfirmDedicatedFixedSsd and -ApproveDurableV2CarryForward are mutually exclusive.')
+}
+if ($ApproveDurableV2CarryForward -and $releaseVersion -cne '4.4.0') {
+    throw '-ApproveDurableV2CarryForward is available only for release 4.4.0.'
+}
+
+foreach ($requiredScript in
+    $statusVerifier,
+    $carryForwardPublisher,
+    $localQualification,
+    $tagValidator) {
     if (-not (Test-Path -LiteralPath $requiredScript -PathType Leaf)) {
         throw "Required release script was not found: $requiredScript"
     }
@@ -124,7 +140,8 @@ function Invoke-StatusVerifier {
     & $statusVerifier `
         -Commit $headCommit `
         -GitHubRepository $GitHubRepository `
-        -ExpectedCreator $ExpectedStatusCreator
+        -ExpectedCreator $ExpectedStatusCreator `
+        -ReleaseVersion $releaseVersion
 }
 
 function Get-ExactCurrentMainCommit {
@@ -231,25 +248,42 @@ $hasReusableStatus = $false
 try {
     Invoke-StatusVerifier
     $hasReusableStatus = $true
-    Write-Host "Reusing the existing canonical durable-v3 status for exact commit $headCommit."
+    Write-Host "Reusing the existing canonical release status for exact commit $headCommit."
 }
 catch {
-    Write-Host "Exact commit $headCommit has no reusable durable-v3 status: $($_.Exception.Message)"
+    Write-Host "Exact commit $headCommit has no reusable canonical release status: $($_.Exception.Message)"
 }
 
 if (-not $hasReusableStatus) {
-    if (-not $ConfirmDedicatedFixedSsd) {
-        throw (
-            "Commit $headCommit does not have a reusable canonical durable-v3 status. " +
-            'Rerun with -ConfirmDedicatedFixedSsd on the idle dedicated fixed-SSD Windows machine.')
+    if ($ApproveDurableV2CarryForward) {
+        & $carryForwardPublisher `
+            -Version $releaseVersion `
+            -GitHubRepository $GitHubRepository `
+            -ExpectedStatusCreator $ExpectedStatusCreator
+
+        Invoke-StatusVerifier
     }
+    elseif ($ConfirmDedicatedFixedSsd) {
+        & $localQualification `
+            -CandidateRef $headCommit `
+            -ConfirmDedicatedFixedSsd `
+            -GitHubRepository $GitHubRepository
 
-    & $localQualification `
-        -CandidateRef $headCommit `
-        -ConfirmDedicatedFixedSsd `
-        -GitHubRepository $GitHubRepository
-
-    Invoke-StatusVerifier
+        Invoke-StatusVerifier
+    }
+    else {
+        $carryForwardGuidance = if ($releaseVersion -ceq '4.4.0') {
+            ' For the approved one-time v4.4.0 exception, rerun with ' +
+            '-ApproveDurableV2CarryForward.'
+        }
+        else {
+            ''
+        }
+        throw (
+            "Commit $headCommit does not have a reusable canonical release status. " +
+            'Rerun with -ConfirmDedicatedFixedSsd on the idle dedicated fixed-SSD ' +
+            "Windows machine.$carryForwardGuidance")
+    }
 }
 
 $currentMainCommit = Get-ExactCurrentMainCommit

--- a/scripts/Test-LocalDurableStatus.ps1
+++ b/scripts/Test-LocalDurableStatus.ps1
@@ -12,17 +12,51 @@ param(
 
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
-    [string] $ExpectedCreator
+    [string] $ExpectedCreator,
+
+    [ValidatePattern('^$|^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$')]
+    [string] $ReleaseVersion = '',
+
+    [switch] $ValidateApprovedCarryForwardEligibility
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$statusContext = 'csharpdb/local-durable-performance'
-$canonicalAttestationPattern =
+$canonicalContext = 'csharpdb/local-durable-performance'
+$carryForwardContext =
+    'csharpdb/local-durable-performance-carry-forward-v4.4.0'
+$durableV3AttestationPattern =
     '^policy=durable-v3; baseline=[0-9a-f]{40}; design=[0-9A-F]{8}; reports=[0-9A-F]{8}/[0-9A-F]{8}$'
+
+# This is a one-release exception. These values deliberately pin both the last
+# successful durable-v2 evidence and the later durable-v3 failure it does not replace.
+$approvedReleaseVersion = '4.4.0'
+$approvedCreatorLogin = 'MaxAkbar'
+$approvedCreatorId = [Int64] 13856299
+$sourceCommit = '61e4d025087f4fae7208381288fba6115f0d1e30'
+$sourceStatusId = [Int64] 51598901859
+$sourceStatusTimestamp = [DateTimeOffset]::Parse('2026-08-04T07:38:51Z')
+$sourceStatusDescription =
+    'policy=durable-v2; baseline=7880dad112f3fdf011c134db2f8a08ec646ee326; ' +
+    'reports=BFF306E7/B9C20AD6'
+$failedV3Commit = 'ee1ea0e996fc22e093e950ec32e14543cd5caeca'
+$failedV3StatusId = [Int64] 51664261883
+$failedV3StatusTimestamp = [DateTimeOffset]::Parse('2026-08-05T02:52:58Z')
+$failedV3StatusDescription =
+    'policy=durable-v3; design=6B500421; local durable qualification failed'
+$allowedProductPath =
+    'src/CSharpDB.Migration/MigrationRejectArtifactPublication.cs'
+$approvedProductBlob = '8e43642cfcd3e523046302b99253673ceb5a33ce'
+$approvedProductTree = 'bee4859c14381fc2dbe209e2e0c84909dc98adc9'
+$carryForwardDescription =
+    'policy=durable-v2-carry-forward-v4.4.0; source=61e4d025; ' +
+    'success=51598901859; failed-v3=51664261883; tree=bee4859c'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $commitSha = $Commit.ToLowerInvariant()
 $expectedCreatorLogin = $ExpectedCreator.Trim()
+$normalizedReleaseVersion = $ReleaseVersion.TrimStart('v')
 
 if ([string]::IsNullOrWhiteSpace($expectedCreatorLogin)) {
     throw 'ExpectedCreator cannot be empty or whitespace.'
@@ -31,53 +65,302 @@ if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
     throw 'GitHub CLI (gh) is required to verify the local durable performance status.'
 }
 
-$apiPath = "repos/$GitHubRepository/commits/$commitSha/statuses?per_page=100"
-$apiOutput = @(& gh api $apiPath 2>&1)
-if ($LASTEXITCODE -ne 0) {
-    $details = ($apiOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
-    throw "Could not read GitHub statuses for commit $commitSha. $details"
+function Get-CommitStatuses {
+    param(
+        [Parameter(Mandatory)]
+        [string] $CommitSha
+    )
+
+    $apiPath = "repos/$GitHubRepository/commits/$CommitSha/statuses?per_page=100"
+    $apiOutput = @(& gh api $apiPath 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        $details = ($apiOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+        throw "Could not read GitHub statuses for commit $CommitSha. $details"
+    }
+
+    try {
+        return @(($apiOutput -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20)
+    }
+    catch {
+        throw "GitHub returned invalid status JSON for commit $CommitSha. $($_.Exception.Message)"
+    }
 }
 
-try {
-    $statuses = @(($apiOutput -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20)
-}
-catch {
-    throw "GitHub returned invalid status JSON for commit $commitSha. $($_.Exception.Message)"
+function Get-LatestStatus {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]] $Statuses,
+
+        [Parameter(Mandatory)]
+        [string] $Context
+    )
+
+    $matching = @(
+        $Statuses |
+            Where-Object { [string] $_.context -ceq $Context } |
+            Sort-Object -Property @(
+                @{ Expression = { [DateTimeOffset] $_.created_at }; Descending = $true },
+                @{ Expression = { [Int64] $_.id }; Descending = $true }
+            )
+    )
+    if ($matching.Count -eq 0) {
+        return $null
+    }
+    return $matching[0]
 }
 
-$matchingStatuses = @(
-    $statuses |
-        Where-Object { [string] $_.context -ceq $statusContext } |
-        Sort-Object -Property @(
-            @{ Expression = { [DateTimeOffset] $_.created_at }; Descending = $true },
-            @{ Expression = { [Int64] $_.id }; Descending = $true }
-        )
-)
-if ($matchingStatuses.Count -eq 0) {
-    throw "Commit $commitSha has no $statusContext status."
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory)]
+        [string[]] $Arguments,
+
+        [Parameter(Mandatory)]
+        [string] $FailureMessage
+    )
+
+    $output = @(& git -C $repositoryRoot @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        $details = ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+        if ([string]::IsNullOrWhiteSpace($details)) {
+            throw $FailureMessage
+        }
+        throw "$FailureMessage$([Environment]::NewLine)$details"
+    }
+    return ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
 }
 
-$latestStatus = $matchingStatuses[0]
-$state = [string] $latestStatus.state
-if ($state -cne 'success') {
+function Assert-PinnedStatus {
+    param(
+        [Parameter(Mandatory)]
+        [object] $Status,
+
+        [Parameter(Mandatory)]
+        [Int64] $Id,
+
+        [Parameter(Mandatory)]
+        [string] $State,
+
+        [Parameter(Mandatory)]
+        [DateTimeOffset] $Timestamp,
+
+        [Parameter(Mandatory)]
+        [string] $Description,
+
+        [Parameter(Mandatory)]
+        [string] $EvidenceName
+    )
+
+    $actualCreator = [string] $Status.creator.login
+    $actualCreatorId = [Int64] $Status.creator.id
+    if ([Int64] $Status.id -ne $Id -or
+        [string] $Status.state -cne $State -or
+        [DateTimeOffset] $Status.created_at -ne $Timestamp -or
+        [DateTimeOffset] $Status.updated_at -ne $Timestamp -or
+        -not $actualCreator.Equals($approvedCreatorLogin, [StringComparison]::OrdinalIgnoreCase) -or
+        $actualCreatorId -ne $approvedCreatorId -or
+        [string] $Status.description -cne $Description) {
+        throw "$EvidenceName no longer matches the exact approved GitHub status record."
+    }
+}
+
+function Compare-StatusOrder {
+    param(
+        [Parameter(Mandatory)]
+        [object] $Left,
+
+        [Parameter(Mandatory)]
+        [object] $Right
+    )
+
+    $timeComparison = ([DateTimeOffset] $Left.created_at).CompareTo(
+        [DateTimeOffset] $Right.created_at)
+    if ($timeComparison -ne 0) {
+        return $timeComparison
+    }
+    return ([Int64] $Left.id).CompareTo([Int64] $Right.id)
+}
+
+function Assert-ApprovedCarryForwardEligibility {
+    if ($normalizedReleaseVersion -cne $approvedReleaseVersion) {
+        throw (
+            "The approved durable-v2 carry-forward applies only to release " +
+            "$approvedReleaseVersion, not '$ReleaseVersion'.")
+    }
+    if (-not $expectedCreatorLogin.Equals(
+        $approvedCreatorLogin,
+        [StringComparison]::OrdinalIgnoreCase)) {
+        throw (
+            "The approved durable-v2 carry-forward is pinned to creator " +
+            "'$approvedCreatorLogin', not '$expectedCreatorLogin'.")
+    }
+    if ($null -eq (Get-Command git -ErrorAction SilentlyContinue)) {
+        throw 'Git is required to verify the approved durable-v2 carry-forward.'
+    }
+
+    $sourceStatuses = @(Get-CommitStatuses -CommitSha $sourceCommit)
+    $sourceStatus = Get-LatestStatus -Statuses $sourceStatuses -Context $canonicalContext
+    if ($null -eq $sourceStatus) {
+        throw "Approved source commit $sourceCommit has no $canonicalContext status."
+    }
+    Assert-PinnedStatus `
+        -Status $sourceStatus `
+        -Id $sourceStatusId `
+        -State 'success' `
+        -Timestamp $sourceStatusTimestamp `
+        -Description $sourceStatusDescription `
+        -EvidenceName 'The durable-v2 source evidence'
+
+    $failedStatuses = @(Get-CommitStatuses -CommitSha $failedV3Commit)
+    $failedStatus = Get-LatestStatus -Statuses $failedStatuses -Context $canonicalContext
+    if ($null -eq $failedStatus) {
+        throw "Known durable-v3 commit $failedV3Commit has no $canonicalContext status."
+    }
+    Assert-PinnedStatus `
+        -Status $failedStatus `
+        -Id $failedV3StatusId `
+        -State 'failure' `
+        -Timestamp $failedV3StatusTimestamp `
+        -Description $failedV3StatusDescription `
+        -EvidenceName 'The preserved durable-v3 failure'
+
+    Invoke-Git `
+        -Arguments @('merge-base', '--is-ancestor', $sourceCommit, $commitSha) `
+        -FailureMessage "Approved source commit $sourceCommit is not an ancestor of $commitSha." |
+        Out-Null
+    Invoke-Git `
+        -Arguments @('merge-base', '--is-ancestor', $failedV3Commit, $commitSha) `
+        -FailureMessage "Known durable-v3 commit $failedV3Commit is not an ancestor of $commitSha." |
+        Out-Null
+
+    $productDiff = Invoke-Git `
+        -Arguments @(
+            'diff',
+            '--name-status',
+            '--no-renames',
+            $sourceCommit,
+            $commitSha,
+            '--',
+            'src') `
+        -FailureMessage 'Could not inspect product-source changes for carry-forward.'
+    $expectedProductDiff = "M`t$allowedProductPath"
+    if ($productDiff -cne $expectedProductDiff) {
+        throw (
+            "Approved durable-v2 carry-forward requires exactly '$expectedProductDiff'; " +
+            "the actual product diff was '$productDiff'.")
+    }
+
+    $productBlob = (Invoke-Git `
+        -Arguments @('rev-parse', '--verify', "${commitSha}:$allowedProductPath") `
+        -FailureMessage "Could not resolve $allowedProductPath for commit $commitSha.").Trim()
+    if ($productBlob -cne $approvedProductBlob) {
+        throw (
+            "Approved product file blob is $approvedProductBlob, but commit $commitSha " +
+            "contains $productBlob.")
+    }
+
+    $productTree = (Invoke-Git `
+        -Arguments @('rev-parse', '--verify', "${commitSha}:src") `
+        -FailureMessage "Could not resolve the src tree for commit $commitSha.").Trim()
+    if ($productTree -cne $approvedProductTree) {
+        throw (
+            "Approved product source tree is $approvedProductTree, but commit $commitSha " +
+            "contains $productTree.")
+    }
+
+    Write-Host (
+        "Validated the one-time durable-v2 carry-forward eligibility for release " +
+        "$approvedReleaseVersion at exact commit $commitSha.")
+}
+
+$candidateStatuses = @(Get-CommitStatuses -CommitSha $commitSha)
+$latestCanonicalStatus =
+    Get-LatestStatus -Statuses $candidateStatuses -Context $canonicalContext
+$canonicalDiagnostic = $null
+
+if ($null -eq $latestCanonicalStatus) {
+    $canonicalDiagnostic = "Commit $commitSha has no $canonicalContext status."
+}
+elseif ([string] $latestCanonicalStatus.state -cne 'success') {
+    $canonicalDiagnostic =
+        "Latest $canonicalContext status for commit $commitSha is " +
+        "'$([string] $latestCanonicalStatus.state)', not 'success'."
+}
+elseif (-not ([string] $latestCanonicalStatus.creator.login).Equals(
+    $expectedCreatorLogin,
+    [StringComparison]::OrdinalIgnoreCase)) {
+    $canonicalDiagnostic =
+        "Latest $canonicalContext status for commit $commitSha was created by " +
+        "'$([string] $latestCanonicalStatus.creator.login)', not expected creator " +
+        "'$expectedCreatorLogin'."
+}
+elseif ([string] $latestCanonicalStatus.description -cnotmatch $durableV3AttestationPattern) {
+    $canonicalDiagnostic =
+        "Latest $canonicalContext status for commit $commitSha does not contain a " +
+        'canonical durable-v3 attestation.'
+}
+else {
+    Write-Host (
+        "Verified canonical durable-v3 status for exact commit $commitSha " +
+        "from $([string] $latestCanonicalStatus.creator.login).")
+    if (-not $ValidateApprovedCarryForwardEligibility) {
+        return
+    }
+}
+
+if (-not $ValidateApprovedCarryForwardEligibility -and
+    $normalizedReleaseVersion -cne $approvedReleaseVersion) {
+    throw $canonicalDiagnostic
+}
+
+Assert-ApprovedCarryForwardEligibility
+if ($ValidateApprovedCarryForwardEligibility) {
+    return
+}
+
+$latestCarryForwardStatus =
+    Get-LatestStatus -Statuses $candidateStatuses -Context $carryForwardContext
+if ($null -eq $latestCarryForwardStatus) {
     throw (
-        "Latest $statusContext status for commit $commitSha is '$state', not 'success'.")
+        "$canonicalDiagnostic No approved $carryForwardContext status exists for " +
+        "release $approvedReleaseVersion.")
+}
+if ([string] $latestCarryForwardStatus.state -cne 'success') {
+    throw (
+        "Latest $carryForwardContext status for commit $commitSha is " +
+        "'$([string] $latestCarryForwardStatus.state)', not 'success'.")
+}
+$carryForwardCreator = [string] $latestCarryForwardStatus.creator.login
+$carryForwardCreatorId = [Int64] $latestCarryForwardStatus.creator.id
+if (-not $carryForwardCreator.Equals(
+    $expectedCreatorLogin,
+    [StringComparison]::OrdinalIgnoreCase) -or
+    $carryForwardCreatorId -ne $approvedCreatorId) {
+    throw (
+        "Latest $carryForwardContext status for commit $commitSha was not created by " +
+        "the approved attestor $approvedCreatorLogin ($approvedCreatorId).")
+}
+if ([string] $latestCarryForwardStatus.description -cne $carryForwardDescription) {
+    throw (
+        "Latest $carryForwardContext status for commit $commitSha does not contain the " +
+        'exact approved v4.4.0 carry-forward attestation.')
 }
 
-$creator = [string] $latestStatus.creator.login
-if (-not $creator.Equals($expectedCreatorLogin, [StringComparison]::OrdinalIgnoreCase)) {
-    throw (
-        "Latest $statusContext status for commit $commitSha was created by '$creator', " +
-        "not expected creator '$expectedCreatorLogin'.")
+$failedStatusRecord = [pscustomobject]@{
+    created_at = $failedV3StatusTimestamp
+    id = $failedV3StatusId
 }
-
-$description = [string] $latestStatus.description
-if ($description -cnotmatch $canonicalAttestationPattern) {
+if ((Compare-StatusOrder -Left $latestCarryForwardStatus -Right $failedStatusRecord) -le 0) {
+    throw 'The approved carry-forward status does not postdate the preserved durable-v3 failure.'
+}
+if ($null -ne $latestCanonicalStatus -and
+    (Compare-StatusOrder -Left $latestCarryForwardStatus -Right $latestCanonicalStatus) -le 0) {
     throw (
-        "Latest $statusContext status for commit $commitSha does not contain a canonical " +
-        'durable-v3 attestation.')
+        "A $canonicalContext status at or after the approved carry-forward requires " +
+        'fresh release qualification.')
 }
 
 Write-Host (
-    "Verified canonical durable-v3 status for exact commit $commitSha " +
-    "from $creator.")
+    "Verified the explicit one-time durable-v2 carry-forward for release " +
+    "$approvedReleaseVersion at exact commit $commitSha from $carryForwardCreator; " +
+    "durable-v3 failure $failedV3StatusId remains preserved.")

--- a/scripts/Test-LocalDurableStatus.ps1
+++ b/scripts/Test-LocalDurableStatus.ps1
@@ -14,7 +14,7 @@ param(
     [ValidateNotNullOrEmpty()]
     [string] $ExpectedCreator,
 
-    [ValidatePattern('^$|^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$')]
+    [ValidatePattern('^$|^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$')]
     [string] $ReleaseVersion = '',
 
     [switch] $ValidateApprovedCarryForwardEligibility

--- a/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
@@ -59,6 +59,35 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
+    public void ReleaseTrigger_UsesFreshRegistrationAndTrustedPublishingImplementation()
+    {
+        string repoRoot = FindRepoRoot();
+        string trigger = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "publish-release.yml")).ReplaceLineEndings("\n");
+        string implementation = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "release.yml")).ReplaceLineEndings("\n");
+
+        Assert.Contains("name: Release\n", trigger);
+        Assert.Contains("      - \"v*\"", trigger);
+        Assert.Contains("uses: ./.github/workflows/release.yml", trigger);
+        Assert.Contains("secrets: inherit", trigger);
+        Assert.Contains("contents: write", trigger);
+        Assert.Contains("statuses: read", trigger);
+        Assert.Contains("id-token: write", trigger);
+        Assert.Contains("cancel-in-progress: false", trigger);
+
+        Assert.Contains("workflow_call:", implementation);
+        Assert.DoesNotContain("tags:", implementation);
+        Assert.Contains("uses: NuGet/login@v1", implementation);
+    }
+
+    [Fact]
     public void SqlReleaseQualificationWorkflow_RunsFunctionalAndHostedStablePerformancePasses()
     {
         string repoRoot = FindRepoRoot();

--- a/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
@@ -38,6 +38,108 @@ public sealed class ReleaseStatusScriptTests
         }
     }
 
+    [Fact]
+    public async Task Verifier_AcceptsPinnedOneTimeCarryForwardWithoutRelabelingV3()
+    {
+        string temporaryRoot = CreateTemporaryRoot();
+        try
+        {
+            string ghLog = Path.Combine(temporaryRoot, "gh.log");
+            string fakeGhRoot = CreateFakeGitHubCli(temporaryRoot);
+
+            ProcessResult result = await RunVerifierAsync(
+                fakeGhRoot,
+                ghLog,
+                scenario: "carry-forward",
+                releaseVersion: "v4.4.0");
+
+            Assert.True(result.ExitCode == 0, result.CombinedOutput);
+            AssertDiagnosticContains(
+                "Verified the explicit one-time durable-v2 carry-forward for release " +
+                $"4.4.0 at exact commit {CandidateCommit}",
+                result.CombinedOutput);
+            AssertDiagnosticContains(
+                "durable-v3 failure 51664261883 remains preserved",
+                result.CombinedOutput);
+            Assert.Equal(
+                [
+                    "api|repos/example/csharpdb/commits/" +
+                    $"{CandidateCommit}/statuses?per_page=100",
+                    "api|repos/example/csharpdb/commits/" +
+                    "61e4d025087f4fae7208381288fba6115f0d1e30/statuses?per_page=100",
+                    "api|repos/example/csharpdb/commits/" +
+                    "ee1ea0e996fc22e093e950ec32e14543cd5caeca/statuses?per_page=100",
+                ],
+                File.ReadAllLines(ghLog));
+        }
+        finally
+        {
+            DeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Verifier_RejectsCarryForwardForAnyOtherRelease()
+    {
+        string temporaryRoot = CreateTemporaryRoot();
+        try
+        {
+            string ghLog = Path.Combine(temporaryRoot, "gh.log");
+            string fakeGhRoot = CreateFakeGitHubCli(temporaryRoot);
+
+            ProcessResult result = await RunVerifierAsync(
+                fakeGhRoot,
+                ghLog,
+                scenario: "carry-forward",
+                releaseVersion: "4.4.1");
+
+            Assert.NotEqual(0, result.ExitCode);
+            AssertDiagnosticContains(
+                $"Commit {CandidateCommit} has no csharpdb/local-durable-performance status",
+                result.CombinedOutput);
+            Assert.Single(File.ReadAllLines(ghLog));
+        }
+        finally
+        {
+            DeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        "carry-forward-source-mismatch",
+        "durable-v2 source evidence no longer matches the exact approved GitHub status record")]
+    [InlineData(
+        "carry-forward-wrong-tree",
+        "Approved product source tree is bee4859c14381fc2dbe209e2e0c84909dc98adc9")]
+    [InlineData(
+        "carry-forward-stale",
+        "status at or after the approved carry-forward requires fresh release qualification")]
+    public async Task Verifier_RejectsTamperedOrStaleCarryForward(
+        string scenario,
+        string expectedDiagnostic)
+    {
+        string temporaryRoot = CreateTemporaryRoot();
+        try
+        {
+            string ghLog = Path.Combine(temporaryRoot, "gh.log");
+            string fakeGhRoot = CreateFakeGitHubCli(temporaryRoot);
+
+            ProcessResult result = await RunVerifierAsync(
+                fakeGhRoot,
+                ghLog,
+                scenario,
+                releaseVersion: "4.4.0");
+
+            Assert.NotEqual(0, result.ExitCode);
+            AssertDiagnosticContains(expectedDiagnostic, result.CombinedOutput);
+        }
+        finally
+        {
+            DeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
     [Theory]
     [InlineData(
         "missing",
@@ -134,6 +236,10 @@ public sealed class ReleaseStatusScriptTests
             repoRoot,
             "scripts",
             "Test-LocalDurableStatus.ps1"));
+        string carryForwardPublisher = File.ReadAllText(Path.Combine(
+            repoRoot,
+            "scripts",
+            "Publish-DurableCarryForwardStatus.ps1"));
 
         Assert.Contains(
             "status', '--porcelain=v1', '--untracked-files=all",
@@ -150,15 +256,53 @@ public sealed class ReleaseStatusScriptTests
         Assert.Contains("-CandidateRef $headCommit", publisher);
         Assert.Contains("refs/tags/$releaseTag`:refs/tags/$releaseTag", publisher);
         Assert.DoesNotContain("--force", publisher, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("merge-base", publisher, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("merge-base", verifier, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("parents", verifier, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("exit 0", verifier, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
             "^policy=durable-v3; baseline=[0-9a-f]{40}; design=[0-9A-F]{8}; " +
             "reports=[0-9A-F]{8}/[0-9A-F]{8}$",
             verifier);
-        Assert.DoesNotContain("policy=durable-v2", verifier, StringComparison.Ordinal);
-        Assert.DoesNotContain("durable-v2", publisher, StringComparison.Ordinal);
+        Assert.Contains(
+            "csharpdb/local-durable-performance-carry-forward-v4.4.0",
+            verifier);
+        Assert.Contains(
+            "61e4d025087f4fae7208381288fba6115f0d1e30",
+            verifier);
+        Assert.Contains("51598901859", verifier);
+        Assert.Contains(
+            "policy=durable-v2; baseline=7880dad112f3fdf011c134db2f8a08ec646ee326;",
+            verifier);
+        Assert.Contains("ee1ea0e996fc22e093e950ec32e14543cd5caeca", verifier);
+        Assert.Contains("51664261883", verifier);
+        Assert.Contains("local durable qualification failed", verifier);
+        Assert.Contains(
+            "src/CSharpDB.Migration/MigrationRejectArtifactPublication.cs",
+            verifier);
+        Assert.Contains("'merge-base', '--is-ancestor'", verifier);
+        Assert.Contains("'--name-status'", verifier);
+        Assert.Contains("'--no-renames'", verifier);
+        Assert.Contains("8e43642cfcd3e523046302b99253673ceb5a33ce", verifier);
+        Assert.Contains("bee4859c14381fc2dbe209e2e0c84909dc98adc9", verifier);
+
+        Assert.Contains("Authenticated GitHub user", carryForwardPublisher);
+        Assert.Contains("statuses/$headCommit", carryForwardPublisher);
+        Assert.Contains("Invoke-StatusVerifier -EligibilityOnly", carryForwardPublisher);
+        Assert.Contains("Publish-DurableCarryForwardStatus.ps1", publisher);
+        Assert.Contains("-ApproveDurableV2CarryForward", publisher);
+        Assert.Contains("mutually exclusive", publisher);
+        Assert.Contains("-ReleaseVersion $releaseVersion", publisher);
+        Assert.DoesNotContain("refs/tags/", carryForwardPublisher, StringComparison.Ordinal);
+
+        int sourceEvidence = carryForwardPublisher.IndexOf(
+            "Invoke-StatusVerifier -EligibilityOnly",
+            StringComparison.Ordinal);
+        int publishStatus = carryForwardPublisher.IndexOf(
+            "--method POST",
+            StringComparison.Ordinal);
+        Assert.True(sourceEvidence >= 0);
+        Assert.True(
+            publishStatus > sourceEvidence,
+            "The source evidence must be verified before a carry-forward status is published.");
 
         int initialVerifier = publisher.IndexOf(
             "Invoke-StatusVerifier",
@@ -276,7 +420,8 @@ public sealed class ReleaseStatusScriptTests
     private static Task<ProcessResult> RunVerifierAsync(
         string fakeGhRoot,
         string ghLog,
-        string scenario)
+        string scenario,
+        string? releaseVersion = null)
     {
         Dictionary<string, string> environment = new()
         {
@@ -285,9 +430,8 @@ public sealed class ReleaseStatusScriptTests
             ["PATH"] = fakeGhRoot + Path.PathSeparator +
                 (Environment.GetEnvironmentVariable("PATH") ?? string.Empty),
         };
-        return RunProcessAsync(
-            "pwsh",
-            environment,
+        List<string> arguments =
+        [
             "-NoLogo",
             "-NoProfile",
             "-File",
@@ -297,7 +441,14 @@ public sealed class ReleaseStatusScriptTests
             "-GitHubRepository",
             "example/csharpdb",
             "-ExpectedCreator",
-            "MaxAkbar");
+            "MaxAkbar",
+        ];
+        if (releaseVersion is not null)
+        {
+            arguments.Add("-ReleaseVersion");
+            arguments.Add(releaseVersion);
+        }
+        return RunProcessAsync("pwsh", environment, [.. arguments]);
     }
 
     private static string CreateFakeGitHubCli(string temporaryRoot)
@@ -322,6 +473,8 @@ public sealed class ReleaseStatusScriptTests
             }
 
             $context = 'csharpdb/local-durable-performance'
+            $carryForwardContext =
+                'csharpdb/local-durable-performance-carry-forward-v4.4.0'
             $canonical =
                 'policy=durable-v3; baseline=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; ' +
                 'design=89ABCDEF; ' +
@@ -333,16 +486,56 @@ public sealed class ReleaseStatusScriptTests
                     [string] $State,
                     [string] $Context = $context,
                     [string] $Creator = 'maxakbar',
+                    [long] $CreatorId = 13856299,
                     [string] $Description = $canonical)
 
                 [pscustomobject]@{
                     id = $Id
                     created_at = $CreatedAt
+                    updated_at = $CreatedAt
                     state = $State
                     context = $Context
-                    creator = [pscustomobject]@{ login = $Creator }
+                    creator = [pscustomobject]@{
+                        login = $Creator
+                        id = $CreatorId
+                    }
                     description = $Description
                 }
+            }
+
+            $apiPath = $CliArguments[1]
+            if ($apiPath -match '61e4d025087f4fae7208381288fba6115f0d1e30') {
+                $sourceId = if ($env:FAKE_GH_SCENARIO -ceq 'carry-forward-source-mismatch') {
+                    51598901860
+                }
+                else {
+                    51598901859
+                }
+                $statuses = @(
+                    (New-FakeStatus `
+                        -Id $sourceId `
+                        -CreatedAt '2026-08-04T07:38:51Z' `
+                        -State success `
+                        -Description (
+                            'policy=durable-v2; ' +
+                            'baseline=7880dad112f3fdf011c134db2f8a08ec646ee326; ' +
+                            'reports=BFF306E7/B9C20AD6'))
+                )
+                ConvertTo-Json -InputObject @($statuses) -Depth 10 -Compress
+                exit 0
+            }
+            if ($apiPath -match 'ee1ea0e996fc22e093e950ec32e14543cd5caeca') {
+                $statuses = @(
+                    (New-FakeStatus `
+                        -Id 51664261883 `
+                        -CreatedAt '2026-08-05T02:52:58Z' `
+                        -State failure `
+                        -Description (
+                            'policy=durable-v3; design=6B500421; ' +
+                            'local durable qualification failed'))
+                )
+                ConvertTo-Json -InputObject @($statuses) -Depth 10 -Compress
+                exit 0
             }
 
             $olderSuccess = New-FakeStatus `
@@ -435,6 +628,42 @@ public sealed class ReleaseStatusScriptTests
                                 'reports=1234ABCD/5678EFAB'))
                     )
                 }
+                { $_ -in @(
+                    'carry-forward',
+                    'carry-forward-source-mismatch',
+                    'carry-forward-wrong-tree') } {
+                    @(
+                        (New-FakeStatus `
+                            -Id 51665000000 `
+                            -CreatedAt '2026-08-05T03:00:00Z' `
+                            -State success `
+                            -Context $carryForwardContext `
+                            -Description (
+                                'policy=durable-v2-carry-forward-v4.4.0; source=61e4d025; ' +
+                                'success=51598901859; failed-v3=51664261883; ' +
+                                'tree=bee4859c'))
+                    )
+                }
+                'carry-forward-stale' {
+                    @(
+                        (New-FakeStatus `
+                            -Id 51665000000 `
+                            -CreatedAt '2026-08-05T03:00:00Z' `
+                            -State success `
+                            -Context $carryForwardContext `
+                            -Description (
+                                'policy=durable-v2-carry-forward-v4.4.0; source=61e4d025; ' +
+                                'success=51598901859; failed-v3=51664261883; ' +
+                                'tree=bee4859c')),
+                        (New-FakeStatus `
+                            -Id 51666000000 `
+                            -CreatedAt '2026-08-05T04:00:00Z' `
+                            -State failure `
+                            -Description (
+                                'policy=durable-v3; design=12345678; ' +
+                                'local durable qualification failed'))
+                    )
+                }
                 default {
                     Write-Error "Unknown fake gh scenario: $env:FAKE_GH_SCENARIO"
                     exit 1
@@ -443,7 +672,6 @@ public sealed class ReleaseStatusScriptTests
 
             ConvertTo-Json -InputObject @($statuses) -Depth 10 -Compress
             """);
-
         if (OperatingSystem.IsWindows())
         {
             File.WriteAllText(
@@ -452,6 +680,32 @@ public sealed class ReleaseStatusScriptTests
                 @echo off
                 pwsh -NoLogo -NoProfile -File "%~dp0fake-gh.ps1" %*
                 exit /b %ERRORLEVEL%
+                """);
+            File.WriteAllText(
+                Path.Combine(toolRoot, "git.cmd"),
+                """
+                @echo off
+                if /I "%~3"=="merge-base" exit /b 0
+                if /I "%~3"=="diff" (
+                    echo M	src/CSharpDB.Migration/MigrationRejectArtifactPublication.cs
+                    exit /b 0
+                )
+                if /I "%~3"=="rev-parse" (
+                    if /I "%~5"=="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:src/CSharpDB.Migration/MigrationRejectArtifactPublication.cs" (
+                        echo 8e43642cfcd3e523046302b99253673ceb5a33ce
+                        exit /b 0
+                    )
+                    if /I "%~5"=="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:src" (
+                        if /I "%FAKE_GH_SCENARIO%"=="carry-forward-wrong-tree" (
+                            echo 1111111111111111111111111111111111111111
+                        ) else (
+                            echo bee4859c14381fc2dbe209e2e0c84909dc98adc9
+                        )
+                        exit /b 0
+                    )
+                )
+                echo Unexpected fake git invocation: %* 1>&2
+                exit /b 1
                 """);
         }
         else
@@ -466,6 +720,55 @@ public sealed class ReleaseStatusScriptTests
                 """);
             File.SetUnixFileMode(
                 launcher,
+                UnixFileMode.UserRead |
+                UnixFileMode.UserWrite |
+                UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead |
+                UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead |
+                UnixFileMode.OtherExecute);
+            string gitLauncher = Path.Combine(toolRoot, "git");
+            File.WriteAllText(
+                gitLauncher,
+                """
+                #!/usr/bin/env sh
+                if [ "$#" -lt 3 ] || [ "$1" != "-C" ]; then
+                  printf '%s\n' "Unexpected fake git invocation: $*" >&2
+                  exit 1
+                fi
+                command_name="$3"
+                case "$command_name" in
+                  merge-base)
+                    exit 0
+                    ;;
+                  diff)
+                    printf 'M\tsrc/CSharpDB.Migration/MigrationRejectArtifactPublication.cs\n'
+                    exit 0
+                    ;;
+                  rev-parse)
+                    object_name=''
+                    for argument in "$@"; do object_name="$argument"; done
+                    case "$object_name" in
+                      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:src/CSharpDB.Migration/MigrationRejectArtifactPublication.cs)
+                        printf '%s\n' '8e43642cfcd3e523046302b99253673ceb5a33ce'
+                        exit 0
+                        ;;
+                      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:src)
+                        if [ "$FAKE_GH_SCENARIO" = 'carry-forward-wrong-tree' ]; then
+                          printf '%s\n' '1111111111111111111111111111111111111111'
+                        else
+                          printf '%s\n' 'bee4859c14381fc2dbe209e2e0c84909dc98adc9'
+                        fi
+                        exit 0
+                        ;;
+                    esac
+                    ;;
+                esac
+                printf '%s\n' "Unexpected fake git invocation: $*" >&2
+                exit 1
+                """);
+            File.SetUnixFileMode(
+                gitLauncher,
                 UnixFileMode.UserRead |
                 UnixFileMode.UserWrite |
                 UnixFileMode.UserExecute |

--- a/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
@@ -19,7 +19,8 @@ public sealed class ReleaseStatusScriptTests
             ProcessResult result = await RunVerifierAsync(
                 fakeGhRoot,
                 ghLog,
-                scenario: "success");
+                scenario: "success",
+                releaseVersion: "v4.5.0-rc.1+build.1");
 
             Assert.True(result.ExitCode == 0, result.CombinedOutput);
             AssertDiagnosticContains(


### PR DESCRIPTION
## Summary

- Register a fresh `v*` release trigger while retaining `release.yml` as the reusable publishing implementation and NuGet trusted-publishing identity.
- Add a one-time, release-locked durable-v2 carry-forward for v4.4.0 using a separate commit-status context.
- Pin the exact successful durable-v2 record, preserved durable-v3 failure, ancestry, only permitted product diff, file blob, and complete `src` tree.
- Integrate the explicit carry-forward with the canonical release-tag publisher and add success, tamper, stale-status, wrong-version, workflow, and packaging regression coverage.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

None.

## Testing

- [ ] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Validation performed:

- Release status and daemon packaging tests: 29 passed.
- Migration release packaging tests: 9 passed.
- NuGet package-closure validation passed.
- All changed PowerShell scripts parsed successfully.
- Workflow YAML passed actionlint.
- The carry-forward eligibility check passed against the live pinned GitHub records and exact Git history without publishing a status or tag.
- Confirmed no product-source files changed.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

The existing durable-v3 failure remains untouched. The approved exception uses the separate `csharpdb/local-durable-performance-carry-forward-v4.4.0` context and is accepted only for v4.4.0 after independently revalidating all pinned evidence.

`publish-release.yml` is the fresh tag trigger. Publishing jobs remain in reusable `release.yml` because NuGet trusted publishing validates the OIDC `job_workflow_ref`; the nuget.org policy must remain pointed at `release.yml`.