### PR TITLE
Add audited v4.5.0 release recovery

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,22 +4,177 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      approve_v4_5_0_local_durable_waiver:
+        description: Approve the one-time v4.5.0 local durable performance waiver
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && 'refs/tags/v4.5.0' || github.ref }}
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  statuses: read
-  id-token: write
+  contents: read
 
 jobs:
-  publish:
+  publish-tag:
+    if: github.event_name == 'push'
     name: Publish exact release tag
     permissions:
       contents: write
       statuses: read
       id-token: write
     uses: ./.github/workflows/release.yml
-    secrets: inherit
+    with:
+      release_tag: ${{ github.ref_name }}
+      release_commit: ${{ github.sha }}
+      waive_local_durable_for_v450: false
+    secrets:
+      NUGET_USER: ${{ secrets.NUGET_USER }}
+
+  validate-v4-5-0-recovery:
+    if: github.event_name == 'workflow_dispatch'
+    name: Validate one-time v4.5.0 recovery
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      statuses: read
+
+    steps:
+      - name: Require the exact approved recovery request and evidence
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          APPROVED: ${{ inputs.approve_v4_5_0_local_durable_waiver }}
+          ACTOR_ID: ${{ github.actor_id }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $expectedRepository = 'MaxAkbar/CSharpDB'
+          $expectedActor = 'MaxAkbar'
+          $expectedActorId = '13856299'
+          $expectedWorkflowRef = 'MaxAkbar/CSharpDB/.github/workflows/publish-release.yml@refs/heads/main'
+          $expectedTag = 'v4.5.0'
+          $expectedCommit = '7aeb66031237283c3643e73849618bf299729ed6'
+          $expectedStatusId = 51899579502L
+          $expectedStatusTime = '2026-08-09T06:02:33Z'
+          $expectedStatusDescription = 'policy=durable-v3; design=6B500421; local durable qualification failed'
+          $expectedCiRunId = 31260517686L
+
+          if ($env:APPROVED -cne 'true') {
+            throw 'The one-time v4.5.0 local durable waiver was not explicitly approved.'
+          }
+          if ($env:GITHUB_REPOSITORY -cne $expectedRepository) {
+            throw "Recovery is pinned to $expectedRepository."
+          }
+          if ($env:GITHUB_EVENT_NAME -cne 'workflow_dispatch') {
+            throw 'Recovery must be started through workflow_dispatch.'
+          }
+          if ($env:GITHUB_REF -cne 'refs/heads/main') {
+            throw 'Recovery must be dispatched from refs/heads/main.'
+          }
+          if ($env:WORKFLOW_REF -cne $expectedWorkflowRef) {
+            throw "Unexpected workflow identity: $env:WORKFLOW_REF"
+          }
+          if ($env:GITHUB_ACTOR -cne $expectedActor -or
+              $env:TRIGGERING_ACTOR -cne $expectedActor -or
+              $env:ACTOR_ID -cne $expectedActorId) {
+            throw 'Recovery must be started and triggered by the pinned repository owner.'
+          }
+
+          $tagRefJson = & gh api "repos/$expectedRepository/git/ref/tags/$expectedTag"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not resolve the immutable $expectedTag tag."
+          }
+          $tagRef = $tagRefJson | ConvertFrom-Json
+          if ($tagRef.object.type -cne 'commit' -or $tagRef.object.sha -cne $expectedCommit) {
+            throw "$expectedTag is not the expected lightweight tag at $expectedCommit."
+          }
+
+          $statusesJson = & gh api "repos/$expectedRepository/commits/$expectedCommit/statuses"
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not read the preserved local durable status evidence.'
+          }
+          $latestStatus = @(
+            $statusesJson |
+              ConvertFrom-Json |
+              Where-Object context -CEQ 'csharpdb/local-durable-performance'
+          ) | Select-Object -First 1
+          $latestStatusTime = if ($null -eq $latestStatus) {
+            $null
+          }
+          else {
+            ([DateTimeOffset]$latestStatus.created_at).ToUniversalTime().ToString(
+              'yyyy-MM-ddTHH:mm:ssZ',
+              [Globalization.CultureInfo]::InvariantCulture)
+          }
+          if ($null -eq $latestStatus -or
+              [long]$latestStatus.id -ne $expectedStatusId -or
+              $latestStatus.state -cne 'failure' -or
+              $latestStatus.creator.login -cne $expectedActor -or
+              $latestStatusTime -cne $expectedStatusTime -or
+              $latestStatus.description -cne $expectedStatusDescription) {
+            throw 'The newest local durable status is not the exact preserved v4.5.0 failure being waived.'
+          }
+
+          $ciRunJson = & gh api "repos/$expectedRepository/actions/runs/$expectedCiRunId"
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not read the pinned exact-commit CI evidence.'
+          }
+          $ciRun = $ciRunJson | ConvertFrom-Json
+          if ([long]$ciRun.id -ne $expectedCiRunId -or
+              $ciRun.path -cne '.github/workflows/ci.yml' -or
+              $ciRun.event -cne 'push' -or
+              $ciRun.head_sha -cne $expectedCommit -or
+              $ciRun.status -cne 'completed' -or
+              $ciRun.conclusion -cne 'success' -or
+              $ciRun.actor.login -cne $expectedActor) {
+            throw 'The pinned exact-commit CI run is not the expected successful qualification.'
+          }
+
+          $releaseIds = @(
+            & gh api --paginate "repos/$expectedRepository/releases" --jq '.[] | select(.tag_name == "v4.5.0") | .id'
+          )
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not check for an existing v4.5.0 GitHub Release.'
+          }
+          if ($releaseIds.Count -ne 0) {
+            throw 'A v4.5.0 GitHub Release already exists; recovery will not update it.'
+          }
+
+          Write-Host '::notice title=Recovery evidence verified::The exact failed local qualification and successful exact-commit CI run are preserved. No success status will be created.'
+
+  approve-v4-5-0-recovery:
+    if: github.event_name == 'workflow_dispatch'
+    name: Approve one-time v4.5.0 recovery
+    needs: validate-v4-5-0-recovery
+    runs-on: ubuntu-latest
+    environment: v4-5-0-recovery
+    permissions:
+      contents: read
+
+    steps:
+      - name: Record protected environment approval
+        run: echo "Protected approval granted for the exact v4.5.0 recovery."
+
+  recover-v4-5-0:
+    if: github.event_name == 'workflow_dispatch'
+    name: Recover exact v4.5.0 release
+    needs: approve-v4-5-0-recovery
+    permissions:
+      contents: write
+      statuses: read
+      id-token: write
+    uses: ./.github/workflows/release.yml
+    with:
+      release_tag: v4.5.0
+      release_commit: 7aeb66031237283c3643e73849618bf299729ed6
+      waive_local_durable_for_v450: true
+    secrets:
+      NUGET_USER: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,31 @@ name: Release implementation
 
 on:
   workflow_call:
