### PR TITLE
Fix batch insert regression and prepare v4.5.1

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,16 +4,9 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
-    inputs:
-      approve_v4_5_0_local_durable_waiver:
-        description: Approve the one-time v4.5.0 local durable performance waiver
-        required: true
-        default: false
-        type: boolean
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && 'refs/tags/v4.5.0' || github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -21,7 +14,6 @@ permissions:
 
 jobs:
   publish-tag:
-    if: github.event_name == 'push'
     name: Publish exact release tag
     permissions:
       contents: write
@@ -31,150 +23,5 @@ jobs:
     with:
       release_tag: ${{ github.ref_name }}
       release_commit: ${{ github.sha }}
-      waive_local_durable_for_v450: false
-    secrets:
-      NUGET_USER: ${{ secrets.NUGET_USER }}
-
-  validate-v4-5-0-recovery:
-    if: github.event_name == 'workflow_dispatch'
-    name: Validate one-time v4.5.0 recovery
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      statuses: read
-
-    steps:
-      - name: Require the exact approved recovery request and evidence
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          APPROVED: ${{ inputs.approve_v4_5_0_local_durable_waiver }}
-          ACTOR_ID: ${{ github.actor_id }}
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-
-          $expectedRepository = 'MaxAkbar/CSharpDB'
-          $expectedActor = 'MaxAkbar'
-          $expectedActorId = '13856299'
-          $expectedWorkflowRef = 'MaxAkbar/CSharpDB/.github/workflows/publish-release.yml@refs/heads/main'
-          $expectedTag = 'v4.5.0'
-          $expectedCommit = '7aeb66031237283c3643e73849618bf299729ed6'
-          $expectedStatusId = 51899579502L
-          $expectedStatusTime = '2026-08-09T06:02:33Z'
-          $expectedStatusDescription = 'policy=durable-v3; design=6B500421; local durable qualification failed'
-          $expectedCiRunId = 31260517686L
-
-          if ($env:APPROVED -cne 'true') {
-            throw 'The one-time v4.5.0 local durable waiver was not explicitly approved.'
-          }
-          if ($env:GITHUB_REPOSITORY -cne $expectedRepository) {
-            throw "Recovery is pinned to $expectedRepository."
-          }
-          if ($env:GITHUB_EVENT_NAME -cne 'workflow_dispatch') {
-            throw 'Recovery must be started through workflow_dispatch.'
-          }
-          if ($env:GITHUB_REF -cne 'refs/heads/main') {
-            throw 'Recovery must be dispatched from refs/heads/main.'
-          }
-          if ($env:WORKFLOW_REF -cne $expectedWorkflowRef) {
-            throw "Unexpected workflow identity: $env:WORKFLOW_REF"
-          }
-          if ($env:GITHUB_ACTOR -cne $expectedActor -or
-              $env:TRIGGERING_ACTOR -cne $expectedActor -or
-              $env:ACTOR_ID -cne $expectedActorId) {
-            throw 'Recovery must be started and triggered by the pinned repository owner.'
-          }
-
-          $tagRefJson = & gh api "repos/$expectedRepository/git/ref/tags/$expectedTag"
-          if ($LASTEXITCODE -ne 0) {
-            throw "Could not resolve the immutable $expectedTag tag."
-          }
-          $tagRef = $tagRefJson | ConvertFrom-Json
-          if ($tagRef.object.type -cne 'commit' -or $tagRef.object.sha -cne $expectedCommit) {
-            throw "$expectedTag is not the expected lightweight tag at $expectedCommit."
-          }
-
-          $statusesJson = & gh api "repos/$expectedRepository/commits/$expectedCommit/statuses"
-          if ($LASTEXITCODE -ne 0) {
-            throw 'Could not read the preserved local durable status evidence.'
-          }
-          $latestStatus = @(
-            $statusesJson |
-              ConvertFrom-Json |
-              Where-Object context -CEQ 'csharpdb/local-durable-performance'
-          ) | Select-Object -First 1
-          $latestStatusTime = if ($null -eq $latestStatus) {
-            $null
-          }
-          else {
-            ([DateTimeOffset]$latestStatus.created_at).ToUniversalTime().ToString(
-              'yyyy-MM-ddTHH:mm:ssZ',
-              [Globalization.CultureInfo]::InvariantCulture)
-          }
-          if ($null -eq $latestStatus -or
-              [long]$latestStatus.id -ne $expectedStatusId -or
-              $latestStatus.state -cne 'failure' -or
-              $latestStatus.creator.login -cne $expectedActor -or
-              $latestStatusTime -cne $expectedStatusTime -or
-              $latestStatus.description -cne $expectedStatusDescription) {
-            throw 'The newest local durable status is not the exact preserved v4.5.0 failure being waived.'
-          }
-
-          $ciRunJson = & gh api "repos/$expectedRepository/actions/runs/$expectedCiRunId"
-          if ($LASTEXITCODE -ne 0) {
-            throw 'Could not read the pinned exact-commit CI evidence.'
-          }
-          $ciRun = $ciRunJson | ConvertFrom-Json
-          if ([long]$ciRun.id -ne $expectedCiRunId -or
-              $ciRun.path -cne '.github/workflows/ci.yml' -or
-              $ciRun.event -cne 'push' -or
-              $ciRun.head_sha -cne $expectedCommit -or
-              $ciRun.status -cne 'completed' -or
-              $ciRun.conclusion -cne 'success' -or
-              $ciRun.actor.login -cne $expectedActor) {
-            throw 'The pinned exact-commit CI run is not the expected successful qualification.'
-          }
-
-          $releaseIds = @(
-            & gh api --paginate "repos/$expectedRepository/releases" --jq '.[] | select(.tag_name == "v4.5.0") | .id'
-          )
-          if ($LASTEXITCODE -ne 0) {
-            throw 'Could not check for an existing v4.5.0 GitHub Release.'
-          }
-          if ($releaseIds.Count -ne 0) {
-            throw 'A v4.5.0 GitHub Release already exists; recovery will not update it.'
-          }
-
-          Write-Host '::notice title=Recovery evidence verified::The exact failed local qualification and successful exact-commit CI run are preserved. No success status will be created.'
-
-  approve-v4-5-0-recovery:
-    if: github.event_name == 'workflow_dispatch'
-    name: Approve one-time v4.5.0 recovery
-    needs: validate-v4-5-0-recovery
-    runs-on: ubuntu-latest
-    environment: v4-5-0-recovery
-    permissions:
-      contents: read
-
-    steps:
-      - name: Record protected environment approval
-        run: echo "Protected approval granted for the exact v4.5.0 recovery."
-
-  recover-v4-5-0:
-    if: github.event_name == 'workflow_dispatch'
-    name: Recover exact v4.5.0 release
-    needs: approve-v4-5-0-recovery
-    permissions:
-      contents: write
-      statuses: read
-      id-token: write
-    uses: ./.github/workflows/release.yml
-    with:
-      release_tag: v4.5.0
-      release_commit: 7aeb66031237283c3643e73849618bf299729ed6
-      waive_local_durable_for_v450: true
     secrets:
       NUGET_USER: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,6 @@ on:
         description: Exact commit targeted by release_tag
         required: true
         type: string
-      waive_local_durable_for_v450:
-        description: One-time owner-approved waiver pinned to the failed v4.5.0 qualification
-        required: false
-        default: false
-        type: boolean
     secrets:
       NUGET_USER:
         description: NuGet profile name used by Trusted Publishing
@@ -26,7 +21,7 @@ permissions:
 
 jobs:
   verify-local-durable-performance:
-    name: Verify local durable performance qualification or approved recovery
+    name: Verify local durable performance qualification
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,32 +59,7 @@ jobs:
             throw "$env:RELEASE_TAG does not resolve to $env:RELEASE_COMMIT."
           }
 
