### PR TITLE
Stabilize hosted release test timeouts

### DIFF
--- a/tests/CSharpDB.Benchmarks.Tests/SqliteComparisonBenchmarkTests.cs
+++ b/tests/CSharpDB.Benchmarks.Tests/SqliteComparisonBenchmarkTests.cs
@@ -152,6 +152,10 @@ public sealed class SqliteComparisonBenchmarkTests
     public async Task PreparedBulkTransaction_CancelledWorkerRollsBackWithinDrain()
     {
         SqliteComparisonBenchmark.MeasurementPolicy policy = CreateFastPolicy();
+        TimeSpan cancellationDrainTimeout =
+            ReleaseWorkerCancellationPolicy.CoordinatedDrainTimeout;
+        TimeSpan testTimeout =
+            cancellationDrainTimeout + BenchmarkTestWatchdog.SchedulingTimeout;
         using var deadline = new ManualMeasurementDeadline();
         using var firstRowStarted = new ManualResetEventSlim();
         using var releaseFirstRow = new ManualResetEventSlim();
@@ -180,7 +184,7 @@ public sealed class SqliteComparisonBenchmarkTests
             },
             policy,
             deadline,
-            TimeSpan.FromMilliseconds(100));
+            cancellationDrainTimeout);
 
         try
         {
@@ -192,7 +196,7 @@ public sealed class SqliteComparisonBenchmarkTests
 
             InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => runTask.WaitAsync(
-                    BenchmarkTestWatchdog.SchedulingTimeout,
+                    testTimeout,
                     TestContext.Current.CancellationToken));
 
             Assert.Contains("90-second measurement cap", exception.Message);

--- a/tests/CSharpDB.Daemon.Tests/PreviousReleasePairedRunnerScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/PreviousReleasePairedRunnerScriptTests.cs
@@ -1007,10 +1007,14 @@ public sealed class PreviousReleasePairedRunnerScriptTests
                 ["FAKE_DOTNET_LOG"] = invocationLog,
             };
             string evidence = Path.Combine(temporaryRoot, "exact-master-durable-evidence");
+            // This exact suite intentionally cold-starts PowerShell for 122 run invocations
+            // plus setup commands; hosted macOS can legitimately exceed the shared budget.
+            TimeSpan processTimeout = TimeSpan.FromMinutes(5);
 
             ProcessResult result = await RunProcessWithEnvironmentAsync(
                 "pwsh",
                 environment,
+                processTimeout,
                 "-NoLogo",
                 "-NoProfile",
                 "-File",
@@ -2320,6 +2324,19 @@ public sealed class PreviousReleasePairedRunnerScriptTests
             fileName,
             environment,
             TimeSpan.FromSeconds(180),
+            arguments);
+    }
+
+    private static Task<ProcessResult> RunProcessWithEnvironmentAsync(
+        string fileName,
+        IReadOnlyDictionary<string, string> environment,
+        TimeSpan timeoutDuration,
+        params string[] arguments)
+    {
+        return RunProcessCoreAsync(
+            fileName,
+            environment,
+            timeoutDuration,
             arguments);
     }
 


### PR DESCRIPTION
## Summary

- Align the positive SQLite cancellation-drain regression with the 30-second hosted-runner policy used by release benchmarks.
- Give that test a 60-second outer watchdog so the bounded drain diagnostic always wins before the test harness times out.
- Give only the exact 122-invocation paired-runner test a five-minute process budget while retaining the shared 180-second default everywhere else.
- Stabilize hosted macOS qualification without changing product or benchmark runtime behavior.

Root causes:

- The cancellation test deliberately blocked a worker and then allowed only 100 ms for hosted macOS to reschedule it, observe cancellation, and roll back, despite production already allowing 30 seconds.
- The exact paired-runner test cold-starts PowerShell for 122 fake benchmark runs plus setup commands on Unix. Its inherited 180-second cap allowed roughly 1.4 seconds per process before file, manifest, and hashing work.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance
- [x] Tests only

## Related Issues

None.

## Testing

- [ ] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Validation performed:

- Corrected cancellation test passed: 1/1.
- Complete `CSharpDB.Benchmarks.Tests` project passed: 130/130.
- Exact paired-runner success and invalid-row fail-closed tests passed: 2/2.
- `git diff --check` passed.
- Two independent reviews found no blocking issue in either correction.
- Confirmed no CSharpDB `dotnet.exe` test process remained after the first validation run.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

Release run [31013702784](https://github.com/MaxAkbar/CSharpDB/actions/runs/31013702784) failed only in macOS clean pass 1 at `PreparedBulkTransaction_CancelledWorkerRollsBackWithinDrain`; the other five qualification passes and durable gate succeeded.

PR run [31017086611](https://github.com/MaxAkbar/CSharpDB/actions/runs/31017086611) then confirmed that correction but exposed the unrelated inherited 180-second budget in `ExactMasterDurableRunner_StagesConditionsAndRetainsEveryScheduledRawRow`. Windows, Ubuntu, and all NativeAOT checks passed.

No v4.4.0 NuGet package or GitHub Release was published. The adjacent negative cancellation tests retain short drains, and all exact paired-runner invocation, schedule, digest, metadata, staging, cleanup, and fail-closed assertions remain unchanged.