+    inputs:
+      release_tag:
+        description: Exact existing release tag to publish
+        required: true
+        type: string
+      release_commit:
+        description: Exact commit targeted by release_tag
+        required: true
+        type: string
+      waive_local_durable_for_v450:
+        description: One-time owner-approved waiver pinned to the failed v4.5.0 qualification
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      NUGET_USER:
+        description: NuGet profile name used by Trusted Publishing
+        required: true
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   verify-local-durable-performance:
-    name: Verify local durable performance qualification
+    name: Verify local durable performance qualification or approved recovery
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,37 +37,96 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.release_commit }}
+
+      - name: Require the exact existing release tag and commit
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ($env:RELEASE_TAG -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+            throw "Release tag is not a supported semantic version: $env:RELEASE_TAG"
+          }
+          if ($env:RELEASE_COMMIT -notmatch '^[0-9a-f]{40}$') {
+            throw "Release commit is not a full lowercase SHA: $env:RELEASE_COMMIT"
+          }
+
+          $head = (& git rev-parse HEAD).Trim()
+          if ($LASTEXITCODE -ne 0 -or $head -cne $env:RELEASE_COMMIT) {
+            throw "Checked-out HEAD $head does not match $env:RELEASE_COMMIT."
+          }
+
+          $tagCommit = (& git rev-parse "refs/tags/$($env:RELEASE_TAG)^{commit}").Trim()
+          if ($LASTEXITCODE -ne 0 -or $tagCommit -cne $env:RELEASE_COMMIT) {
+            throw "$env:RELEASE_TAG does not resolve to $env:RELEASE_COMMIT."
+          }
+
+      - name: Record the approved one-time v4.5.0 waiver
+        if: ${{ inputs.waive_local_durable_for_v450 }}
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ($env:GITHUB_REPOSITORY -cne 'MaxAkbar/CSharpDB' -or
+              $env:GITHUB_EVENT_NAME -cne 'workflow_dispatch' -or
+              $env:GITHUB_REF -cne 'refs/heads/main' -or
+              $env:WORKFLOW_REF -cne 'MaxAkbar/CSharpDB/.github/workflows/publish-release.yml@refs/heads/main' -or
+              $env:GITHUB_ACTOR -cne 'MaxAkbar' -or
+              $env:TRIGGERING_ACTOR -cne 'MaxAkbar' -or
+              $env:RELEASE_TAG -cne 'v4.5.0' -or
+              $env:RELEASE_COMMIT -cne '7aeb66031237283c3643e73849618bf299729ed6') {
+            throw 'The local durable waiver is valid only for the exact owner-dispatched v4.5.0 recovery.'
+          }
+
+          Write-Host '::warning title=Explicit v4.5.0 recovery waiver::The failed local durable-v3 evidence is preserved. Hosted qualification remains blocking, and no success status is being fabricated.'
 
       - name: Require a successful matching-commit local performance status