-      - name: Record the approved one-time v4.5.0 waiver
-        if: ${{ inputs.waive_local_durable_for_v450 }}
-        shell: pwsh
-        env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          RELEASE_COMMIT: ${{ inputs.release_commit }}
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-
-          if ($env:GITHUB_REPOSITORY -cne 'MaxAkbar/CSharpDB' -or
-              $env:GITHUB_EVENT_NAME -cne 'workflow_dispatch' -or
-              $env:GITHUB_REF -cne 'refs/heads/main' -or
-              $env:WORKFLOW_REF -cne 'MaxAkbar/CSharpDB/.github/workflows/publish-release.yml@refs/heads/main' -or
-              $env:GITHUB_ACTOR -cne 'MaxAkbar' -or
-              $env:TRIGGERING_ACTOR -cne 'MaxAkbar' -or
-              $env:RELEASE_TAG -cne 'v4.5.0' -or
-              $env:RELEASE_COMMIT -cne '7aeb66031237283c3643e73849618bf299729ed6') {
-            throw 'The local durable waiver is valid only for the exact owner-dispatched v4.5.0 recovery.'
-          }
-
-          Write-Host '::warning title=Explicit v4.5.0 recovery waiver::The failed local durable-v3 evidence is preserved. Hosted qualification remains blocking, and no success status is being fabricated.'
-
       - name: Require a successful matching-commit local performance status
-        if: ${{ !inputs.waive_local_durable_for_v450 }}
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
@@ -108,7 +78,9 @@ jobs:
     with:
       release_version: ${{ inputs.release_tag }}
       release_commit: ${{ inputs.release_commit }}