+        if: ${{ !inputs.waive_local_durable_for_v450 }}
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_STATUS_CREATOR: ${{ vars.LOCAL_DURABLE_ATTESTOR || github.repository_owner }}
         run: |
           ./scripts/Test-LocalDurableStatus.ps1 `
-            -Commit '${{ github.sha }}' `
+            -Commit '${{ inputs.release_commit }}' `
             -GitHubRepository '${{ github.repository }}' `
             -ExpectedCreator $env:EXPECTED_STATUS_CREATOR `
-            -ReleaseVersion '${{ github.ref_name }}'
+            -ReleaseVersion '${{ inputs.release_tag }}'
 
   build-and-test:
     name: Qualify release source
     needs: verify-local-durable-performance
     uses: ./.github/workflows/sql-release-qualification.yml
     with:
-      release_version: ${{ github.ref_name }}
-      release_commit: ${{ github.sha }}
+      release_version: ${{ inputs.release_tag }}
+      release_commit: ${{ inputs.release_commit }}
+      previous_release_ref: ${{ inputs.waive_local_durable_for_v450 && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}
 
   publish-nuget:
     name: Publish NuGet
     needs: build-and-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_commit }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -62,8 +138,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          if [[ -z "$version" || "$version" == "$GITHUB_REF_NAME" ]]; then
+          version="${RELEASE_TAG#v}"
+          if [[ -z "$version" || "$version" == "$RELEASE_TAG" ]]; then
             echo "Tag must start with v (for example v1.0.1)." >&2
             exit 1
           fi
@@ -85,7 +161,7 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x scripts/fix-nuget-readme-links.sh
-          scripts/fix-nuget-readme-links.sh "$GITHUB_REF_NAME" \
+          scripts/fix-nuget-readme-links.sh "$RELEASE_TAG" \
             src/CSharpDB/README.md \
             src/CSharpDB.Primitives/README.md \
             src/CSharpDB.Sql/README.md \
@@ -142,6 +218,29 @@ jobs:
           ./scripts/Test-EfCoreMigrationTool.ps1 `
             -FeedPath artifacts/nuget `
             -Version "${{ steps.version.outputs.version }}"
+
+      - name: Revalidate the immutable publication target
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $resolved = & gh api "repos/$env:GITHUB_REPOSITORY/commits/$env:RELEASE_TAG" --jq .sha
+          if ($LASTEXITCODE -ne 0 -or $resolved.Trim() -cne $env:RELEASE_COMMIT) {
+            throw "$env:RELEASE_TAG no longer resolves to $env:RELEASE_COMMIT."
+          }
+
+          $releaseTags = @(
+            & gh api --paginate "repos/$env:GITHUB_REPOSITORY/releases" --jq '.[].tag_name'
+          )
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not check for an existing $env:RELEASE_TAG GitHub Release."
+          }
+          if ($releaseTags -ccontains $env:RELEASE_TAG) {
+            throw "A $env:RELEASE_TAG GitHub Release already exists; packages will not be published."
+          }
 
       - name: NuGet login through Trusted Publishing
         id: nuget-login
@@ -211,6 +310,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_commit }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -220,7 +321,7 @@ jobs:
       - name: Publish reviewed migration archive
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           $version = $env:RELEASE_TAG -replace '^v', ''
           ./scripts/Publish-CSharpDbMigrationRelease.ps1 `