-      previous_release_ref: ${{ inputs.waive_local_durable_for_v450 && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}
+      # v4.5.0 was tagged but never published, so v4.5.1 must measure the
+      # cumulative public delta from the last published release, v4.4.0.
+      previous_release_ref: ${{ inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}
 
   publish-nuget:
     name: Publish NuGet
@@ -804,7 +776,7 @@ jobs:
             throw "Could not check for an existing $env:RELEASE_TAG GitHub Release."
           }
           if ($releaseTags -ccontains $env:RELEASE_TAG) {
-            throw "A $env:RELEASE_TAG GitHub Release already exists; recovery will not update it."
+            throw "A $env:RELEASE_TAG GitHub Release already exists; publication will not update it."
           }
 
       - name: Create release (custom notes)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,23 @@
 # What's New
 
-## CSharpDB 4.5.0
+## CSharpDB 4.5.1
 
-CSharpDB 4.5.0 adds a persisted logical SQL type system across the engine,
+CSharpDB 4.5.1 is the first published release in the 4.5 line. The `v4.5.0`
+Git tag is retained as release-attempt history, but it was not published as a
+release. These notes therefore preserve the complete public change from
+v4.4.0 to v4.5.1.
+
+This release adds a persisted logical SQL type system across the engine,
 providers, transports, migration tooling, archives, and public metadata. It
 also adds bounded XPath 1.0 querying for XML values. Declared types, coercion,
 materialization, and schema rendering now follow one contract end to end.
+
+### Batch Insert Performance
+
+- Removed an avoidable per-value allocation from successful declared-type
+  assignment coercion. Qualified type-mismatch diagnostics are now formatted
+  only on failure, preserving the same error messages and SQL semantics while
+  improving in-memory SQL batch-insert throughput.
 
 ### Complete SQL Type System
 
@@ -68,7 +80,7 @@ in the [SQL datatype reference](https://csharpdb.com/docs/sql-reference.html#dat
   are rejected, and document depth and XPath length are limited.
 - The supported surface is the documented function-style API. Standard
   `XMLEXISTS(... PASSING ...)`, `XML_TABLE`, and XML path indexes are not part
-  of 4.5.0.
+  of 4.5.1.
 
 ### Providers, Migration, and Interchange
 
@@ -80,8 +92,9 @@ in the [SQL datatype reference](https://csharpdb.com/docs/sql-reference.html#dat
 - Added explicit SQL Server migration mappings for integer widths, `bit`,
   temporal types, and `timestamp`/`rowversion`. Migration plans now preserve
   the logical target SQL declaration separately from its physical carrier.
-- Added a separately digested 4.5.0 migration capability catalog while
-  retaining the immutable 4.4.0 and 4.3.0 catalogs for deterministic replay.
+- Added a separately digested current `4.5.1` migration capability catalog
+  while retaining the immutable 4.5.0, 4.4.0, and 4.3.0 catalogs for
+  deterministic replay.
 - Native table archive format v8 records the final 4.5 integer semantics and
   preserves every logical facet. CSV/JSON migration manifests and streaming
   exports retain exact decimals and logical target declarations.

--- a/docs/releases/v4.5.1-pr-notes.md
+++ b/docs/releases/v4.5.1-pr-notes.md
@@ -1,0 +1,117 @@
+## Summary
+
+Prepare CSharpDB 4.5.1 as the first published release in the 4.5 line. The
+`v4.5.0` Git tag is retained as release-attempt history, but it was not
+published as a release.
+
+### Pull-request delta: current main to v4.5.1
+
+- Remove the successful-path allocation of qualified diagnostic text from SQL
+  assignment coercion. Failure paths retain the same error code, inner
+  exception, and qualified or unqualified message.
+- Add focused allocation and diagnostic-message regression coverage alongside
+  the existing integer range and identity semantics coverage.
+- Add the separately digested current `4.5.1` migration capability catalog
+  while retaining the immutable 4.5.0, 4.4.0, and 4.3.0 catalogs for
+  deterministic replay.
+- Update release metadata and documentation for a new v4.5.1 tag, and remove
+  the retired one-time v4.5.0 recovery dispatch and qualification waiver. The
+  v4.5.0 tag is not moved or recreated.
+- Serialize test-project execution inside the release qualification so
+  process-heavy suites do not contend with one another. No test, assertion,
+  timeout, or platform lane is skipped or weakened.
+
+### Tagged-code delta: v4.5.0 to v4.5.1
+
+- Include the focused coercion-performance fix, tests, and release preparation
+  described above.
+- Add generic exact tag/commit checks, fail-closed secret and qualification
+  handling, package-authentication safeguards, and partial-publication retry
+  guards that were introduced after the v4.5.0 tag and are carried forward
+  without the interim release-specific recovery path.
+
+### Public delta: v4.4.0 to v4.5.1
+
+Because v4.5.0 was never published, the public release delta includes the full
+4.5 feature set. It adds 25 persisted logical SQL type kinds plus generated
+`ROWVERSION`, exact `DECIMAL`, declared facets, 32-bit `INTEGER` semantics,
+Booleans, bit strings, UUID, temporal and interval types, JSON, XML, and
+canonical type metadata across the engine, providers, transports, archives,
+and migration tooling.
+
+Bare `TIMESTAMP` now aliases the generated database-wide `ROWVERSION` token;
+offset-free temporal values use `DATETIME2` and offset-aware values use
+`DATETIMEOFFSET`. The release also adds bounded `XML_EXISTS`/`XMLEXISTS` and
+`XML_VALUE` XPath 1.0 querying with secure parsing and explicit resource
+limits. Compatibility handling preserves legacy descriptor-less integer data
+as `BIGINT` and upgrades legacy rowversion allocation safely.
+
+## Type of Change
+
+- [x] Bug fix
+- [x] New feature
+- [x] Breaking change
+- [x] Documentation update
+- [x] Refactor / maintenance
+- [ ] Tests only
+
+## Related Issues
+
+None linked.
+
+## Testing
+
+Local validation is complete for the batch-insert regression fix and release
+preparation. Hosted release qualification is not claimed yet.
+
+- [x] `dotnet build CSharpDB.slnx`
+- [x] Relevant tests executed
+- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
+- [x] Manual verification performed (if applicable)
+
+Focused evidence:
+
+- Both paired performance passes used exact v4.4.0 commit
+  `86e25435f3c64f47afe2a776c6b03cbe84e56858` as the previous-release baseline
+  and exact candidate commit `b2ba3971115bf2b69fe1989ce9a6617fa173196e`
+  for scenario `Storage_InMemory_Sql_Batch100_5s`.
+- SQL type-coercion and integer-semantics tests passed: **7/7 passed**.
+  Coverage includes the allocation-free success path, exact qualified and
+  unqualified failure messages, integer ranges, arithmetic, and identity
+  exhaustion.
+- Paired performance pass 1: **PASS**, with a combined throughput regression
+  of **6.77%** and order-stratum effects of **5.43% / 8.08%**.
+- Paired performance pass 2: **PASS**, with a combined throughput regression
+  of **4.81%** and order-stratum effects of **5.59% / 4.02%**.
+- Both performance passes reported **0 invalid**, **0 unstable**,
+  **0 order-sensitive**, and **0 regression** rows.
+- Public documentation validation passed with
+  `./scripts/Test-Documentation.ps1`.
+- The Release solution build passed with **0 warnings** and **0 errors**.
+- The serialized full solution matrix passed across 24 test projects:
+  **6,023 passed**, **4 expected live/opt-in skips**, and **0 failed**.
+- Final hosted release qualification remains pending and must pass before
+  release.
+
+## Checklist
+
+- [x] I followed the project style and conventions.
+- [x] I added or updated tests for behavior changes.
+- [x] I covered both success and failure paths for changed behavior.
+- [x] I updated docs for user-facing changes.
+- [x] I verified no sensitive data was added.
+
+## Notes for Reviewers
+
+- Review the branch-level fix separately from the public release contents. The
+  code change after current main is intentionally narrow; the public
+  v4.4.0-to-v4.5.1 delta includes all previously prepared 4.5 SQL type and XML
+  functionality because v4.5.0 was not published.
+- The performance fix only defers construction of assignment-error context
+  until an error occurs. It does not bypass declared-type coercion, integer
+  range validation, or primary-key validation.
+- The `4.5.1` migration capability catalog is current. The immutable `4.5.0`
+  catalog is retained only as deterministic replay history; its presence does
+  not indicate that a v4.5.0 release was published.
+- Do not move or recreate the v4.5.0 tag. Publish v4.5.1 from its own exact tag
+  only after the remaining full validation succeeds.

--- a/scripts/Publish-CSharpDbMigrationRelease.ps1
+++ b/scripts/Publish-CSharpDbMigrationRelease.ps1
@@ -56,7 +56,7 @@ $Version = (Read-Host 'Release version without the v prefix').Trim()
 #>
 [CmdletBinding()]
 param(
-    [string] $Version = '4.5.0',
+    [string] $Version = '4.5.1',
 
     [ValidateSet('win-x64', 'linux-x64', 'osx-arm64')]
     [string[]] $Runtime = @(

--- a/scripts/Test-SqlReleaseQualification.ps1
+++ b/scripts/Test-SqlReleaseQualification.ps1
@@ -240,6 +240,7 @@ try {
             $Configuration,
             '--no-build',
             '--no-restore',
+            '--maxcpucount:1',
             '--verbosity',
             'minimal',
             '--logger',

--- a/src/CSharpDB.Execution/SqlTypeCoercion.cs
+++ b/src/CSharpDB.Execution/SqlTypeCoercion.cs
@@ -21,10 +21,6 @@ internal static class SqlTypeCoercion
         string? tableName = null)
     {
         ArgumentNullException.ThrowIfNull(column);
-        string target = tableName is null
-            ? $"column '{column.Name}'"
-            : $"column '{tableName}.{column.Name}'";
-
         if (value.IsNull)
             return value;
 
@@ -47,6 +43,9 @@ internal static class SqlTypeCoercion
             OverflowException or
             JsonException)
         {
+            string target = tableName is null
+                ? $"column '{column.Name}'"
+                : $"column '{tableName}.{column.Name}'";
             throw new CSharpDbException(
                 ErrorCode.TypeMismatch,
                 $"Value of type {value.Type} is not valid for {target} declared as {column.EffectiveType.ToSql()}: {ex.Message}",

--- a/src/CSharpDB.Migration/CSharpDB.Migration.csproj
+++ b/src/CSharpDB.Migration/CSharpDB.Migration.csproj
@@ -30,6 +30,8 @@
                       LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.4.0.json" />
     <EmbeddedResource Include="Capabilities\csharpdb-4.5.0.json"
                       LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.5.0.json" />
+    <EmbeddedResource Include="Capabilities\csharpdb-4.5.1.json"
+                      LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.5.1.json" />
   </ItemGroup>
 
 </Project>

--- a/src/CSharpDB.Migration/CSharpDbCapabilityCatalog.cs
+++ b/src/CSharpDB.Migration/CSharpDbCapabilityCatalog.cs
@@ -102,7 +102,7 @@ public sealed record CSharpDbCapabilityCatalog
 
 public static class CSharpDbCapabilityCatalogLoader
 {
-    public const string CurrentTargetVersion = "4.5.0";
+    public const string CurrentTargetVersion = "4.5.1";
     public const string Format = "csharpdb-target-capabilities/v1";
 
     private static readonly JsonSerializerOptions s_options = CreateOptions();
@@ -111,6 +111,7 @@ public static class CSharpDbCapabilityCatalogLoader
         {
             ["4.3.0"] = CreateCatalog("4.3.0"),
             ["4.4.0"] = CreateCatalog("4.4.0"),
+            ["4.5.0"] = CreateCatalog("4.5.0"),
             [CurrentTargetVersion] = CreateCatalog(CurrentTargetVersion),
         };
 

--- a/src/CSharpDB.Migration/Capabilities/csharpdb-4.5.1.json
+++ b/src/CSharpDB.Migration/Capabilities/csharpdb-4.5.1.json
@@ -1,0 +1,376 @@
+{
+  "format": "csharpdb-target-capabilities/v1",
+  "targetCSharpDbVersion": "4.5.1",
+  "surface": "local-typed-engine",
+  "maxIdentifierLength": 128,
+  "identifiersCaseInsensitive": true,
+  "quotedIdentifiers": true,
+  "engineEnforcesMappedColumnType": true,
+  "valueTypes": [
+    {
+      "type": "null",
+      "isRuntimeValue": true,
+      "isColumnType": false,
+      "representation": "Runtime null tag; not a declarable persistent SQL column type."
+    },
+    {
+      "type": "integer",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Shared signed 64-bit physical carrier. Logical INTEGER is signed 32-bit, BIGINT is signed 64-bit, and BOOLEAN is canonical 0/1."
+    },
+    {
+      "type": "real",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "IEEE 754 binary64 floating-point value."
+    },
+    {
+      "type": "text",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Persisted UTF-8 text."
+    },
+    {
+      "type": "blob",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Raw byte sequence."
+    },
+    {
+      "type": "decimal",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Exact base-10 decimal with an Int64 coefficient and scale up to 18 digits of precision."
+    }
+  ],
+  "rules": [
+    {
+      "ruleId": "CSDB-OBJ-DATABASE-001",
+      "objectKind": "database",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "A migration target is one local CSharpDB database."
+    },
+    {
+      "ruleId": "CSDB-OBJ-NAMESPACE-001",
+      "objectKind": "namespace",
+      "feature": "object",
+      "status": "compatibleWithRewrite",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "CSharpDB has no source-style namespace catalog; names must be flattened deterministically."
+    },
+    {
+      "ruleId": "CSDB-OBJ-TABLE-001",
+      "objectKind": "table",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Typed SQL tables are supported."
+    },
+    {
+      "ruleId": "CSDB-OBJ-COLLECTION-001",
+      "objectKind": "collection",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-COLLECTION",
+      "notes": "Collections use the collection API and serialized document storage rather than SQL DDL."
+    },
+    {
+      "ruleId": "CSDB-OBJ-COLUMN-001",
+      "objectKind": "column",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Persistent columns retain a logical SQL type descriptor over INTEGER, REAL, TEXT, BLOB, or DECIMAL storage."
+    },
+    {
+      "ruleId": "CSDB-OBJ-KEY-001",
+      "objectKind": "key",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-KEYS",
+      "notes": "Primary and unique keys are supported subject to key type and collation rules."
+    },
+    {
+      "ruleId": "CSDB-OBJ-FOREIGNKEY-001",
+      "objectKind": "foreignKey",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "notes": "Single and composite immediate foreign keys are supported with bounded actions."
+    },
+    {
+      "ruleId": "CSDB-OBJ-CHECK-001",
+      "objectKind": "checkConstraint",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CHECKS",
+      "notes": "Deterministic row-local check expressions are supported."
+    },
+    {
+      "ruleId": "CSDB-OBJ-INDEX-001",
+      "objectKind": "index",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-INDEXES",
+      "notes": "Ordinary column indexes are supported subject to type restrictions."
+    },
+    {
+      "ruleId": "CSDB-OBJ-SEQUENCE-001",
+      "objectKind": "sequence",
+      "feature": "object",
+      "status": "unsupported",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "There is no standalone sequence catalog object."
+    },
+    {
+      "ruleId": "CSDB-OBJ-VIEW-001",
+      "objectKind": "view",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "A view body must parse, bind, and pass scratch execution before it is executable evidence."
+    },
+    {
+      "ruleId": "CSDB-OBJ-TRIGGER-001",
+      "objectKind": "trigger",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "Trigger timing, event, and body must be checked; WHEN is rejected with SyntaxError before catalog persistence."
+    },
+    {
+      "ruleId": "CSDB-OBJ-ROUTINE-001",
+      "objectKind": "routine",
+      "feature": "object",
+      "status": "unsupported",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Source database routines do not have a general automatic CSharpDB lowering contract."
+    },
+    {
+      "ruleId": "CSDB-OBJ-OTHER-001",
+      "objectKind": "other",
+      "feature": "object",
+      "status": "unknown",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Provider-specific objects require an explicit capability rule."
+    },
+    {
+      "ruleId": "CSDB-IDENTIFIER-001",
+      "objectKind": "database",
+      "feature": "identifier",
+      "status": "compatible",
+      "maxCount": 128,
+      "evidenceId": "EVID-IDENTIFIERS",
+      "notes": "Identifiers are quoted when rendered, limited to 128 UTF-16 code units, and compared case-insensitively by catalogs."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-TYPE-001",
+      "objectKind": "column",
+      "feature": "columnType",
+      "status": "compatible",
+      "allowedTypes": ["integer", "real", "text", "blob", "decimal"],
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Logical SQL declarations map to these persistent storage types; declared facets are retained and enforced."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-NULLABLE-001",
+      "objectKind": "column",
+      "feature": "nullable",
+      "status": "compatible",
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Nullable and NOT NULL columns are supported."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-DEFAULT-001",
+      "objectKind": "column",
+      "feature": "defaultValue",
+      "status": "conditional",
+      "allowedValues": ["null", "typed-literal"],
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Defaults must be NULL or compatible typed literals; arbitrary source expressions require analysis."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-IDENTITY-001",
+      "objectKind": "column",
+      "feature": "identity",
+      "status": "conditional",
+      "allowedTypes": ["integer"],
+      "maxCount": 1,
+      "evidenceId": "EVID-COLUMN",
+      "notes": "IDENTITY is limited to logical INTEGER or BIGINT and implies a primary key. INTEGER generation stops at 2147483647; BIGINT generation stops at 9223372036854775807."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-ROWVERSION-001",
+      "objectKind": "column",
+      "feature": "rowVersion",
+      "status": "conditional",
+      "allowedTypes": ["blob"],
+      "maxCount": 1,
+      "evidenceId": "EVID-ROWVERSION",
+      "notes": "At most one generated ROWVERSION column is permitted per table. Tokens come from a durable database-wide counter and the column cannot participate in keys, foreign keys, or indexes."
+    },
+    {
+      "ruleId": "CSDB-KEY-PRIMARY-001",
+      "objectKind": "key",
+      "feature": "primaryKey",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "evidenceId": "EVID-KEYS",
+      "notes": "Single or composite INTEGER/TEXT primary keys are supported."
+    },
+    {
+      "ruleId": "CSDB-KEY-UNIQUE-001",
+      "objectKind": "key",
+      "feature": "uniqueConstraint",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "evidenceId": "EVID-KEYS",
+      "notes": "Single or composite INTEGER/TEXT unique keys are supported; tuples containing NULL do not conflict."
+    },
+    {
+      "ruleId": "CSDB-FOREIGNKEY-001",
+      "objectKind": "foreignKey",
+      "feature": "foreignKey",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "allowedValues": [
+        "immediate",
+        "match-simple",
+        "on-delete-cascade",
+        "on-delete-no-action",
+        "on-delete-restrict",
+        "on-delete-set-null",
+        "on-delete-set-default",
+        "on-update-cascade",
+        "on-update-no-action",
+        "on-update-restrict",
+        "on-update-set-null",
+        "on-update-set-default"
+      ],
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "notes": "Child and ordered parent key types/collations must match. SET NULL requires every child column to be nullable and outside the primary key. SET DEFAULT requires a proven compatible literal default, or proven no/NULL default on a nullable non-key child column. Deferred matching remains unsupported."
+    },
+    {
+      "ruleId": "CSDB-CHECK-001",
+      "objectKind": "checkConstraint",
+      "feature": "checkConstraint",
+      "status": "conditional",
+      "allowedValues": ["deterministic", "row-local"],
+      "evidenceId": "EVID-CHECKS",
+      "notes": "Functions, subqueries, and parameters are not accepted in check expressions."
+    },
+    {
+      "ruleId": "CSDB-INDEX-001",
+      "objectKind": "index",
+      "feature": "index",
+      "status": "conditional",
+      "allowedTypes": ["integer", "real", "text"],
+      "allowedValues": ["column-only", "composite", "equality", "nonunique", "unique"],
+      "evidenceId": "EVID-INDEXES",
+      "notes": "Column-only INTEGER/TEXT/REAL equality indexes are supported. REAL components use hashed equality and do not provide ordered or range scans. BLOB/rowversion, expression, partial, included-column, and sort-direction indexes are unsupported."
+    },
+    {
+      "ruleId": "CSDB-VIEW-BODY-001",
+      "objectKind": "view",
+      "feature": "viewBody",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "The body must parse, bind, scratch-apply, and catalog-compare."
+    },
+    {
+      "ruleId": "CSDB-TRIGGER-BODY-001",
+      "objectKind": "trigger",
+      "feature": "triggerBody",
+      "status": "conditional",
+      "allowedValues": ["after-delete", "after-insert", "after-update", "before-delete", "before-insert", "before-update"],
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "Trigger bodies are bounded to INSERT, UPDATE, and DELETE statements."
+    },
+    {
+      "ruleId": "CSDB-TRIGGER-WHEN-001",
+      "objectKind": "trigger",
+      "feature": "triggerWhen",
+      "status": "unsupported",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "WHEN is represented by the parser and rejected with SyntaxError before catalog persistence."
+    },
+    {
+      "ruleId": "CSDB-COLLECTION-INDEX-001",
+      "objectKind": "collection",
+      "feature": "collectionIndex",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "allowedValues": ["array-element-path", "nested-path", "nonunique", "scalar-path"],
+      "evidenceId": "EVID-COLLECTION",
+      "notes": "Collection indexes are nonunique; range scans exclude array-element paths."
+    },
+    {
+      "ruleId": "CSDB-TARGET-TYPE-ENFORCEMENT-001",
+      "objectKind": "column",
+      "feature": "targetTypeEnforcement",
+      "status": "compatible",
+      "evidenceId": "EVID-INSERT-BATCH",
+      "notes": "Every row assignment is coerced and validated against the column's logical SQL type descriptor before persistence."
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "EVID-CATALOG",
+      "source": "CSharpDB.Engine catalog implementations and CSharpDB.Sql.Parser",
+      "assertion": "The installed source defines the target object catalog and supported SQL DDL forms."
+    },
+    {
+      "evidenceId": "EVID-CHECKS",
+      "source": "CSharpDB.Engine.RowConstraintValidator and DefaultCheckConstraintTests",
+      "assertion": "Check expressions are deterministic and row-local with bounded syntax."
+    },
+    {
+      "evidenceId": "EVID-COLLECTION",
+      "source": "CSharpDB.Engine.Collection and CollectionIndexBinding; CollectionIndexTests",
+      "assertion": "Collections use document storage with bounded scalar, nested, and array-element index behavior."
+    },
+    {
+      "evidenceId": "EVID-COLUMN",
+      "source": "CSharpDB.Primitives.DbType, CSharpDB.Sql.Parser, and CSharpDB.Storage.Serialization.RecordEncoder",
+      "assertion": "Runtime tags include Null, Integer, Real, Text, Blob, and exact Decimal; persistent columns retain validated logical SQL type descriptors, including signed 32-bit INTEGER, BIGINT, BOOLEAN, temporal, and bit-string distinctions."
+    },
+    {
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "source": "CSharpDB.Engine.QueryPlanner and ForeignKeyIntegrationTests",
+      "assertion": "Foreign keys require compatible ordered parent keys and support immediate MATCH SIMPLE with RESTRICT, NO ACTION, CASCADE, eligible-child SET NULL, or proven-literal SET DEFAULT behavior for delete and update actions."
+    },
+    {
+      "evidenceId": "EVID-IDENTIFIERS",
+      "source": "CSharpDB.Primitives.SqlIdentifierRules",
+      "assertion": "Quoted identifiers support embedded quotes, reject NUL, and are limited to 128 UTF-16 code units."
+    },
+    {
+      "evidenceId": "EVID-INDEXES",
+      "source": "CSharpDB.Engine.QueryPlanner and CSharpDB.Sql.Ast.CreateIndexStatement",
+      "assertion": "Indexes are column-only and constrained to INTEGER/TEXT/REAL key components with supported collations; REAL components use equality-only hashed keys while ordered and range access remains limited to supported INTEGER/TEXT shapes."
+    },
+    {
+      "evidenceId": "EVID-INSERT-BATCH",
+      "source": "CSharpDB.Execution.RowConstraintValidator and SqlTypeCoercion",
+      "assertion": "All write paths validate and normalize values against the persisted logical SQL type descriptor before storage."
+    },
+    {
+      "evidenceId": "EVID-KEYS",
+      "source": "CSharpDB.Engine.QueryPlanner and LogicalKeyConstraintTests",
+      "assertion": "INTEGER/TEXT primary and unique keys support single and composite forms with documented NULL tuple semantics."
+    },
+    {
+      "evidenceId": "EVID-ROWVERSION",
+      "source": "CSharpDB.Engine.RowConstraintValidator, QueryPlanner, and RowVersionIntegrationTests",
+      "assertion": "A table may contain one generated ROWVERSION excluded from keys, foreign keys, and indexes; inserts and updates allocate durable database-wide tokens."
+    },
+    {
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "source": "CSharpDB.Sql.Parser, CSharpDB.Execution.QueryPlanner, and UnsupportedSqlFeatureDiagnosticTests",
+      "assertion": "Views and bounded triggers exist, while trigger WHEN is rejected with SyntaxError before catalog persistence."
+    }
+  ]
+}

--- a/src/CSharpDB.Migration/README.md
+++ b/src/CSharpDB.Migration/README.md
@@ -26,9 +26,9 @@ core:
 - source-neutral catalog objects with explicit containment, set-like
   dependencies, ordered role-qualified schema members, and safe source identity;
 - stable compatibility, evidence, diagnostic, and mapping states;
-- an embedded, digested CSharpDB 4.5.0 capability catalog tied to the installed
-  Migration and Primitives binaries, plus immutable 4.4.0 and 4.3.0 catalogs
-  for independently replaying plans created against those releases;
+- an embedded, digested CSharpDB 4.5.1 capability catalog tied to the installed
+  Migration and Primitives binaries, plus immutable 4.5.0, 4.4.0, and 4.3.0
+  catalogs for independently replaying plans created against those versions;
 - target plans bound to the source-catalog digest, capability digest, naming
   algorithm, and versioned mapping policy;
 - detailed target-capability evaluation for columns, keys, foreign keys,

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>4.5.0</Version>
+    <Version>4.5.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />

--- a/tests/CSharpDB.Cli.Tests/MigrationDdlPreviewCommandRunnerTests.cs
+++ b/tests/CSharpDB.Cli.Tests/MigrationDdlPreviewCommandRunnerTests.cs
@@ -41,7 +41,7 @@ public sealed class MigrationDdlPreviewCommandRunnerTests
             string jsonDigest = Sha256(first);
             Assert.True(
                 string.Equals(
-                    "4bda01ed3989003d79322254dd79362eab11ccb06139e6b7a365a10c566a3c3d",
+                    "375fe8237dafb75418b308124b6041e441cd373e66bd8275a2e767b2230f945d",
                     jsonDigest,
                     StringComparison.Ordinal),
                 $"JSON preview digest: {jsonDigest}");
@@ -92,7 +92,7 @@ public sealed class MigrationDdlPreviewCommandRunnerTests
             string textDigest = Sha256(text);
             Assert.True(
                 string.Equals(
-                    "f4ecf78066f3b31fea9f11ce2659ca73803ed112ab4cb7ab24c433c08a2b727b",
+                    "258cf8a0a56f7373ba4ab05d21516d2dfc3746005f785d5c8b55bdf77e6143d2",
                     textDigest,
                     StringComparison.Ordinal),
                 $"Text preview digest: {textDigest}");

--- a/tests/CSharpDB.Cli.Tests/MigrationReleasePackagingTests.cs
+++ b/tests/CSharpDB.Cli.Tests/MigrationReleasePackagingTests.cs
@@ -152,7 +152,7 @@ public sealed class MigrationReleasePackagingTests
             "Publish-CSharpDbMigrationRelease.ps1");
 
         Assert.Contains(
-            "[string] $Version = '4.5.0'",
+            "[string] $Version = '4.5.1'",
             script,
             StringComparison.Ordinal);
         Assert.Contains("win-x64", script, StringComparison.Ordinal);

--- a/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
@@ -75,10 +75,12 @@ public sealed class DaemonPackagingAssetsTests
 
         Assert.Contains("name: Release\n", trigger);
         Assert.Contains("      - \"v*\"", trigger);
-        Assert.Contains("workflow_dispatch:", trigger);
+        Assert.DoesNotContain("workflow_dispatch:", trigger);
+        Assert.Contains("group: release-${{ github.ref }}", trigger);
         Assert.Contains("uses: ./.github/workflows/release.yml", trigger);
         Assert.Contains("NUGET_USER: ${{ secrets.NUGET_USER }}", trigger);
         Assert.DoesNotContain("secrets: inherit", trigger);
+        Assert.DoesNotContain("waive_local_durable", trigger);
         Assert.Contains("contents: write", trigger);
         Assert.Contains("statuses: read", trigger);
         Assert.Contains("id-token: write", trigger);
@@ -268,9 +270,10 @@ public sealed class DaemonPackagingAssetsTests
             "release_commit: ${{ inputs.release_commit }}",
             normalized);
         Assert.Contains(
-            "previous_release_ref: ${{ inputs.waive_local_durable_for_v450 && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}",
+            "previous_release_ref: ${{ inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}",
             normalized);
         Assert.Contains("verify-local-durable-performance:", normalized);
+        Assert.Contains("name: Verify local durable performance qualification", normalized);
         Assert.Contains("statuses: read", normalized);
         Assert.Contains("LOCAL_DURABLE_ATTESTOR", normalized);
         Assert.Contains("github.repository_owner", normalized);
@@ -279,7 +282,13 @@ public sealed class DaemonPackagingAssetsTests
         Assert.Contains(
             "./scripts/Test-LocalDurableStatus.ps1",
             normalized);
-        Assert.Contains("if: ${{ !inputs.waive_local_durable_for_v450 }}", normalized);
+        Assert.Contains(
+            """
+                  - name: Require a successful matching-commit local performance status
+                    shell: pwsh
+            """.ReplaceLineEndings("\n"),
+            normalized);
+        Assert.DoesNotContain("waive_local_durable", normalized);
         Assert.Contains("-Commit '${{ inputs.release_commit }}'", normalized);
         Assert.Contains("-ReleaseVersion '${{ inputs.release_tag }}'", normalized);
         Assert.Contains("-GitHubRepository '${{ github.repository }}'", normalized);
@@ -303,7 +312,30 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
-    public void ReleaseWorkflow_OneTimeV450RecoveryIsPinnedAndCannotBecomeGeneralWaiver()
+    public void ReleaseWorkflow_V451HostedBaselineUsesLastPublishedV440Only()
+    {
+        string repoRoot = FindRepoRoot();
+        string implementation = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "release.yml")).ReplaceLineEndings("\n");
+
+        const string expectedBaselineInput =
+            "previous_release_ref: ${{ inputs.release_tag == 'v4.5.1' && " +
+            "'86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}";
+
+        Assert.Contains("v4.5.0 was tagged but never published", implementation);
+        Assert.Contains(expectedBaselineInput, implementation);
+        Assert.Single(
+            System.Text.RegularExpressions.Regex.Matches(
+                implementation,
+                @"(?m)^\s+previous_release_ref:"));
+        Assert.DoesNotContain("waive", implementation, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_IsTagOnlyAndHasNoManualRecoveryOrDurableWaiver()
     {
         string repoRoot = FindRepoRoot();
         string trigger = File.ReadAllText(Path.Combine(
@@ -317,47 +349,28 @@ public sealed class DaemonPackagingAssetsTests
             "workflows",
             "release.yml")).ReplaceLineEndings("\n");
 
-        const string releaseTag = "v4.5.0";
-        const string releaseCommit = "7aeb66031237283c3643e73849618bf299729ed6";
-        const string baselineCommit = "86e25435f3c64f47afe2a776c6b03cbe84e56858";
-
-        int dispatchStart = trigger.IndexOf("  workflow_dispatch:\n", StringComparison.Ordinal);
-        int concurrencyStart = trigger.IndexOf("\nconcurrency:\n", StringComparison.Ordinal);
-        Assert.True(dispatchStart >= 0 && concurrencyStart > dispatchStart);
-        string dispatchInputs = trigger[dispatchStart..concurrencyStart];
-
-        Assert.Contains("approve_v4_5_0_local_durable_waiver:", dispatchInputs);
-        Assert.Contains("type: boolean", dispatchInputs);
-        Assert.Contains("default: false", dispatchInputs);
-        Assert.DoesNotContain("release_tag:", dispatchInputs);
-        Assert.DoesNotContain("release_commit:", dispatchInputs);
-
-        Assert.Contains("refs/heads/main", trigger);
-        Assert.Contains("MaxAkbar/CSharpDB/.github/workflows/publish-release.yml@refs/heads/main", trigger);
-        Assert.Contains("ACTOR_ID: ${{ github.actor_id }}", trigger);
-        Assert.Contains("$expectedActorId = '13856299'", trigger);
-        Assert.Contains("$expectedTag = 'v4.5.0'", trigger);
-        Assert.Contains($"$expectedCommit = '{releaseCommit}'", trigger);
-        Assert.Contains("$expectedStatusId = 51899579502L", trigger);
-        Assert.Contains("$expectedStatusTime = '2026-08-09T06:02:33Z'", trigger);
-        Assert.Contains("$expectedStatusDescription = 'policy=durable-v3; design=6B500421; local durable qualification failed'", trigger);
-        Assert.Contains("$expectedCiRunId = 31260517686L", trigger);
-        Assert.Contains("environment: v4-5-0-recovery", trigger);
-        Assert.Contains("waive_local_durable_for_v450: false", trigger);
-        Assert.Contains("waive_local_durable_for_v450: true", trigger);
-        Assert.Contains($"release_tag: {releaseTag}", trigger);
-        Assert.Contains($"release_commit: {releaseCommit}", trigger);
-        Assert.Contains("release-${{ github.event_name == 'workflow_dispatch' && 'refs/tags/v4.5.0' || github.ref }}", trigger);
+        Assert.Contains("      - \"v*\"", trigger);
+        Assert.Contains("group: release-${{ github.ref }}", trigger);
+        Assert.Contains("release_tag: ${{ github.ref_name }}", trigger);
+        Assert.Contains("release_commit: ${{ github.sha }}", trigger);
+        Assert.Contains("NUGET_USER: ${{ secrets.NUGET_USER }}", trigger);
+        Assert.DoesNotContain("workflow_dispatch:", trigger);
+        Assert.DoesNotContain("recovery", trigger, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("waive", trigger, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("v4.5.0", trigger);
         Assert.DoesNotContain("statuses: write", trigger);
         Assert.DoesNotContain("secrets: inherit", trigger);
 
-        Assert.Contains("if: ${{ inputs.waive_local_durable_for_v450 }}", implementation);
-        Assert.Contains($"$env:RELEASE_TAG -cne '{releaseTag}'", implementation);
-        Assert.Contains($"$env:RELEASE_COMMIT -cne '{releaseCommit}'", implementation);
-        Assert.Contains(baselineCommit, implementation);
+        Assert.Contains("- name: Require the exact existing release tag and commit", implementation);
+        Assert.Contains("- name: Require a successful matching-commit local performance status", implementation);
+        Assert.Contains("./scripts/Test-LocalDurableStatus.ps1", implementation);
+        Assert.DoesNotContain("workflow_dispatch", implementation);
+        Assert.DoesNotContain("waive", implementation, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("7aeb66031237283c3643e73849618bf299729ed6", implementation);
         Assert.Contains("- name: Revalidate the immutable publication target", implementation);
         Assert.Contains("- name: Require the immutable target and absent release before creation", implementation);
         Assert.Contains("packages will not be published", implementation);
+        Assert.Contains("publication will not update it", implementation);
         Assert.DoesNotContain("Publish-DurableCarryForwardStatus.ps1", implementation);
         Assert.DoesNotContain("statuses: write", implementation);
         Assert.Equal(
@@ -414,6 +427,16 @@ public sealed class DaemonPackagingAssetsTests
         Assert.Contains("Test-MySqlMigrationIsolation.ps1", script);
         Assert.Contains("Test-AccessMigrationIsolation.ps1", script);
         Assert.Contains("Test-EfCoreMigrationTool.ps1", script);
+
+        System.Text.RegularExpressions.Match fullTestArguments =
+            System.Text.RegularExpressions.Regex.Match(
+                script,
+                @"(?s)-StepName 'full-test-suite'.*?-ArgumentList @\((?<arguments>.*?)\)");
+        Assert.True(fullTestArguments.Success);
+        Assert.Contains(
+            "'--maxcpucount:1'",
+            fullTestArguments.Groups["arguments"].Value,
+            StringComparison.Ordinal);
 
         System.Text.RegularExpressions.Match accessArguments =
             System.Text.RegularExpressions.Regex.Match(

--- a/tests/CSharpDB.Migration.Files.Tests/CsvMigrationDataSourceTests.cs
+++ b/tests/CSharpDB.Migration.Files.Tests/CsvMigrationDataSourceTests.cs
@@ -225,7 +225,7 @@ public sealed class CsvMigrationDataSourceTests
 
             const string expectedCursor =
                 "csharpdb-csv-cursor-v1/1/1/" +
-                "6f68f229963eaed20652bd21eeef43fc6eaaa7853ed35ae719a41e860f313100";
+                "dbb2f0bc0ef913611e67f78c62a2e831961ff9fc5807d88e4e17b6343a602dc4";
             Assert.True(
                 string.Equals(expectedCursor, first.NextCursor, StringComparison.Ordinal),
                 $"CSV cursor golden changed. Actual value: {first.NextCursor}");

--- a/tests/CSharpDB.Migration.MySql.Tests/MySqlCatalogBuilderTests.cs
+++ b/tests/CSharpDB.Migration.MySql.Tests/MySqlCatalogBuilderTests.cs
@@ -6,7 +6,7 @@ namespace CSharpDB.Migration.MySql.Tests;
 public sealed class MySqlCatalogBuilderTests
 {
     private const string GoldenCatalogDigest =
-        "b3593d28d7ca9cc1d50560e282731be5117ee7c43f7de76b1208e019e2e441d7";
+        "9d9423184603ce469c2d70a306a63bafe329d8adbe20f0a7173d3e34f664ee41";
     private const string GoldenSourceFingerprint =
         "sha256:3e8b79eed8a2f36c0962a6e252404180d715dbbaab46d1fec4f1af61b75e383c";
 

--- a/tests/CSharpDB.Migration.SqlServer.Tests/SqlServerCatalogBuilderTests.cs
+++ b/tests/CSharpDB.Migration.SqlServer.Tests/SqlServerCatalogBuilderTests.cs
@@ -6,7 +6,7 @@ namespace CSharpDB.Migration.SqlServer.Tests;
 public sealed partial class SqlServerCatalogBuilderTests
 {
     private const string GoldenCatalogDigest =
-        "fd2ba8bac9b29c7abc530cbbf1d143117915e0b353ee36462c31c6bdbd2f01fc";
+        "629716b9dd229f9ca370be2b20f97398d4f3e7e732a8c617272909a08f2bcfe2";
     private const string GoldenSourceFingerprint =
         "sha256:9ca68e4d38d4caa4d6feeb034355a7ad75da5af6c7456d9bdefa7270f9a92c21";
 

--- a/tests/CSharpDB.Migration.Tests/CSharpDbValidationActivationTests.cs
+++ b/tests/CSharpDB.Migration.Tests/CSharpDbValidationActivationTests.cs
@@ -250,7 +250,7 @@ public sealed class CSharpDbValidationActivationTests
 
         string expectedIdentity =
             $"staged-target:{GoldenTargetIdentity}:awaiting-validation:outcomes:" +
-            "40868c5654620bfffd0bfb5c083e301de409084318db01c873071ed6b541d398";
+            "b59bddbbf8b078a5de71c2660905d686f809ba8827822f0c97e039f6d0faedd6";
         Assert.True(
             string.Equals(expectedIdentity, snapshot.SnapshotIdentity, StringComparison.Ordinal),
             $"Validation snapshot golden identity changed. Actual value: {snapshot.SnapshotIdentity}");

--- a/tests/CSharpDB.Migration.Tests/Fixtures/catalog-v1.golden.json
+++ b/tests/CSharpDB.Migration.Tests/Fixtures/catalog-v1.golden.json
@@ -1,9 +1,9 @@
 {
   "format": "csharpdb-migration-catalog/v1",
   "digestAlgorithm": "sha256",
-  "digest": "fdb2779f7d108a81d7f7f23b7e776a25f3ae67f216accedbba55aca876b1f6dd",
+  "digest": "3f4e60759e6b1e795b931fd3cecce9b8a6e5701c14d477aa92fa0e7fa50feaea",
   "payload": {
-    "targetCSharpDbVersion": "4.5.0",
+    "targetCSharpDbVersion": "4.5.1",
     "source": {
       "kind": "synthetic",
       "identity": "fixture:awkward-v1",

--- a/tests/CSharpDB.Migration.Tests/Fixtures/synthetic-planning-v1.golden.json
+++ b/tests/CSharpDB.Migration.Tests/Fixtures/synthetic-planning-v1.golden.json
@@ -1,5 +1,5 @@
 {
-  "catalogDigest": "963b7cad53e19fc9106f49e1581006b683cc11b30c277b83d9ae7b3b8afdf3e7",
-  "preservePlanDigest": "299adcae78c97fbebff6a6dd97f5835721284ac834c777abb89e0c0439edd04c",
-  "queryablePlanDigest": "b7046342317a72e71178c439c2c17a13e5343d40202487817cdc074bbb9aa168"
+  "catalogDigest": "7e09fa94acc96486b474ddd345b73158c1d7856b6d8ccf313c4ca1336d4f6f4b",
+  "preservePlanDigest": "679a3f4cdcaddd68ade9546b892788abd620933d1ceeae4a529141efaa77b8e8",
+  "queryablePlanDigest": "68a3b6b0a6ec7a28436febd9ae649e8fa69c02bc7d1936ca3f3b5d547acff659"
 }

--- a/tests/CSharpDB.Migration.Tests/MigrationPlannerTests.cs
+++ b/tests/CSharpDB.Migration.Tests/MigrationPlannerTests.cs
@@ -11,7 +11,7 @@ public sealed class MigrationPlannerTests
     {
         CSharpDbCapabilityCatalog capabilities = CSharpDbCapabilityCatalogLoader.LoadEmbedded();
 
-        Assert.Equal("4.5.0", capabilities.TargetCSharpDbVersion);
+        Assert.Equal("4.5.1", capabilities.TargetCSharpDbVersion);
         Assert.Equal("local-typed-engine", capabilities.Surface);
         Assert.Equal(SqlIdentifierRules.MaxLength, capabilities.MaxIdentifierLength);
         Assert.Equal(64, capabilities.Digest.Length);
@@ -49,9 +49,9 @@ public sealed class MigrationPlannerTests
     }
 
     [Fact]
-    public void EmbeddedCapabilities_AreBoundToThe450ReleaseAssembliesAndResource()
+    public void EmbeddedCapabilities_AreBoundToThe451ReleaseAssembliesAndResource()
     {
-        const string expectedVersion = "4.5.0";
+        const string expectedVersion = "4.5.1";
         Assembly migrationAssembly = typeof(CSharpDbCapabilityCatalogLoader).Assembly;
         Assembly primitivesAssembly = typeof(DbType).Assembly;
 
@@ -70,22 +70,34 @@ public sealed class MigrationPlannerTests
             CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.3.0");
         CSharpDbCapabilityCatalog previous =
             CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.4.0");
+        CSharpDbCapabilityCatalog tagged =
+            CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.5.0");
         CSharpDbCapabilityCatalog current =
             CSharpDbCapabilityCatalogLoader.LoadEmbedded();
 
         Assert.Equal(
-            ["4.3.0", "4.4.0", "4.5.0"],
+            ["4.3.0", "4.4.0", "4.5.0", "4.5.1"],
             CSharpDbCapabilityCatalogLoader.SupportedTargetVersions);
         Assert.Equal("4.3.0", oldest.TargetCSharpDbVersion);
         Assert.Equal("4.4.0", previous.TargetCSharpDbVersion);
-        Assert.Equal("4.5.0", current.TargetCSharpDbVersion);
+        Assert.Equal("4.5.0", tagged.TargetCSharpDbVersion);
+        Assert.Equal("4.5.1", current.TargetCSharpDbVersion);
         Assert.False(oldest.IsColumnType(DbType.Decimal));
         Assert.False(previous.IsColumnType(DbType.Decimal));
+        Assert.True(tagged.IsColumnType(DbType.Decimal));
         Assert.True(current.IsColumnType(DbType.Decimal));
         Assert.False(oldest.EngineEnforcesMappedColumnType);
         Assert.False(previous.EngineEnforcesMappedColumnType);
+        Assert.True(tagged.EngineEnforcesMappedColumnType);
         Assert.True(current.EngineEnforcesMappedColumnType);
         Assert.NotEqual(previous.Digest, current.Digest);
+        Assert.NotEqual(tagged.Digest, current.Digest);
+        Assert.Equal(
+            JsonSerializer.Serialize(tagged with
+            {
+                TargetCSharpDbVersion = current.TargetCSharpDbVersion,
+            }),
+            JsonSerializer.Serialize(current));
 
         CSharpDbCapabilityRule previousForeignKey = oldest.Rules.Single(rule =>
             rule.Feature == CSharpDbCapabilityFeature.ForeignKey);

--- a/tests/CSharpDB.Tests/SqlTypeCoercionTests.cs
+++ b/tests/CSharpDB.Tests/SqlTypeCoercionTests.cs
@@ -1,0 +1,61 @@
+using CSharpDB.Execution;
+using CSharpDB.Primitives;
+
+namespace CSharpDB.Tests;
+
+public sealed class SqlTypeCoercionTests
+{
+    private static readonly ColumnDefinition IntegerColumn = new()
+    {
+        Name = "value",
+        Type = DbType.Integer,
+        DeclaredType = SqlTypeDescriptor.Create(SqlTypeKind.Integer),
+    };
+
+    [Theory]
+    [InlineData(
+        null,
+        "Value of type Text is not valid for column 'value' declared as INTEGER: An exact integral value is required.")]
+    [InlineData(
+        "bench",
+        "Value of type Text is not valid for column 'bench.value' declared as INTEGER: An exact integral value is required.")]
+    public void CoerceForAssignment_PreservesQualifiedTypeMismatchMessage(
+        string? tableName,
+        string expectedMessage)
+    {
+        CSharpDbException exception = Assert.Throws<CSharpDbException>(() =>
+            SqlTypeCoercion.CoerceForAssignment(
+                DbValue.FromText("bad"),
+                IntegerColumn,
+                tableName));
+
+        Assert.Equal(ErrorCode.TypeMismatch, exception.Code);
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Fact]
+    public void CoerceForAssignment_SuccessPathDoesNotAllocateQualifiedTarget()
+    {
+        DbValue input = DbValue.FromInteger(42);
+        DbValue result = SqlTypeCoercion.CoerceForAssignment(
+            input,
+            IntegerColumn,
+            tableName: "bench");
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 4096; i++)
+        {
+            result = SqlTypeCoercion.CoerceForAssignment(
+                input,
+                IntegerColumn,
+                tableName: "bench");
+        }
+
+        long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(
+            allocatedBytes <= 1024,
+            $"Successful assignment coercion allocated {allocatedBytes:N0} bytes.");
+        Assert.Equal(42, result.AsInteger);
+    }
+}


### PR DESCRIPTION
## Summary

Prepare CSharpDB 4.5.1 as the first published release in the 4.5 line. The
`v4.5.0` Git tag is retained as release-attempt history, but it was not
published as a release.

### Pull-request delta: current main to v4.5.1

- Remove the successful-path allocation of qualified diagnostic text from SQL
  assignment coercion. Failure paths retain the same error code, inner
  exception, and qualified or unqualified message.
- Add focused allocation and diagnostic-message regression coverage alongside
  the existing integer range and identity semantics coverage.
- Add the separately digested current `4.5.1` migration capability catalog
  while retaining the immutable 4.5.0, 4.4.0, and 4.3.0 catalogs for
  deterministic replay.
- Update release metadata and documentation for a new v4.5.1 tag, and remove
  the retired one-time v4.5.0 recovery dispatch and qualification waiver. The
  v4.5.0 tag is not moved or recreated.
- Serialize test-project execution inside the release qualification so
  process-heavy suites do not contend with one another. No test, assertion,
  timeout, or platform lane is skipped or weakened.

### Tagged-code delta: v4.5.0 to v4.5.1

- Include the focused coercion-performance fix, tests, and release preparation
  described above.
- Add generic exact tag/commit checks, fail-closed secret and qualification
  handling, package-authentication safeguards, and partial-publication retry
  guards that were introduced after the v4.5.0 tag and are carried forward
  without the interim release-specific recovery path.

### Public delta: v4.4.0 to v4.5.1

Because v4.5.0 was never published, the public release delta includes the full
4.5 feature set. It adds 25 persisted logical SQL type kinds plus generated
`ROWVERSION`, exact `DECIMAL`, declared facets, 32-bit `INTEGER` semantics,
Booleans, bit strings, UUID, temporal and interval types, JSON, XML, and
canonical type metadata across the engine, providers, transports, archives,
and migration tooling.

Bare `TIMESTAMP` now aliases the generated database-wide `ROWVERSION` token;
offset-free temporal values use `DATETIME2` and offset-aware values use
`DATETIMEOFFSET`. The release also adds bounded `XML_EXISTS`/`XMLEXISTS` and
`XML_VALUE` XPath 1.0 querying with secure parsing and explicit resource
limits. Compatibility handling preserves legacy descriptor-less integer data
as `BIGINT` and upgrades legacy rowversion allocation safely.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

None linked.

## Testing

Local validation is complete for the batch-insert regression fix and release
preparation. Hosted release qualification is not claimed yet.

- [x] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Focused evidence:

- Both paired performance passes used exact v4.4.0 commit
  `86e25435f3c64f47afe2a776c6b03cbe84e56858` as the previous-release baseline
  and exact candidate commit `b2ba3971115bf2b69fe1989ce9a6617fa173196e`
  for scenario `Storage_InMemory_Sql_Batch100_5s`.
- SQL type-coercion and integer-semantics tests passed: **7/7 passed**.
  Coverage includes the allocation-free success path, exact qualified and
  unqualified failure messages, integer ranges, arithmetic, and identity
  exhaustion.
- Paired performance pass 1: **PASS**, with a combined throughput regression
  of **6.77%** and order-stratum effects of **5.43% / 8.08%**.
- Paired performance pass 2: **PASS**, with a combined throughput regression
  of **4.81%** and order-stratum effects of **5.59% / 4.02%**.
- Both performance passes reported **0 invalid**, **0 unstable**,
  **0 order-sensitive**, and **0 regression** rows.
- Public documentation validation passed with
  `./scripts/Test-Documentation.ps1`.
- The Release solution build passed with **0 warnings** and **0 errors**.
- The serialized full solution matrix passed across 24 test projects:
  **6,023 passed**, **4 expected live/opt-in skips**, and **0 failed**.
- Final hosted release qualification remains pending and must pass before
  release.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- Review the branch-level fix separately from the public release contents. The
  code change after current main is intentionally narrow; the public
  v4.4.0-to-v4.5.1 delta includes all previously prepared 4.5 SQL type and XML
  functionality because v4.5.0 was not published.
- The performance fix only defers construction of assignment-error context
  until an error occurs. It does not bypass declared-type coercion, integer
  range validation, or primary-key validation.
- The `4.5.1` migration capability catalog is current. The immutable `4.5.0`
  catalog is retained only as deterministic replay history; its presence does
  not indicate that a v4.5.0 release was published.
- Do not move or recreate the v4.5.0 tag. Publish v4.5.1 from its own exact tag
  only after the remaining full validation succeeds.