@@ -232,7 +333,7 @@ jobs:
       - name: Verify migration archive and publisher checksum
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           $ErrorActionPreference = 'Stop'
           $version = $env:RELEASE_TAG -replace '^v', ''
@@ -278,6 +379,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_commit }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -356,6 +459,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_commit }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -364,13 +469,17 @@ jobs:
 
       - name: Publish daemon archive
         shell: pwsh
-        run: ./scripts/Publish-CSharpDbDaemonRelease.ps1 -Runtime ${{ matrix.rid }} -OutputRoot artifacts/daemon-release
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: ./scripts/Publish-CSharpDbDaemonRelease.ps1 -Version $env:RELEASE_TAG -Runtime ${{ matrix.rid }} -OutputRoot artifacts/daemon-release
 
       - name: Verify daemon archive and smoke start
         shell: pwsh
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $version = $env:GITHUB_REF_NAME -replace '^v', ''
+          $version = $env:RELEASE_TAG -replace '^v', ''
           $archiveName = "csharpdb-daemon-v$version-${{ matrix.rid }}.${{ matrix.extension }}"
           $archivePath = Join-Path "artifacts/daemon-release/archives" $archiveName
           $checksumsPath = Join-Path "artifacts/daemon-release/archives" "SHA256SUMS.txt"
@@ -521,6 +630,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_commit }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -529,13 +640,17 @@ jobs:
 
       - name: Publish Admin desktop archive
         shell: pwsh
-        run: ./scripts/Publish-CSharpDbAdminRelease.ps1 -Runtime win-x64 -OutputRoot artifacts/admin-release
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: ./scripts/Publish-CSharpDbAdminRelease.ps1 -Version $env:RELEASE_TAG -Runtime win-x64 -OutputRoot artifacts/admin-release
 
       - name: Verify Admin desktop archive
         shell: pwsh
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $version = $env:GITHUB_REF_NAME -replace '^v', ''
+          $version = $env:RELEASE_TAG -replace '^v', ''
           $archiveName = "csharpdb-admin-desktop-v$version-win-x64.zip"
           $archivePath = Join-Path 'artifacts/admin-release/archives' $archiveName
           $checksumPath = 'artifacts/admin-release/archives/ADMIN-SHA256SUMS.txt'
@@ -579,6 +694,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_commit }}
 
       - name: Download NuGet artifacts
         uses: actions/download-artifact@v8
@@ -627,6 +745,19 @@ jobs:
           cd artifacts/migration
           sha256sum csharpdb-migration-tool-v* > MIGRATION-SHA256SUMS.txt
 
+      - name: Revalidate the immutable release target
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $resolved = & gh api "repos/$env:GITHUB_REPOSITORY/commits/$env:RELEASE_TAG" --jq .sha
+          if ($LASTEXITCODE -ne 0 -or $resolved.Trim() -cne $env:RELEASE_COMMIT) {
+            throw "$env:RELEASE_TAG no longer resolves to $env:RELEASE_COMMIT."
+          }
+
       - name: Resolve release notes
         id: notes
         shell: bash
@@ -652,12 +783,38 @@ jobs:
             echo "has_notes=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Require the immutable target and absent release before creation
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $resolved = & gh api "repos/$env:GITHUB_REPOSITORY/commits/$env:RELEASE_TAG" --jq .sha
+          if ($LASTEXITCODE -ne 0 -or $resolved.Trim() -cne $env:RELEASE_COMMIT) {
+            throw "$env:RELEASE_TAG no longer resolves to $env:RELEASE_COMMIT."
+          }
+
+          $releaseTags = @(
+            & gh api --paginate "repos/$env:GITHUB_REPOSITORY/releases" --jq '.[].tag_name'
+          )
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not check for an existing $env:RELEASE_TAG GitHub Release."
+          }
+          if ($releaseTags -ccontains $env:RELEASE_TAG) {
+            throw "A $env:RELEASE_TAG GitHub Release already exists; recovery will not update it."
+          }
+
       - name: Create release (custom notes)
         if: steps.notes.outputs.has_notes == 'true'
         uses: softprops/action-gh-release@v2
         with:
           name: CSharpDB v${{ needs.publish-nuget.outputs.version }}
           body_path: ${{ steps.notes.outputs.path }}
+          tag_name: ${{ inputs.release_tag }}
+          target_commitish: ${{ inputs.release_commit }}
           files: |
             artifacts/nuget/*.nupkg
             artifacts/native/*
@@ -671,6 +828,8 @@ jobs:
         with:
           name: CSharpDB v${{ needs.publish-nuget.outputs.version }}
           generate_release_notes: true
+          tag_name: ${{ inputs.release_tag }}
+          target_commitish: ${{ inputs.release_commit }}
           files: |
             artifacts/nuget/*.nupkg
             artifacts/native/*

--- a/.github/workflows/sql-release-qualification.yml
+++ b/.github/workflows/sql-release-qualification.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           clean: true
           fetch-depth: 0
+          ref: ${{ inputs.release_commit || github.sha }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -81,7 +82,7 @@ jobs:
       - name: Run SQL release qualification
         shell: pwsh
         env:
-          QUALIFICATION_OUTPUT: ${{ runner.temp }}/csharpdb-sql-release-qualification/${{ github.sha }}/${{ matrix.os }}/pass-${{ matrix.qualification_pass }}
+          QUALIFICATION_OUTPUT: ${{ runner.temp }}/csharpdb-sql-release-qualification/${{ inputs.release_commit || github.sha }}/${{ matrix.os }}/pass-${{ matrix.qualification_pass }}
           RELEASE_VERSION: ${{ inputs.release_version }}
           RELEASE_COMMIT: ${{ inputs.release_commit }}
         run: |
@@ -96,8 +97,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: sql-release-qualification-${{ github.sha }}-${{ matrix.os }}-pass-${{ matrix.qualification_pass }}
-          path: ${{ runner.temp }}/csharpdb-sql-release-qualification/${{ github.sha }}/${{ matrix.os }}/pass-${{ matrix.qualification_pass }}/evidence
+          name: sql-release-qualification-${{ inputs.release_commit || github.sha }}-${{ matrix.os }}-pass-${{ matrix.qualification_pass }}
+          path: ${{ runner.temp }}/csharpdb-sql-release-qualification/${{ inputs.release_commit || github.sha }}/${{ matrix.os }}/pass-${{ matrix.qualification_pass }}/evidence
           if-no-files-found: warn
           retention-days: 14
 
@@ -119,6 +120,7 @@ jobs:
         with:
           clean: true
           fetch-depth: 0
+          ref: ${{ inputs.release_commit || github.sha }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -150,7 +152,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: previous-release-hosted-stable-performance-${{ github.sha }}-pass-${{ matrix.qualification_pass }}-attempt-${{ github.run_attempt }}
+          name: previous-release-hosted-stable-performance-${{ inputs.release_commit || github.sha }}-pass-${{ matrix.qualification_pass }}-attempt-${{ github.run_attempt }}
           path: |
             ${{ runner.temp }}/cdb-perf/stable/p${{ matrix.qualification_pass }}/previous-release-performance-preflight.md
             ${{ runner.temp }}/cdb-perf/stable/p${{ matrix.qualification_pass }}/previous-release-performance.md

--- a/tests/CSharpDB.Cli.Tests/MigrationReleasePackagingTests.cs
+++ b/tests/CSharpDB.Cli.Tests/MigrationReleasePackagingTests.cs
@@ -288,7 +288,7 @@ public sealed class MigrationReleasePackagingTests
             workflow,
             StringComparison.Ordinal);
         Assert.Contains(
-            "RELEASE_TAG: ${{ github.ref_name }}",
+            "RELEASE_TAG: ${{ inputs.release_tag }}",
             workflow,
             StringComparison.Ordinal);
         Assert.Contains(

--- a/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
@@ -75,8 +75,10 @@ public sealed class DaemonPackagingAssetsTests
 
         Assert.Contains("name: Release\n", trigger);
         Assert.Contains("      - \"v*\"", trigger);
+        Assert.Contains("workflow_dispatch:", trigger);
         Assert.Contains("uses: ./.github/workflows/release.yml", trigger);
-        Assert.Contains("secrets: inherit", trigger);
+        Assert.Contains("NUGET_USER: ${{ secrets.NUGET_USER }}", trigger);
+        Assert.DoesNotContain("secrets: inherit", trigger);
         Assert.Contains("contents: write", trigger);
         Assert.Contains("statuses: read", trigger);
         Assert.Contains("id-token: write", trigger);
@@ -114,6 +116,17 @@ public sealed class DaemonPackagingAssetsTests
             normalized);
         Assert.Contains("Test-SqlReleaseQualification.ps1", normalized);
         Assert.Contains("${{ runner.temp }}", normalized);
+        Assert.Equal(
+            2,
+            System.Text.RegularExpressions.Regex.Matches(
+                normalized,
+                @"(?m)^          ref: \$\{\{ inputs\.release_commit \|\| github\.sha \}\}$").Count);
+        Assert.Contains(
+            "sql-release-qualification-${{ inputs.release_commit || github.sha }}",
+            normalized);
+        Assert.Contains(
+            "previous-release-hosted-stable-performance-${{ inputs.release_commit || github.sha }}",
+            normalized);
         Assert.DoesNotContain(
             "    env:\n      QUALIFICATION_OUTPUT: ${{ runner.temp }}",
             normalized);
@@ -249,12 +262,14 @@ public sealed class DaemonPackagingAssetsTests
             "uses: ./.github/workflows/sql-release-qualification.yml",
             normalized);
         Assert.Contains(
-            "release_version: ${{ github.ref_name }}",
+            "release_version: ${{ inputs.release_tag }}",
             normalized);
         Assert.Contains(
-            "release_commit: ${{ github.sha }}",
+            "release_commit: ${{ inputs.release_commit }}",
             normalized);
-        Assert.DoesNotContain("previous_release_ref:", normalized);
+        Assert.Contains(
+            "previous_release_ref: ${{ inputs.waive_local_durable_for_v450 && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}",
+            normalized);
         Assert.Contains("verify-local-durable-performance:", normalized);
         Assert.Contains("statuses: read", normalized);
         Assert.Contains("LOCAL_DURABLE_ATTESTOR", normalized);
@@ -264,9 +279,18 @@ public sealed class DaemonPackagingAssetsTests
         Assert.Contains(
             "./scripts/Test-LocalDurableStatus.ps1",
             normalized);
-        Assert.Contains("-Commit '${{ github.sha }}'", normalized);
+        Assert.Contains("if: ${{ !inputs.waive_local_durable_for_v450 }}", normalized);
+        Assert.Contains("-Commit '${{ inputs.release_commit }}'", normalized);
+        Assert.Contains("-ReleaseVersion '${{ inputs.release_tag }}'", normalized);
         Assert.Contains("-GitHubRepository '${{ github.repository }}'", normalized);
         Assert.Contains("-ExpectedCreator $env:EXPECTED_STATUS_CREATOR", normalized);
+        Assert.DoesNotContain("github.ref_name", normalized);
+        Assert.DoesNotContain("github.sha", normalized);
+        Assert.Equal(
+            7,
+            System.Text.RegularExpressions.Regex.Matches(
+                normalized,
+                @"(?m)^          ref: \$\{\{ inputs\.release_commit \}\}$").Count);
         Assert.Equal(
             5,
             System.Text.RegularExpressions.Regex.Matches(
@@ -276,6 +300,76 @@ public sealed class DaemonPackagingAssetsTests
             System.Text.RegularExpressions.Regex.Matches(
                 normalized,
                 @"(?m)^    needs: verify-local-durable-performance$"));
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_OneTimeV450RecoveryIsPinnedAndCannotBecomeGeneralWaiver()
+    {
+        string repoRoot = FindRepoRoot();
+        string trigger = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "publish-release.yml")).ReplaceLineEndings("\n");
+        string implementation = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "release.yml")).ReplaceLineEndings("\n");
+
+        const string releaseTag = "v4.5.0";
+        const string releaseCommit = "7aeb66031237283c3643e73849618bf299729ed6";
+        const string baselineCommit = "86e25435f3c64f47afe2a776c6b03cbe84e56858";
+
+        int dispatchStart = trigger.IndexOf("  workflow_dispatch:\n", StringComparison.Ordinal);
+        int concurrencyStart = trigger.IndexOf("\nconcurrency:\n", StringComparison.Ordinal);
+        Assert.True(dispatchStart >= 0 && concurrencyStart > dispatchStart);
+        string dispatchInputs = trigger[dispatchStart..concurrencyStart];
+
+        Assert.Contains("approve_v4_5_0_local_durable_waiver:", dispatchInputs);
+        Assert.Contains("type: boolean", dispatchInputs);
+        Assert.Contains("default: false", dispatchInputs);
+        Assert.DoesNotContain("release_tag:", dispatchInputs);
+        Assert.DoesNotContain("release_commit:", dispatchInputs);
+
+        Assert.Contains("refs/heads/main", trigger);
+        Assert.Contains("MaxAkbar/CSharpDB/.github/workflows/publish-release.yml@refs/heads/main", trigger);
+        Assert.Contains("ACTOR_ID: ${{ github.actor_id }}", trigger);
+        Assert.Contains("$expectedActorId = '13856299'", trigger);
+        Assert.Contains("$expectedTag = 'v4.5.0'", trigger);
+        Assert.Contains($"$expectedCommit = '{releaseCommit}'", trigger);
+        Assert.Contains("$expectedStatusId = 51899579502L", trigger);
+        Assert.Contains("$expectedStatusTime = '2026-08-09T06:02:33Z'", trigger);
+        Assert.Contains("$expectedStatusDescription = 'policy=durable-v3; design=6B500421; local durable qualification failed'", trigger);
+        Assert.Contains("$expectedCiRunId = 31260517686L", trigger);
+        Assert.Contains("environment: v4-5-0-recovery", trigger);
+        Assert.Contains("waive_local_durable_for_v450: false", trigger);
+        Assert.Contains("waive_local_durable_for_v450: true", trigger);
+        Assert.Contains($"release_tag: {releaseTag}", trigger);
+        Assert.Contains($"release_commit: {releaseCommit}", trigger);
+        Assert.Contains("release-${{ github.event_name == 'workflow_dispatch' && 'refs/tags/v4.5.0' || github.ref }}", trigger);
+        Assert.DoesNotContain("statuses: write", trigger);
+        Assert.DoesNotContain("secrets: inherit", trigger);
+
+        Assert.Contains("if: ${{ inputs.waive_local_durable_for_v450 }}", implementation);
+        Assert.Contains($"$env:RELEASE_TAG -cne '{releaseTag}'", implementation);
+        Assert.Contains($"$env:RELEASE_COMMIT -cne '{releaseCommit}'", implementation);
+        Assert.Contains(baselineCommit, implementation);
+        Assert.Contains("- name: Revalidate the immutable publication target", implementation);
+        Assert.Contains("- name: Require the immutable target and absent release before creation", implementation);
+        Assert.Contains("packages will not be published", implementation);
+        Assert.DoesNotContain("Publish-DurableCarryForwardStatus.ps1", implementation);
+        Assert.DoesNotContain("statuses: write", implementation);
+        Assert.Equal(
+            2,
+            System.Text.RegularExpressions.Regex.Matches(
+                implementation,
+                @"(?m)^          tag_name: \$\{\{ inputs\.release_tag \}\}$").Count);
+        Assert.Equal(
+            2,
+            System.Text.RegularExpressions.Regex.Matches(
+                implementation,
+                @"(?m)^          target_commitish: \$\{\{ inputs\.release_commit \}\}$").Count);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds a one-time, owner-approved recovery lane for the immutable `v4.5.0` release after repeated local durable-v3 attempts were invalidated by environmental contamination.

The manual lane is hard-pinned to tag `v4.5.0`, commit `7aeb66031237283c3643e73849618bf299729ed6`, baseline `v4.4.0`, the preserved failed local status, and the successful exact-commit CI run. It never creates a synthetic success status. Every hosted functional, cross-platform, package, archive, and stable-performance qualification remains blocking before publication.

The reusable release workflow now accepts explicit release identity inputs, checks out the immutable commit in every job, uses the explicit tag for every versioned artifact, and revalidates the remote tag and release absence immediately before NuGet and GitHub Release publication.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

Relates to failed release run [31263630562](https://github.com/MaxAkbar/CSharpDB/actions/runs/31263630562).

## Testing

- [x] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (canonical status verifier and pinned waiver policy assertions)
- [x] Manual verification performed (checksum-verified `actionlint` plus live read-only authorization/publication guards)

Additional validation:

- 30/30 `DaemonPackagingAssetsTests` and `ReleaseStatusScriptTests`
- 1/1 focused migration release packaging test
- NuGet package-closure validation
- Documentation validation
- PowerShell AST parsing for changed workflow blocks
- `git diff --check`

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes. (Not applicable: this is an internal one-time release recovery.)
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- The waiver cannot target another tag, commit, repository, workflow, branch, actor, status, or CI run.
- Status permissions remain read-only; the failed durable-v3 evidence is preserved.
- `NUGET_USER` is passed explicitly instead of inheriting all repository secrets.
- The approval environment is deliberately separate from the NuGet job so the existing Trusted Publishing OIDC identity is unchanged.
- Before dispatch, create and protect the `v4-5-0-recovery` environment with required reviewer `MaxAkbar`, self-review allowed, admin bypass disabled, and a main-only deployment policy.
- Before dispatch, confirm nuget.org Trusted Publishing is configured for owner `MaxAkbar`, repository `CSharpDB`, workflow `publish-release.yml`, and no environment.
- After successful publication and verification, remove the one-time dispatch lane and recovery environment in a follow-up change.
