### PR TITLE
Simplify release validation workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,6 @@ jobs:
     name: Publish exact release tag
     permissions:
       contents: write
-      statuses: read
       id-token: write
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,11 @@ permissions:
   contents: read
 
 jobs:
-  verify-local-durable-performance:
-    name: Verify local durable performance qualification
+  verify-release-target:
+    name: Verify exact release target
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      statuses: read
 
     steps:
       - name: Checkout exact release source
@@ -59,21 +58,9 @@ jobs:
             throw "$env:RELEASE_TAG does not resolve to $env:RELEASE_COMMIT."
           }
 
-      - name: Require a successful matching-commit local performance status
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EXPECTED_STATUS_CREATOR: ${{ vars.LOCAL_DURABLE_ATTESTOR || github.repository_owner }}
-        run: |
-          ./scripts/Test-LocalDurableStatus.ps1 `
-            -Commit '${{ inputs.release_commit }}' `
-            -GitHubRepository '${{ github.repository }}' `
-            -ExpectedCreator $env:EXPECTED_STATUS_CREATOR `
-            -ReleaseVersion '${{ inputs.release_tag }}'
-
   build-and-test:
     name: Qualify release source
-    needs: verify-local-durable-performance
+    needs: verify-release-target
     uses: ./.github/workflows/sql-release-qualification.yml
     with:
       release_version: ${{ inputs.release_tag }}
@@ -84,7 +71,7 @@ jobs:
 
   publish-nuget:
     name: Publish NuGet
-    needs: build-and-test
+    needs: [build-and-test, migration-archives, native-aot, daemon-archives, admin-desktop-archive]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/sql-release-qualification.yml
+++ b/.github/workflows/sql-release-qualification.yml
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   qualify:
-    name: ${{ matrix.os }} / clean pass ${{ matrix.qualification_pass }}
+    name: ${{ matrix.os }} / clean qualification
     runs-on: ${{ matrix.os }}
     timeout-minutes: 240
     strategy:
@@ -54,9 +54,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-        qualification_pass:
-          - 1
-          - 2
 
     steps:
       - name: Checkout
@@ -82,14 +79,14 @@ jobs:
       - name: Run SQL release qualification
         shell: pwsh
         env:
-          QUALIFICATION_OUTPUT: ${{ runner.temp }}/csharpdb-sql-release-qualification/${{ inputs.release_commit || github.sha }}/${{ matrix.os }}/pass-${{ matrix.qualification_pass }}
+          QUALIFICATION_OUTPUT: ${{ runner.temp }}/csharpdb-sql-release-qualification/${{ inputs.release_commit || github.sha }}/${{ matrix.os }}
           RELEASE_VERSION: ${{ inputs.release_version }}
           RELEASE_COMMIT: ${{ inputs.release_commit }}
         run: |
           ./scripts/Test-SqlReleaseQualification.ps1 `
             -OutputPath $env:QUALIFICATION_OUTPUT `
             -Configuration Release `
-            -QualificationPass ${{ matrix.qualification_pass }} `
+            -QualificationPass 1 `
             -ReleaseVersion $env:RELEASE_VERSION `
             -ReleaseCommit $env:RELEASE_COMMIT
 
@@ -97,22 +94,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: sql-release-qualification-${{ inputs.release_commit || github.sha }}-${{ matrix.os }}-pass-${{ matrix.qualification_pass }}
-          path: ${{ runner.temp }}/csharpdb-sql-release-qualification/${{ inputs.release_commit || github.sha }}/${{ matrix.os }}/pass-${{ matrix.qualification_pass }}/evidence
+          name: sql-release-qualification-${{ inputs.release_commit || github.sha }}-${{ matrix.os }}-attempt-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/csharpdb-sql-release-qualification/${{ inputs.release_commit || github.sha }}/${{ matrix.os }}/evidence
           if-no-files-found: warn
           retention-days: 14
 
   previous-release-hosted-stable-performance:
-    name: Windows previous-release hosted-stable rows / balanced paired pass ${{ matrix.qualification_pass }}
+    name: Windows previous-release hosted-stable rows / balanced paired qualification
     needs: qualify
     runs-on: windows-latest
     timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        qualification_pass:
-          - 1
-          - 2
 
     steps:
       - name: Checkout
@@ -130,7 +121,7 @@ jobs:
       - name: Compare stable rows with previous release
         shell: pwsh
         env:
-          PERFORMANCE_OUTPUT: ${{ runner.temp }}/cdb-perf/stable/p${{ matrix.qualification_pass }}
+          PERFORMANCE_OUTPUT: ${{ runner.temp }}/cdb-perf/stable/p1
           PREVIOUS_RELEASE_REF: ${{ inputs.previous_release_ref }}
           CANDIDATE_REF: ${{ inputs.release_commit || github.sha }}
         run: |
@@ -138,7 +129,7 @@ jobs:
             -PreviousRef $env:PREVIOUS_RELEASE_REF `
             -CandidateRef $env:CANDIDATE_REF `
             -OutputPath $env:PERFORMANCE_OUTPUT `
-            -QualificationPass ${{ matrix.qualification_pass }} `
+            -QualificationPass 1 `
             -Paired `
             -SuiteName master-table-hosted-stable `
             -RepeatCount 3 `
@@ -152,12 +143,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: previous-release-hosted-stable-performance-${{ inputs.release_commit || github.sha }}-pass-${{ matrix.qualification_pass }}-attempt-${{ github.run_attempt }}
+          name: previous-release-hosted-stable-performance-${{ inputs.release_commit || github.sha }}-attempt-${{ github.run_attempt }}
           path: |
-            ${{ runner.temp }}/cdb-perf/stable/p${{ matrix.qualification_pass }}/previous-release-performance-preflight.md
-            ${{ runner.temp }}/cdb-perf/stable/p${{ matrix.qualification_pass }}/previous-release-performance.md
-            ${{ runner.temp }}/cdb-perf/stable/p${{ matrix.qualification_pass }}/baseline-results
-            ${{ runner.temp }}/cdb-perf/stable/p${{ matrix.qualification_pass }}/candidate-results
-            ${{ runner.temp }}/cdb-perf/stable/p${{ matrix.qualification_pass }}/logs
+            ${{ runner.temp }}/cdb-perf/stable/p1/previous-release-performance-preflight.md
+            ${{ runner.temp }}/cdb-perf/stable/p1/previous-release-performance.md
+            ${{ runner.temp }}/cdb-perf/stable/p1/baseline-results
+            ${{ runner.temp }}/cdb-perf/stable/p1/candidate-results
+            ${{ runner.temp }}/cdb-perf/stable/p1/logs
           if-no-files-found: warn
           retention-days: 14

--- a/docs/releases/v4.5.1-pr-notes.md
+++ b/docs/releases/v4.5.1-pr-notes.md
@@ -4,31 +4,35 @@ Prepare CSharpDB 4.5.1 as the first published release in the 4.5 line. The
 `v4.5.0` Git tag is retained as release-attempt history, but it was not
 published as a release.
 
-### Pull-request delta: current main to v4.5.1
+### Pull-request delta: current main to the simplified v4.5.1 release flow
 
-- Remove the successful-path allocation of qualified diagnostic text from SQL
-  assignment coercion. Failure paths retain the same error code, inner
-  exception, and qualified or unqualified message.
-- Add focused allocation and diagnostic-message regression coverage alongside
-  the existing integer range and identity semantics coverage.
-- Add the separately digested current `4.5.1` migration capability catalog
-  while retaining the immutable 4.5.0, 4.4.0, and 4.3.0 catalogs for
-  deterministic replay.
-- Update release metadata and documentation for a new v4.5.1 tag, and remove
-  the retired one-time v4.5.0 recovery dispatch and qualification waiver. The
-  v4.5.0 tag is not moved or recreated.
-- Serialize test-project execution inside the release qualification so
-  process-heavy suites do not contend with one another. No test, assertion,
-  timeout, or platform lane is skipped or weakened.
+- Simplify release tagging to exact clean-main, package-version, and tag
+  validation followed by an exact tag push. Remove the publisher's dependency
+  on local durable status, carry-forward waivers, local benchmark execution,
+  and GitHub commit-status permissions.
+- Consolidate blocking qualification in the hosted release workflow: one clean
+  functional qualification per supported operating system and one balanced
+  paired Windows hosted-stable benchmark. `RepeatCount 3` supplies three pairs
+  per execution order in that single performance job.
+- Require all archive jobs to complete before NuGet publication, retain the
+  existing exact-target and publication safeguards, and update workflow
+  contract tests and release documentation for the simpler gate. Local durable
+  tooling remains available only as an optional diagnostic.
 
 ### Tagged-code delta: v4.5.0 to v4.5.1
 
-- Include the focused coercion-performance fix, tests, and release preparation
-  described above.
-- Add generic exact tag/commit checks, fail-closed secret and qualification
-  handling, package-authentication safeguards, and partial-publication retry
-  guards that were introduced after the v4.5.0 tag and are carried forward
-  without the interim release-specific recovery path.
+- Include the focused coercion-performance fix and its allocation and
+  diagnostic-message regression tests.
+- Add the separately digested current `4.5.1` migration capability catalog
+  while retaining immutable 4.5.0, 4.4.0, and 4.3.0 catalogs for deterministic
+  replay. Update release metadata for the new tag and serialize test-project
+  execution during release qualification.
+- Retire the one-time v4.5.0 recovery dispatch and qualification waiver without
+  moving or recreating the v4.5.0 tag.
+- Carry forward generic exact tag/commit checks, fail-closed secret and
+  qualification handling, package-authentication safeguards, and
+  partial-publication retry guards. Simplify the blocking gate to the hosted
+  functional and balanced paired performance qualifications described above.
 
 ### Public delta: v4.4.0 to v4.5.1
 
@@ -61,15 +65,31 @@ None linked.
 
 ## Testing
 
-Local validation is complete for the batch-insert regression fix and release
-preparation. Hosted release qualification is not claimed yet.
+Validation for this release-flow simplification is complete locally. The
+tag-triggered hosted release qualification is not claimed yet.
 
-- [x] `dotnet build CSharpDB.slnx`
+- [ ] `dotnet build CSharpDB.slnx`
 - [x] Relevant tests executed
-- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
+- [x] Failure-path tests executed (if applicable: invalid release state and
+  unsupported workflow paths)
 - [x] Manual verification performed (if applicable)
 
-Focused evidence:
+This pull request:
+
+- Focused workflow and publisher contract tests passed: **31/31 passed**, covering
+  the exact-tag publisher preflight, the single hosted qualification shape, the
+  pinned v4.5.1 baseline, removal of status/waiver paths, and publication
+  ordering.
+- The focused migration release-asset workflow contract passed: **1/1 passed**.
+- Modified PowerShell release scripts passed parser validation: **2/2 passed**.
+- Modified GitHub Actions workflow files passed YAML parsing: **3/3 passed**.
+- Public documentation validation passed with
+  `./scripts/Test-Documentation.ps1`, and the changed files passed the Git
+  whitespace/error check.
+- Final hosted release qualification remains pending and must pass before
+  release.
+
+Earlier v4.5.1 product evidence, retained as tagged/public release context:
 
 - Both paired performance passes used exact v4.4.0 commit
   `86e25435f3c64f47afe2a776c6b03cbe84e56858` as the previous-release baseline
@@ -85,13 +105,9 @@ Focused evidence:
   of **4.81%** and order-stratum effects of **5.59% / 4.02%**.
 - Both performance passes reported **0 invalid**, **0 unstable**,
   **0 order-sensitive**, and **0 regression** rows.
-- Public documentation validation passed with
-  `./scripts/Test-Documentation.ps1`.
 - The Release solution build passed with **0 warnings** and **0 errors**.
 - The serialized full solution matrix passed across 24 test projects:
   **6,023 passed**, **4 expected live/opt-in skips**, and **0 failed**.
-- Final hosted release qualification remains pending and must pass before
-  release.
 
 ## Checklist
 
@@ -103,15 +119,18 @@ Focused evidence:
 
 ## Notes for Reviewers
 
-- Review the branch-level fix separately from the public release contents. The
-  code change after current main is intentionally narrow; the public
-  v4.4.0-to-v4.5.1 delta includes all previously prepared 4.5 SQL type and XML
-  functionality because v4.5.0 was not published.
-- The performance fix only defers construction of assignment-error context
-  until an error occurs. It does not bypass declared-type coercion, integer
-  range validation, or primary-key validation.
+- Review this branch's release-flow simplification separately from the tagged
+  and public release contents. The public v4.4.0-to-v4.5.1 delta includes all
+  previously prepared 4.5 SQL type and XML functionality because v4.5.0 was
+  not published.
+- The earlier performance fix only defers construction of assignment-error
+  context until an error occurs. It does not bypass declared-type coercion,
+  integer range validation, or primary-key validation.
 - The `4.5.1` migration capability catalog is current. The immutable `4.5.0`
   catalog is retained only as deterministic replay history; its presence does
   not indicate that a v4.5.0 release was published.
+- `Publish-ReleaseTag.ps1` does not run or require local performance evidence.
+  The tag-triggered hosted workflow must pass before package or release
+  publication begins.
 - Do not move or recreate the v4.5.0 tag. Publish v4.5.1 from its own exact tag
   only after the remaining full validation succeeds.

--- a/scripts/Publish-ReleaseTag.ps1
+++ b/scripts/Publish-ReleaseTag.ps1
@@ -4,48 +4,19 @@
 param(
     [Parameter(Mandatory)]
     [ValidatePattern('^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$')]
-    [string] $Version,
-
-    [switch] $ConfirmDedicatedFixedSsd,
-
-    [switch] $ApproveDurableV2CarryForward,
-
-    [ValidatePattern('^$|^[^/\s]+/[^/\s]+$')]
-    [string] $GitHubRepository = '',
-
-    [string] $ExpectedStatusCreator = ''
+    [string] $Version
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
-$statusVerifier = Join-Path $PSScriptRoot 'Test-LocalDurableStatus.ps1'
-$carryForwardPublisher =
-    Join-Path $PSScriptRoot 'Publish-DurableCarryForwardStatus.ps1'
-$localQualification = Join-Path `
-    $repositoryRoot `
-    'tests/CSharpDB.Benchmarks/scripts/Test-LocalDurablePerformance.ps1'
 $tagValidator = Join-Path $PSScriptRoot 'Test-ReleaseTag.ps1'
 $releaseVersion = $Version.TrimStart('v')
 $releaseTag = "v$releaseVersion"
 
-if ($ConfirmDedicatedFixedSsd -and $ApproveDurableV2CarryForward) {
-    throw (
-        '-ConfirmDedicatedFixedSsd and -ApproveDurableV2CarryForward are mutually exclusive.')
-}
-if ($ApproveDurableV2CarryForward -and $releaseVersion -cne '4.4.0') {
-    throw '-ApproveDurableV2CarryForward is available only for release 4.4.0.'
-}
-
-foreach ($requiredScript in
-    $statusVerifier,
-    $carryForwardPublisher,
-    $localQualification,
-    $tagValidator) {
-    if (-not (Test-Path -LiteralPath $requiredScript -PathType Leaf)) {
-        throw "Required release script was not found: $requiredScript"
-    }
+if (-not (Test-Path -LiteralPath $tagValidator -PathType Leaf)) {
+    throw "Required release script was not found: $tagValidator"
 }
 
 function Invoke-Git {
@@ -136,14 +107,6 @@ function Resolve-RemoteTagCommitOrNull {
     return [string] $direct[0].Sha
 }
 
-function Invoke-StatusVerifier {
-    & $statusVerifier `
-        -Commit $headCommit `
-        -GitHubRepository $GitHubRepository `
-        -ExpectedCreator $ExpectedStatusCreator `
-        -ReleaseVersion $releaseVersion
-}
-
 function Get-ExactCurrentMainCommit {
     $workingTreeChanges = Invoke-Git `
         -Arguments @('status', '--porcelain=v1', '--untracked-files=all') `
@@ -201,95 +164,10 @@ if ($packageVersion -cne $releaseVersion) {
         "'$packageVersion' in '$buildPropsPath'.")
 }
 
-if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
-    throw 'GitHub CLI (gh) is required to publish a release tag.'
-}
-if ([string]::IsNullOrWhiteSpace($GitHubRepository)) {
-    $repositoryOutput = @(
-        & gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>&1
-    )
-    if ($LASTEXITCODE -ne 0) {
-        $details = ($repositoryOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
-        throw "Could not resolve the GitHub repository. $details"
-    }
-    $GitHubRepository = (($repositoryOutput | ForEach-Object { [string] $_ }) -join '').Trim()
-}
-if ($GitHubRepository -cnotmatch '^[^/\s]+/[^/\s]+$') {
-    throw "GitHubRepository must use the owner/name form: $GitHubRepository"
-}
-
-if ([string]::IsNullOrWhiteSpace($ExpectedStatusCreator)) {
-    $variableOutput = @(
-        & gh variable get LOCAL_DURABLE_ATTESTOR --repo $GitHubRepository 2>&1
-    )
-    $variableExitCode = $LASTEXITCODE
-    if ($variableExitCode -eq 0) {
-        $ExpectedStatusCreator =
-            (($variableOutput | ForEach-Object { [string] $_ }) -join '').Trim()
-    }
-    else {
-        $variableFailure =
-            ($variableOutput | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
-        if ($variableFailure -notmatch '(?i)(HTTP\s+404|not\s+found)') {
-            throw (
-                "Could not resolve the LOCAL_DURABLE_ATTESTOR repository variable. " +
-                $variableFailure)
-        }
-    }
-    if ([string]::IsNullOrWhiteSpace($ExpectedStatusCreator)) {
-        $ExpectedStatusCreator = $GitHubRepository.Split('/', 2)[0]
-    }
-}
-else {
-    $ExpectedStatusCreator = $ExpectedStatusCreator.Trim()
-}
-
-$hasReusableStatus = $false
-try {
-    Invoke-StatusVerifier
-    $hasReusableStatus = $true
-    Write-Host "Reusing the existing canonical release status for exact commit $headCommit."
-}
-catch {
-    Write-Host "Exact commit $headCommit has no reusable canonical release status: $($_.Exception.Message)"
-}
-
-if (-not $hasReusableStatus) {
-    if ($ApproveDurableV2CarryForward) {
-        & $carryForwardPublisher `
-            -Version $releaseVersion `
-            -GitHubRepository $GitHubRepository `
-            -ExpectedStatusCreator $ExpectedStatusCreator
-
-        Invoke-StatusVerifier
-    }
-    elseif ($ConfirmDedicatedFixedSsd) {
-        & $localQualification `
-            -CandidateRef $headCommit `
-            -ConfirmDedicatedFixedSsd `
-            -GitHubRepository $GitHubRepository
-
-        Invoke-StatusVerifier
-    }
-    else {
-        $carryForwardGuidance = if ($releaseVersion -ceq '4.4.0') {
-            ' For the approved one-time v4.4.0 exception, rerun with ' +
-            '-ApproveDurableV2CarryForward.'
-        }
-        else {
-            ''
-        }
-        throw (
-            "Commit $headCommit does not have a reusable canonical release status. " +
-            'Rerun with -ConfirmDedicatedFixedSsd on the idle dedicated fixed-SSD ' +
-            "Windows machine.$carryForwardGuidance")
-    }
-}
-
 $currentMainCommit = Get-ExactCurrentMainCommit
 if ($currentMainCommit -cne $headCommit) {
     throw (
-        "The exact main commit changed during release qualification. Qualified $headCommit, " +
+        "The exact main commit changed during release validation. Validated $headCommit, " +
         "but current main is $currentMainCommit. Restart release tagging for the current commit.")
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,8 +12,9 @@ and are included in daemon release archives.
 
 The release and local workflow notes are grouped by audience:
 
-- Release maintainers use `scripts/Publish-ReleaseTag.ps1` to qualify the exact
-  merged `main` commit and publish its release tag. They can use
+- Release maintainers use `scripts/Publish-ReleaseTag.ps1` to validate the exact
+  merged `main` commit and publish its release tag. The tag push starts the
+  hosted release qualification and publication workflow. Maintainers can use
   `scripts/Publish-CSharpDbDaemonRelease.ps1` directly for local packaging
   checks. The GitHub Release workflow also uses the daemon publisher after the
   guarded `v*` tag is pushed.
@@ -48,7 +49,8 @@ Use this path before tagging or when validating release packaging locally.
 Commit implementation, version, documentation, roadmap, and release-note
 changes together. The release tag is the immutable record of that source state.
 
-2. Run the complete local release qualification from a clean checkout.
+2. Optionally run the complete local release qualification from a clean
+   checkout before opening or merging the release pull request.
 
 ```powershell
 $QualificationOutput = Join-Path `
@@ -67,20 +69,22 @@ isolation check on Windows. Logs, TRX results, temporary package state, and the
 Markdown result are written beneath the caller-selected output path outside
 the repository. The source tree must be clean before and after the run.
 
-The authoritative GitHub `SQL Release Qualification` workflow executes this
-same functional check in two independent clean jobs on each of Windows, Linux,
-and macOS. It can be started manually for a release candidate and is also
-required automatically by the tag release workflow before any publishing job
-starts. Before the workflow has first reached the default branch, pushing a
-non-release `qualification-*` tag runs it from that exact candidate commit
-without invoking the `v*` publishing workflow. Once registered on the default
-branch, normal manual dispatch can target any release-candidate branch. The
-workflow also keeps the 18 persistent-read and in-memory master-table rows
-blocking in two balanced paired Windows jobs. Only the ten disk-sensitive
-durable writes are excluded from hosted performance qualification.
+The authoritative GitHub `SQL Release Qualification` workflow executes one
+clean functional qualification job on each of Windows, Linux, and macOS. It can
+be started manually for a release candidate and is required automatically by
+the tag release workflow before any publishing job starts. Before the workflow
+has first reached the default branch, pushing a non-release `qualification-*`
+tag runs it from that exact candidate commit without invoking the `v*`
+publishing workflow. Once registered on the default branch, normal manual
+dispatch can target any release-candidate branch.
 
-The durable-write comparison is run against the final release commit immediately
-before tagging in step 5 below.
+The workflow also runs one balanced paired previous-release comparison for the
+18 hosted-stable persistent-read and in-memory master-table rows on Windows.
+`RepeatCount 3` records three pairs beginning with the previous release and
+three beginning with the candidate in the same job, so both execution orders
+are covered without duplicate pass jobs. The ten disk-sensitive durable-write
+rows remain available through the optional local diagnostic tooling below; they
+are not a release prerequisite.
 
 For a same-artifact exact-row A/A diagnostic, use an absent or empty output
 directory outside the checkout:
@@ -107,8 +111,8 @@ requires equal commits and maps one candidate DLL and closure to both labels.
 Both logical identities, the shared execution-time path, and all relative
 closure file hashes are recorded.
 
-These controls diagnose the harness only and cannot replace either balanced
-paired cross-version qualification pass or promote a baseline.
+These controls diagnose the harness only and cannot replace the hosted balanced
+paired cross-version qualification or promote a baseline.
 `-PostBuildQuiescenceSeconds` is an opt-in build-server shutdown plus fixed wait,
 not a machine-idleness guarantee, and it can affect concurrent .NET builds.
 Preflight metadata, hash manifests, raw and aggregate CSV evidence, logs, and
@@ -136,8 +140,8 @@ Get-ChildItem artifacts\daemon-release-local\archives
 Get-Content artifacts\daemon-release-local\archives\SHA256SUMS.txt
 ```
 
-5. After the pull request is merged, update local `main`, then run the canonical
-   release-tag publisher on the dedicated fixed-SSD Windows machine.
+5. After the pull request is merged, update local `main`, then run the
+   release-tag publisher.
 
 ```powershell
 git switch main
@@ -147,110 +151,61 @@ if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za
   throw 'Enter a semantic release version in major.minor.patch form.'
 }
 
-.\scripts\Publish-ReleaseTag.ps1 `
-  -Version $Version `
-  -ConfirmDedicatedFixedSsd
+.\scripts\Publish-ReleaseTag.ps1 -Version $Version
 ```
 
 `Publish-ReleaseTag.ps1` is the only supported way to create a release tag. Do
 not create release tags in the GitHub UI or with raw `git tag` / `git push`
-commands; those paths bypass the preflight and cause the fail-closed Release
-workflow to reject the tag. The publisher requires a clean, checked-out `main`,
-fetches `origin/main`, and requires local `HEAD` to equal that remote commit. It
-also validates the requested version and requires a canonical
-`csharpdb/local-durable-performance` success status from the configured attestor
-on that exact SHA before it creates or pushes the tag.
+commands; those unsupported paths bypass the clean-main, version, and tag
+preflight. The publisher requires a clean, checked-out `main`, fetches
+`origin/main`, and requires local `HEAD` to equal that remote commit. It
+also validates that the requested version matches the package version and that
+the local or remote tag is absent or already points to that exact commit. It
+rechecks `main` before validating and pushing the tag. It does not build, test,
+benchmark, inspect a commit status, or accept a local-performance waiver.
 
-When that exact commit already has a valid status, the publisher reuses it and
-does not rerun the benchmarks. Otherwise `-ConfirmDedicatedFixedSsd` authorizes
-the publisher to run the local durable wrapper. That wrapper forces durable mode
-and qualifies each of the ten durable SQL/collection single and batch write rows
-independently in two sequential balanced paired passes. Every row uses adjacent
-previous/candidate measurements, pass two reverses the starting order, and each
-individual measurement must retain at least 30 seconds and 10,000 latency
-samples. On an idle fixed-SSD machine this normally takes 3.5–4.5 hours total.
-It pins the candidate and previous commits, uses symmetrically conditioned
-artifacts with the same hash-recorded candidate benchmark harness, retains
-hash-verified raw evidence and a Markdown summary outside the repository,
-creates no repository JSON, and publishes the status only after both passes
-succeed. Without a reusable status or the confirmation switch, the publisher
-stops before creating a tag and explains how to run the required qualification.
+The command is idempotent for the same version and exact commit. It safely
+reuses an existing local or remote tag at that commit and rejects a same-named
+tag that points elsewhere.
 
-Every logical side has one predeclared attempt; a failed or contaminated sample
-is not discarded, replaced, or silently retried. After conditioning,
-build-server shutdown, and the post-build quiet window, the canonical Windows
-monitor takes one-second samples until after the final declared measurement.
-It excludes the qualification runner and its descendants. Five consecutive
-samples above either 8% observable external process CPU, 0.5 CPU-core
-equivalent, or 4,194,304 observable external process read-plus-write bytes per
-second make contamination sticky. The canonical prohibited external process
-names are `devenv`, `msbuild`, `vbcscompiler`, `testhost`, `vstest.console`,
-`msiexec`, `trustedinstaller`, `tiworker`, `mousocoreworker`, `usoclient`,
-`winget`, and `nuget`; observing any outside the runner tree contaminates
-immediately. External process I/O is process-transfer telemetry rather than
-whole-disk telemetry. Unavailable external process counters are retained as
-diagnostics, while inability to observe allowed runner-tree CPU contaminates
-immediately. The monitor must be ready before the first measurement, its
-ready-to-first and inter-sample gaps may not exceed five seconds, and its final
-sample must cover the final declared measurement end. Missing, stale,
-discontinuous, or early-exit monitor evidence fails closed. The official status
-cannot disable or alter the monitor; overrides are diagnostic only.
+The `v*` tag push starts the fail-closed Release workflow. The workflow first
+verifies that the existing tag resolves to the supplied exact commit. It then
+runs one clean functional qualification on each supported operating system and
+one balanced paired hosted-stable performance comparison on Windows. The
+performance job uses `RepeatCount 3`, which covers both previous/candidate
+execution orders in one job. For v4.5.1, the hosted comparison is pinned to the
+last published v4.4.0 commit because v4.5.0 was tagged but not published.
 
-The wrapper's Windows quiescence preflight refuses to start while a Windows
-Installer transaction is active or Component-Based Servicing (CBS) or Windows
-Update reports that a restart is required. It classifies
-`PendingFileRenameOperations` separately: a stable, well-formed deletion-only
-set may be fingerprinted and accepted as the
-run baseline, while malformed entries and replacement or rename operations
-block qualification. An active installer normally means wait for it to finish
-and run the preflight again; restart Windows when CBS or Windows Update requires
-it, or when blocking file operations remain after installers and updates have
-settled.
+Publication starts only after the hosted gates and all release-archive jobs
+succeed. The workflow publishes the NuGet packages, daemon archives for
+`win-x64`, `linux-x64`, and `osx-arm64`, migration and NativeAOT artifacts, and
+the Admin desktop archive, then creates the GitHub Release with the combined
+checksums and smoke-tested assets.
 
-Before, during, and after each pass, the wrapper records and audits Windows
-Installer transactions, Application event-log continuity, and the fingerprinted
-pending-file-operation baseline. A completed toolchain setup transaction is
-allowed only when it finishes before the configured post-build quiet window.
-Missing or unverifiable interference evidence, any installer event in that quiet
-window or after measurements begin, any pending-file baseline change, or any
-external-monitor contamination fails closed, prevents qualification, and stops
-the affected pass without replacing evidence. The wrapper may still collect the
-next predeclared pass after its normal system-state preflight.
-Start a new clean run instead of reusing contaminated evidence.
+### Optional local durable diagnostics
 
-The command is idempotent for the same version and exact commit: it safely
-reuses a valid status and an existing local or remote tag that already points to
-that commit. It rejects a same-named tag that points elsewhere. Optional
-`-GitHubRepository owner/name` and `-ExpectedStatusCreator login` arguments are
-available when repository discovery or the configured attestor must be supplied
-explicitly.
+`Test-LocalDurablePerformance.ps1` remains available when a maintainer needs to
+investigate the ten disk-sensitive durable SQL and collection write rows on an
+idle fixed-SSD Windows machine. It is diagnostic only: the tag publisher and
+Release workflow do not require or consume its commit status or evidence.
 
-The Release workflow remains a fail-closed backstop. It independently requires
-the matching-commit status, completes both clean functional passes on Windows,
-Linux, and macOS, and runs the 18 persistent-read and in-memory performance rows
-on hosted Windows runners before publishing. Those hosted comparisons block on
-throughput and P95 while retaining P99 as required diagnostic evidence. It then
-publishes the daemon archives for `win-x64`, `linux-x64`, and `osx-arm64`,
-smoke-starts each extracted binary,
-calls the daemon REST `/api/info` endpoint, verifies a gRPC `GetInfoAsync`
-client call, combines checksums, and attaches everything to the GitHub Release.
+Use `-NoGitHubStatus` for ordinary diagnostics so the run cannot be mistaken for
+release authorization. The wrapper retains its exact-row paired design,
+duration and latency-sample floors, Windows installer/update preflight, and
+external CPU, I/O, and prohibited-process monitoring. Contaminated evidence is
+never retried or promoted silently; start a new diagnostic run when needed.
 
-`-NoGitHubStatus` is available only for diagnostics and wrapper tests. A run with
-that switch does not satisfy the release workflow's matching-commit check.
-The official status is available only with automatic previous-release discovery
-and the canonical `durable-v3` exact-row, duration/sample-floor, quiescence, and
-regression settings. The blocking limits remain 15% for throughput; P95 fails
-only when it exceeds both 25% relative regression and 0.05 ms absolute
-regression. P99 is retained as diagnostic evidence and is not release-blocking.
-Selecting P99 or any other override requires `-NoGitHubStatus`.
+```powershell
+$DiagnosticOutput = Join-Path `
+  ([IO.Path]::GetTempPath()) `
+  "csharpdb-local-durable-$([Guid]::NewGuid().ToString('N'))"
 
-Canonical success has exactly this description:
-`policy=durable-v3; baseline=<40 lowercase hex>; design=<8 uppercase hex>; reports=<8 uppercase>/<8 uppercase>`.
-The design and report digests bind the policy design and both pass reports to the
-exact candidate status. Older policy descriptions are rejected. The workflow
-accepts the status only from the login named by the `LOCAL_DURABLE_ATTESTOR`
-repository variable, falling back to the repository owner when the variable is
-unset.
+.\tests\CSharpDB.Benchmarks\scripts\Test-LocalDurablePerformance.ps1 `
+  -CandidateRef HEAD `
+  -OutputPath $DiagnosticOutput `
+  -ConfirmDedicatedFixedSsd `
+  -NoGitHubStatus
+```
 
 ## Operator Walkthrough
 
@@ -514,9 +469,9 @@ $OutputPath = Join-Path `
   -QualificationPass 1
 ```
 
-The GitHub workflow runs qualification passes 1 and 2 in separate clean hosted
-jobs for each supported operating system. The pass number identifies evidence;
-it does not weaken or filter the checks.
+The GitHub workflow runs one clean qualification job for each supported
+operating system. It supplies `-QualificationPass 1` as a stable evidence label;
+the label does not weaken or filter the checks and does not imply a second run.
 
 ### `Test-AccessMigrationIsolation.ps1`
 

--- a/scripts/Test-ReleaseTag.ps1
+++ b/scripts/Test-ReleaseTag.ps1
@@ -63,8 +63,6 @@ if ($workingTreeChanges.Count -gt 0) {
     throw "Release validation requires a clean working tree: $($workingTreeChanges -join ', ')"
 }
 
-& (Join-Path $PSScriptRoot 'Test-Documentation.ps1')
-
 $semanticReleaseTagPattern = '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
 $validReleaseTags = @(
     & git -C $repoRoot tag --list |

--- a/tests/CSharpDB.Benchmarks/BENCHMARK_CATALOG.md
+++ b/tests/CSharpDB.Benchmarks/BENCHMARK_CATALOG.md
@@ -8,7 +8,6 @@ This file lists the available benchmark harnesses and how they are used. The mai
 |---|---|
 | `core` | Feeds the generated README scorecard and current core result tables. |
 | `hosted release gate` | Required previous-release comparison on GitHub-hosted Windows runners. |
-| `local release gate` | Required pre-tag comparison on one idle fixed-SSD Windows machine. |
 | `release guardrail` | Used by `Run-Perf-Guardrails.ps1 -Mode release` or PR guardrails. |
 | `diagnostic` | Kept for investigations, tuning, comparisons, and one-off validation. |
 
@@ -30,8 +29,8 @@ Use `--release-core --repeat 3 --repro` to run the core suites in one command.
 
 | Command | Class | Purpose |
 |---|---|---|
-| `--master-table-durable-writes` | `local release gate` | Ten file-backed, hybrid durable, and direct-client SQL/collection single and batch write rows. Normally invoked through `scripts/Test-LocalDurablePerformance.ps1` for two sequential paired passes. |
-| `--master-table-hosted-stable` | `hosted release gate` | The other 18 master-table rows: persistent reads plus in-memory reads and writes. Invoked by SQL Release Qualification in two balanced paired Windows jobs with throughput and P95 blocking; P99 remains diagnostic. |
+| `--master-table-durable-writes` | `diagnostic` | Ten file-backed, hybrid durable, and direct-client SQL/collection single and batch write rows. Optionally invoked through `scripts/Test-LocalDurablePerformance.ps1` for two sequential paired passes. |
+| `--master-table-hosted-stable` | `hosted release gate` | The other 18 master-table rows: persistent reads plus in-memory reads and writes. Invoked by SQL Release Qualification in one balanced paired Windows job; `RepeatCount 3` covers both execution orders, throughput and P95 block, and P99 remains diagnostic. |
 
 ## Release Guardrails
 

--- a/tests/CSharpDB.Benchmarks/README.md
+++ b/tests/CSharpDB.Benchmarks/README.md
@@ -442,37 +442,33 @@ dotnet run -c Release --project .\tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.
 ```
 
 After the release pull request is merged, update local `main` and use the
-canonical publisher on one idle, fixed-SSD Windows machine. This command owns
-both exact-commit durable qualification and release-tag publication:
+canonical publisher to validate and publish the exact release tag:
 
 ```powershell
 git switch main
 git pull --ff-only
 $Version = (Read-Host 'Release version without the v prefix').Trim()
 
-.\scripts\Publish-ReleaseTag.ps1 `
-  -Version $Version `
-  -ConfirmDedicatedFixedSsd
+.\scripts\Publish-ReleaseTag.ps1 -Version $Version
 ```
 
 Do not create a release tag in the GitHub UI or with raw `git tag` / `git push`
-commands. Those paths bypass the release preflight and the fail-closed Release
-workflow will reject the tag. `Publish-ReleaseTag.ps1` requires a clean,
-checked-out `main`, fetches `origin/main`, requires local `HEAD` to equal that
-remote commit, validates the version, and requires a canonical
-`csharpdb/local-durable-performance` success status from the configured attestor
-on that exact SHA.
+commands. Those unsupported paths bypass the clean-main, version, and tag
+preflight. `Publish-ReleaseTag.ps1` requires a clean, checked-out `main`, fetches
+`origin/main`, requires local `HEAD` to equal that remote commit, validates the
+package version, and rejects a same-named local or remote tag at another commit.
+It does not run or require a local benchmark or commit status.
 
-If that exact commit already has a valid status, the publisher reuses it without
-rerunning the benchmarks. If it does not, the confirmation switch permits the
-publisher to run `Test-LocalDurablePerformance.ps1`; this normally takes about
-3.5–4.5 hours on an idle fixed-SSD machine. Without a reusable status or
-`-ConfirmDedicatedFixedSsd`, it stops before creating a tag and tells the
-operator how to qualify the commit. The publisher is idempotent for the same
-version and exact commit: an existing local or remote tag at that commit is
-reused, while a same-named tag at another commit is rejected.
+The publisher is idempotent for the same version and exact commit. The `v*` tag
+push starts the fail-closed Release workflow, which runs one clean functional
+qualification on each of Windows, Linux, and macOS and one balanced paired
+hosted-stable comparison on Windows. That comparison uses `RepeatCount 3`, so
+one job records three pairs per previous/candidate execution order. Publication
+begins only after those hosted gates and all archive jobs succeed.
 
-During a new qualification, the repository must remain clean because both
+### Optional local durable-write diagnostics
+
+During a new local diagnostic, the repository must remain clean because both
 revisions are built from committed source. The wrapper resolves the candidate to
 one immutable commit. It discovers the nearest prior semantic release reachable
 from that candidate during pass 1 and pins it for pass 2. The previous revision
@@ -499,7 +495,7 @@ configured post-build quiet window. Any installer event in that quiet window or
 after measurements begin, any pending-file baseline change, a prohibited build
 or update workload, sustained observable external load, missing monitor
 evidence, unavailable allowed runner-tree CPU, or a telemetry gap contaminates
-the timing evidence and prevents qualification. The affected
+the timing evidence and invalidates the diagnostic. The affected
 pass stops without replacement; the wrapper may still collect the next
 predeclared pass after its normal system-state preflight. Start a new clean run
 instead of reusing contaminated evidence.
@@ -526,20 +522,21 @@ anchor at every pass start and around each installer-event audit, and fails the
 qualification if the channel is disabled, full, cleared, overwritten, or reuses
 the anchor record ID.
 
-The local release gate runs `master-table-durable-write-scenarios`: ten exact
+The local diagnostic suite runs `master-table-durable-write-scenarios`: ten exact
 durable SQL and collection single/batch write rows from file-backed, hybrid
 incremental-durable, and direct-client paths. Each previous/candidate row pair
 runs adjacently; the deterministic row order rotates across pair rounds so no
 row owns one time position, and pass 2 reverses the starting revision. It
 intentionally excludes reads and in-memory rows. The other 18 master-table rows
-remain a blocking two-pass comparison on GitHub-hosted Windows runners. Both
-local passes run sequentially so they never contend for the same disk. The
-wrapper forces
+form the blocking one-job hosted comparison; `RepeatCount 3` covers both
+execution orders within that job. Both optional local passes run sequentially
+so they never contend for the same disk. The wrapper forces
 `CSHARPDB_BENCH_DURABILITY=Durable` for its children and restores the caller's
 prior process value afterward.
 
-Only the canonical release policy may publish the official status: automatic
-previous-release discovery, exact-row execution, three repeats per order, a
+The wrapper retains a canonical evidence policy when a GitHub status is
+requested: automatic previous-release discovery, exact-row execution, three
+repeats per order, a
 30-second post-build wait, a 10-second boundary before every recorded side, at
 least 30 measured seconds and 10,000 retained latency samples per side, the
 canonical external-load monitor, a 15% throughput limit, and the combined 25% plus
@@ -547,7 +544,9 @@ canonical external-load monitor, a 15% throughput limit, and the combined 25% pl
 are reported diagnostically but do not affect stability, order-sensitivity, or
 regression status. To change any of those settings, disable the monitor, select
 another blocking percentile, or supply `-PreviousRef`, also supply
-`-NoGitHubStatus`; that run is diagnostic and cannot authorize a release.
+`-NoGitHubStatus`. Use `-NoGitHubStatus` for ordinary diagnostics because neither
+the tag publisher nor Release workflow consumes this status, and no local run
+authorizes a release.
 
 The candidate benchmark source is hash-verified and synchronized into the
 previous-release worktree so both engines run the same harness. Candidate and
@@ -582,39 +581,30 @@ when its increase exceeds both 25% and the 0.05 ms absolute allowance, so
 percentage-amplified sub-millisecond noise remains visible without blocking by
 itself. P99 remains required, validated diagnostic evidence, but valid P99
 values do not affect stability, order-sensitivity, or regression status. Both
-clean, balanced paired durable-write passes must pass before the release tag is
-created.
+clean, balanced paired durable-write passes must pass for a successful local
+diagnostic result; they do not gate creation of the release tag.
 
 This short suite does not claim release-grade P99 qualification. A future
 blocking P99 policy requires a separately designed longer experiment with
 enough tail observations and repeatability to distinguish engine behavior from
 machine-state noise; it is not inferred from this P95 gate.
 
-GitHub's `SQL Release Qualification` workflow retains the two clean Windows,
-Linux, and macOS functional passes and two blocking comparisons of the 18 stable
-master-table rows, but no longer runs the ten disk-sensitive rows on transient
-hosted storage. The hosted comparisons use the same 15% throughput and combined
-25% plus 0.05 ms P95 blocking limits; P99 is required and reported but remains
-diagnostic because the short hosted experiment is not a release-grade tail
-measurement. Normal coordinated benchmark shutdown permits up to 30 seconds for
-workers to observe cancellation on a busy runner; genuinely unresponsive work
-still fails with a bounded diagnostic and is quarantined from cleanup. A normal
-local gate run publishes the
-`csharpdb/local-durable-performance` commit status only after both passes
-succeed. The release workflow requires that success status on the exact tagged
-commit before any package or archive can be published. GitHub CLI authentication
-with permission to create commit statuses is therefore required. The
-`-NoGitHubStatus` switch is for local diagnostics and tests only; a run using it
-cannot qualify a release. The release workflow accepts the status only from the
-login configured in the `LOCAL_DURABLE_ATTESTOR` repository variable, or from
-the repository owner when that variable is unset, and requires a canonical
-`durable-v3` policy attestation containing the previous-release SHA, the frozen
-experiment-design digest, and both pass-report digests. Older policy
-attestations are rejected. This check remains a fail-closed backstop; it
-does not replace the preflight performed by `Publish-ReleaseTag.ps1`.
+GitHub's `SQL Release Qualification` workflow runs one clean Windows, Linux, and
+macOS functional qualification plus one blocking comparison of the 18 stable
+master-table rows on Windows. The hosted job uses `RepeatCount 3` to cover both
+execution orders in one balanced comparison. It uses the same 15% throughput
+and combined 25% plus 0.05 ms P95 blocking limits; P99 is required and reported
+but remains diagnostic because the short hosted experiment is not a
+release-grade tail measurement. Normal coordinated benchmark shutdown permits
+up to 30 seconds for workers to observe cancellation on a busy runner;
+genuinely unresponsive work still fails with a bounded diagnostic and is
+quarantined from cleanup.
 
-The canonical description is exactly
+When explicitly requested, the local wrapper can still publish a diagnostic
+`csharpdb/local-durable-performance` status with the canonical description
 `policy=durable-v3; baseline=<40 lowercase hex>; design=<8 uppercase hex>; reports=<8 uppercase>/<8 uppercase>`.
+That status is retained for audit and tooling compatibility only; the hosted
+release path does not read it.
 
 The existing scheduled perf-guardrail workflow remains report-only and includes
 the durable SQL batching baseline plus its configured micro and diagnostic
@@ -637,8 +627,9 @@ caller-selected directory outside the checkout; it never updates the curated
 `release-core-manifest.json` or introduces generated JSON into the repository.
 
 The same balanced paired mode is also available below for focused A/A, exact-row,
-and order-sensitivity investigations. Those diagnostic forms do not replace
-either blocking local durable-write qualification pass.
+and order-sensitivity investigations. Those focused forms are narrower than the
+optional full two-pass durable-write diagnostic, and neither form is a release
+gate.
 
 ### Focused A/A and exact-row diagnostics
 
@@ -687,9 +678,9 @@ requested fixed wait, failing if shutdown fails. It does not prove that the
 machine or disk is idle, so use a dedicated runner without concurrent builds.
 The release workflow uses a 30-second post-build wait.
 
-A/A and exact-row results are harness diagnostics only. They cannot satisfy the
-previous-release gate, replace either balanced paired durable-write qualification
-pass, promote a baseline, or modify published benchmark numbers.
+A/A and exact-row results are harness diagnostics only. They cannot satisfy or
+replace the hosted balanced paired previous-release comparison, promote a
+baseline, or modify published benchmark numbers.
 
 Run the release guardrail comparison:
 
@@ -715,18 +706,14 @@ pwsh -NoProfile .\tests\CSharpDB.Benchmarks\scripts\Update-BenchmarkReadme.ps1 `
 Promotion checklist:
 
 - The release-core suite was run with `--repeat 3 --repro`.
-- Both hosted-stable previous-release comparisons passed for the candidate
-  commit.
-- Both balanced paired local durable-write comparisons passed with the
-  same hash-verified candidate harness and retained raw evidence, and the exact
-  candidate commit has a successful `csharpdb/local-durable-performance`
-  `durable-v3` status. Blocking P95 and throughput evidence passed; diagnostic
-  P99 was retained but did not determine the result.
-- No comparison row is `INVALID`, `UNSTABLE`, `ORDER-SENSITIVE`, or
-  `REGRESSION`, and every local durable side has at least 30 measured seconds
-  and 10,000 retained latency observations. The observable-process monitor
-  timeline is clean and covers every declared measurement interval; unavailable
-  external-process counter counts are retained as diagnostics.
+- The one hosted-stable previous-release comparison passed for the candidate
+  commit. `RepeatCount 3` supplied three pairs per execution order.
+- No hosted comparison row is `INVALID`, `UNSTABLE`, `ORDER-SENSITIVE`, or
+  `REGRESSION`. Blocking P95 and throughput evidence passed; diagnostic P99 was
+  retained but did not determine the result.
+- Any cited local durable-write evidence is clearly labeled optional diagnostic
+  evidence. It is not a promotion or release requirement, and contaminated
+  local evidence is not promoted.
 - The release guardrail result is clean.
 - The manifest points only to the approved median artifacts.
 - The generated README diff only changes benchmark numbers, source artifacts, or snapshot metadata.
@@ -741,7 +728,7 @@ Related files:
 - [SQLITE_COMPARISON.md](SQLITE_COMPARISON.md): focused same-runner CSharpDB vs SQLite comparison.
 - `release-core-manifest.json`: source-of-truth manifest for published README tables.
 - `scripts/Compare-ReleaseCore.ps1`: strict same-runner release comparison.
-- `scripts/Test-LocalDurablePerformance.ps1`: sequential two-pass local release gate.
+- `scripts/Test-LocalDurablePerformance.ps1`: sequential two-pass local durable-write diagnostic.
 - `scripts/Test-PreviousReleasePerformance.ps1`: clean two-revision benchmark runner.
 - `scripts/Watch-LocalPerformanceEnvironment.ps1`: fail-closed observable external-load evidence monitor.
 - `scripts/Update-BenchmarkReadme.ps1`: generated-results updater.

--- a/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
@@ -82,7 +82,7 @@ public sealed class DaemonPackagingAssetsTests
         Assert.DoesNotContain("secrets: inherit", trigger);
         Assert.DoesNotContain("waive_local_durable", trigger);
         Assert.Contains("contents: write", trigger);
-        Assert.Contains("statuses: read", trigger);
+        Assert.DoesNotContain("statuses:", trigger);
         Assert.Contains("id-token: write", trigger);
         Assert.Contains("cancel-in-progress: false", trigger);
 
@@ -92,7 +92,7 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
-    public void SqlReleaseQualificationWorkflow_RunsFunctionalAndHostedStablePerformancePasses()
+    public void SqlReleaseQualificationWorkflow_RunsOneFunctionalPassPerOsAndOneHostedPairedBenchmark()
     {
         string repoRoot = FindRepoRoot();
         string workflow = File.ReadAllText(Path.Combine(
@@ -109,13 +109,13 @@ public sealed class DaemonPackagingAssetsTests
         Assert.Contains("- ubuntu-latest", normalized);
         Assert.Contains("- windows-latest", normalized);
         Assert.Contains("- macos-latest", normalized);
-        Assert.Contains(
-            """
-            qualification_pass:
-                      - 1
-                      - 2
-            """.ReplaceLineEndings("\n"),
-            normalized);
+        Assert.DoesNotContain("qualification_pass:", normalized);
+        Assert.Equal(
+            2,
+            System.Text.RegularExpressions.Regex.Matches(
+                normalized,
+                @"(?m)^\s+-QualificationPass 1 `$").Count);
+        Assert.DoesNotContain("-QualificationPass 2", normalized);
         Assert.Contains("Test-SqlReleaseQualification.ps1", normalized);
         Assert.Contains("${{ runner.temp }}", normalized);
         Assert.Equal(
@@ -127,7 +127,13 @@ public sealed class DaemonPackagingAssetsTests
             "sql-release-qualification-${{ inputs.release_commit || github.sha }}",
             normalized);
         Assert.Contains(
+            "sql-release-qualification-${{ inputs.release_commit || github.sha }}-${{ matrix.os }}-attempt-${{ github.run_attempt }}",
+            normalized);
+        Assert.Contains(
             "previous-release-hosted-stable-performance-${{ inputs.release_commit || github.sha }}",
+            normalized);
+        Assert.Contains(
+            "previous-release-hosted-stable-performance-${{ inputs.release_commit || github.sha }}-attempt-${{ github.run_attempt }}",
             normalized);
         Assert.DoesNotContain(
             "    env:\n      QUALIFICATION_OUTPUT: ${{ runner.temp }}",
@@ -250,7 +256,7 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
-    public void ReleaseWorkflow_GatesEveryPublisherOnFunctionalHostedAndLocalQualification()
+    public void ReleaseWorkflow_GatesEveryPublisherOnExactTargetFunctionalAndHostedQualification()
     {
         string repoRoot = FindRepoRoot();
         string workflow = File.ReadAllText(Path.Combine(
@@ -272,27 +278,20 @@ public sealed class DaemonPackagingAssetsTests
         Assert.Contains(
             "previous_release_ref: ${{ inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}",
             normalized);
-        Assert.Contains("verify-local-durable-performance:", normalized);
-        Assert.Contains("name: Verify local durable performance qualification", normalized);
-        Assert.Contains("statuses: read", normalized);
-        Assert.Contains("LOCAL_DURABLE_ATTESTOR", normalized);
-        Assert.Contains("github.repository_owner", normalized);
+        Assert.Contains("verify-release-target:", normalized);
+        Assert.Contains("name: Verify exact release target", normalized);
+        Assert.DoesNotContain("statuses:", normalized);
+        Assert.DoesNotContain("LOCAL_DURABLE_ATTESTOR", normalized);
         Assert.Contains("- name: Checkout exact release source", normalized);
         Assert.Contains("uses: actions/checkout@v7", normalized);
         Assert.Contains(
-            "./scripts/Test-LocalDurableStatus.ps1",
-            normalized);
-        Assert.Contains(
             """
-                  - name: Require a successful matching-commit local performance status
+                  - name: Require the exact existing release tag and commit
                     shell: pwsh
             """.ReplaceLineEndings("\n"),
             normalized);
+        Assert.DoesNotContain("Test-LocalDurableStatus.ps1", normalized);
         Assert.DoesNotContain("waive_local_durable", normalized);
-        Assert.Contains("-Commit '${{ inputs.release_commit }}'", normalized);
-        Assert.Contains("-ReleaseVersion '${{ inputs.release_tag }}'", normalized);
-        Assert.Contains("-GitHubRepository '${{ github.repository }}'", normalized);
-        Assert.Contains("-ExpectedCreator $env:EXPECTED_STATUS_CREATOR", normalized);
         Assert.DoesNotContain("github.ref_name", normalized);
         Assert.DoesNotContain("github.sha", normalized);
         Assert.Equal(
@@ -301,14 +300,20 @@ public sealed class DaemonPackagingAssetsTests
                 normalized,
                 @"(?m)^          ref: \$\{\{ inputs\.release_commit \}\}$").Count);
         Assert.Equal(
-            5,
+            4,
             System.Text.RegularExpressions.Regex.Matches(
                 normalized,
                 @"(?m)^    needs: build-and-test$").Count);
+        Assert.Contains(
+            "needs: [build-and-test, migration-archives, native-aot, daemon-archives, admin-desktop-archive]",
+            normalized);
+        Assert.Contains(
+            "needs: [publish-nuget, migration-archives, native-aot, daemon-archives, admin-desktop-archive]",
+            normalized);
         Assert.Single(
             System.Text.RegularExpressions.Regex.Matches(
                 normalized,
-                @"(?m)^    needs: verify-local-durable-performance$"));
+                @"(?m)^    needs: verify-release-target$"));
     }
 
     [Fact]
@@ -362,8 +367,8 @@ public sealed class DaemonPackagingAssetsTests
         Assert.DoesNotContain("secrets: inherit", trigger);
 
         Assert.Contains("- name: Require the exact existing release tag and commit", implementation);
-        Assert.Contains("- name: Require a successful matching-commit local performance status", implementation);
-        Assert.Contains("./scripts/Test-LocalDurableStatus.ps1", implementation);
+        Assert.DoesNotContain("matching-commit local performance status", implementation);
+        Assert.DoesNotContain("Test-LocalDurableStatus.ps1", implementation);
         Assert.DoesNotContain("workflow_dispatch", implementation);
         Assert.DoesNotContain("waive", implementation, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("7aeb66031237283c3643e73849618bf299729ed6", implementation);

--- a/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
@@ -226,22 +226,17 @@ public sealed class ReleaseStatusScriptTests
     }
 
     [Fact]
-    public void PublishReleaseTag_RequiresExactCleanMainStatusBeforeExactTagPush()
+    public void PublishReleaseTag_RequiresExactCleanMainAndVersionBeforeExactTagPush()
     {
         string repoRoot = FindRepoRoot();
         string publisher = File.ReadAllText(Path.Combine(
             repoRoot,
             "scripts",
             "Publish-ReleaseTag.ps1"));
-        string verifier = File.ReadAllText(Path.Combine(
+        string tagValidator = File.ReadAllText(Path.Combine(
             repoRoot,
             "scripts",
-            "Test-LocalDurableStatus.ps1"));
-        string carryForwardPublisher = File.ReadAllText(Path.Combine(
-            repoRoot,
-            "scripts",
-            "Publish-DurableCarryForwardStatus.ps1"));
-
+            "Test-ReleaseTag.ps1"));
         Assert.Contains(
             "status', '--porcelain=v1', '--untracked-files=all",
             publisher);
@@ -250,79 +245,51 @@ public sealed class ReleaseStatusScriptTests
         Assert.Contains("refs/heads/main:refs/remotes/origin/main", publisher);
         Assert.Contains("origin/main^{commit}", publisher);
         Assert.Contains("local main to equal origin/main exactly", publisher);
-        Assert.Contains("Test-LocalDurableStatus.ps1", publisher);
-        Assert.Contains("-Commit $headCommit", publisher);
-        Assert.Contains("exact commit $headCommit", publisher);
-        Assert.Contains("Test-LocalDurablePerformance.ps1", publisher);
-        Assert.Contains("-CandidateRef $headCommit", publisher);
+        Assert.Contains("$packageVersion -cne $releaseVersion", publisher);
+        Assert.Contains("$currentMainCommit -cne $headCommit", publisher);
+        Assert.Contains("Test-ReleaseTag.ps1", publisher);
+        Assert.Contains(
+            "& $tagValidator -Version $releaseTag -TagCommit $headCommit",
+            publisher);
         Assert.Contains("refs/tags/$releaseTag`:refs/tags/$releaseTag", publisher);
         Assert.DoesNotContain("--force", publisher, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("parents", verifier, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("exit 0", verifier, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(
-            "^policy=durable-v3; baseline=[0-9a-f]{40}; design=[0-9A-F]{8}; " +
-            "reports=[0-9A-F]{8}/[0-9A-F]{8}$",
-            verifier);
-        Assert.Contains(
-            "csharpdb/local-durable-performance-carry-forward-v4.4.0",
-            verifier);
-        Assert.Contains(
-            "61e4d025087f4fae7208381288fba6115f0d1e30",
-            verifier);
-        Assert.Contains("51598901859", verifier);
-        Assert.Contains(
-            "policy=durable-v2; baseline=7880dad112f3fdf011c134db2f8a08ec646ee326;",
-            verifier);
-        Assert.Contains("ee1ea0e996fc22e093e950ec32e14543cd5caeca", verifier);
-        Assert.Contains("51664261883", verifier);
-        Assert.Contains("local durable qualification failed", verifier);
-        Assert.Contains(
-            "src/CSharpDB.Migration/MigrationRejectArtifactPublication.cs",
-            verifier);
-        Assert.Contains("'merge-base', '--is-ancestor'", verifier);
-        Assert.Contains("'--name-status'", verifier);
-        Assert.Contains("'--no-renames'", verifier);
-        Assert.Contains("8e43642cfcd3e523046302b99253673ceb5a33ce", verifier);
-        Assert.Contains("bee4859c14381fc2dbe209e2e0c84909dc98adc9", verifier);
+        Assert.DoesNotContain("Test-LocalDurableStatus.ps1", publisher);
+        Assert.DoesNotContain("Test-LocalDurablePerformance.ps1", publisher);
+        Assert.DoesNotContain("Publish-DurableCarryForwardStatus.ps1", publisher);
+        Assert.DoesNotContain("ConfirmDedicatedFixedSsd", publisher);
+        Assert.DoesNotContain("ApproveDurableV2CarryForward", publisher);
+        Assert.DoesNotContain("csharpdb/local-durable-performance", publisher);
+        Assert.DoesNotContain("Test-Documentation.ps1", tagValidator);
 
-        Assert.Contains("Authenticated GitHub user", carryForwardPublisher);
-        Assert.Contains("statuses/$headCommit", carryForwardPublisher);
-        Assert.Contains("Invoke-StatusVerifier -EligibilityOnly", carryForwardPublisher);
-        Assert.Contains("Publish-DurableCarryForwardStatus.ps1", publisher);
-        Assert.Contains("-ApproveDurableV2CarryForward", publisher);
-        Assert.Contains("mutually exclusive", publisher);
-        Assert.Contains("-ReleaseVersion $releaseVersion", publisher);
-        Assert.DoesNotContain("refs/tags/", carryForwardPublisher, StringComparison.Ordinal);
-
-        int sourceEvidence = carryForwardPublisher.IndexOf(
-            "Invoke-StatusVerifier -EligibilityOnly",
+        int exactMainValidation = publisher.IndexOf(
+            "$headCommit = Get-ExactCurrentMainCommit",
             StringComparison.Ordinal);
-        int publishStatus = carryForwardPublisher.IndexOf(
-            "--method POST",
-            StringComparison.Ordinal);
-        Assert.True(sourceEvidence >= 0);
-        Assert.True(
-            publishStatus > sourceEvidence,
-            "The source evidence must be verified before a carry-forward status is published.");
-
-        int initialVerifier = publisher.IndexOf(
-            "Invoke-StatusVerifier",
-            publisher.IndexOf("$hasReusableStatus", StringComparison.Ordinal),
+        int versionValidation = publisher.IndexOf(
+            "$packageVersion -cne $releaseVersion",
             StringComparison.Ordinal);
         int localTagMutation = publisher.IndexOf(
             "'tag', $releaseTag, $headCommit",
+            StringComparison.Ordinal);
+        int tagValidation = publisher.IndexOf(
+            "& $tagValidator -Version $releaseTag -TagCommit $headCommit",
             StringComparison.Ordinal);
         int exactTagPush = publisher.IndexOf(
             "refs/tags/$releaseTag`:refs/tags/$releaseTag",
             localTagMutation,
             StringComparison.Ordinal);
 
-        Assert.True(initialVerifier >= 0, "The exact status must be verified.");
+        Assert.True(exactMainValidation >= 0, "The exact main commit must be validated.");
         Assert.True(
-            localTagMutation > initialVerifier,
-            "The exact status must be verified before a local tag is created.");
+            versionValidation > exactMainValidation,
+            "The package version must be validated after resolving exact main.");
         Assert.True(
-            exactTagPush > localTagMutation,
+            localTagMutation > versionValidation,
+            "The package version must be validated before a local tag is created.");
+        Assert.True(
+            tagValidation > localTagMutation,
+            "The exact local tag must be validated before it is pushed.");
+        Assert.True(
+            exactTagPush > tagValidation,
             "Only the exact validated tag may be pushed after local validation.");
     }
 


### PR DESCRIPTION
## Summary

Prepare CSharpDB 4.5.1 as the first published release in the 4.5 line. The
`v4.5.0` Git tag is retained as release-attempt history, but it was not
published as a release.

### Pull-request delta: current main to the simplified v4.5.1 release flow

- Simplify release tagging to exact clean-main, package-version, and tag
  validation followed by an exact tag push. Remove the publisher's dependency
  on local durable status, carry-forward waivers, local benchmark execution,
  and GitHub commit-status permissions.
- Consolidate blocking qualification in the hosted release workflow: one clean
  functional qualification per supported operating system and one balanced
  paired Windows hosted-stable benchmark. `RepeatCount 3` supplies three pairs
  per execution order in that single performance job.
- Require all archive jobs to complete before NuGet publication, retain the
  existing exact-target and publication safeguards, and update workflow
  contract tests and release documentation for the simpler gate. Local durable
  tooling remains available only as an optional diagnostic.

### Tagged-code delta: v4.5.0 to v4.5.1

- Include the focused coercion-performance fix and its allocation and
  diagnostic-message regression tests.
- Add the separately digested current `4.5.1` migration capability catalog
  while retaining immutable 4.5.0, 4.4.0, and 4.3.0 catalogs for deterministic
  replay. Update release metadata for the new tag and serialize test-project
  execution during release qualification.
- Retire the one-time v4.5.0 recovery dispatch and qualification waiver without
  moving or recreating the v4.5.0 tag.
- Carry forward generic exact tag/commit checks, fail-closed secret and
  qualification handling, package-authentication safeguards, and
  partial-publication retry guards. Simplify the blocking gate to the hosted
  functional and balanced paired performance qualifications described above.

### Public delta: v4.4.0 to v4.5.1

Because v4.5.0 was never published, the public release delta includes the full
4.5 feature set. It adds 25 persisted logical SQL type kinds plus generated
`ROWVERSION`, exact `DECIMAL`, declared facets, 32-bit `INTEGER` semantics,
Booleans, bit strings, UUID, temporal and interval types, JSON, XML, and
canonical type metadata across the engine, providers, transports, archives,
and migration tooling.

Bare `TIMESTAMP` now aliases the generated database-wide `ROWVERSION` token;
offset-free temporal values use `DATETIME2` and offset-aware values use
`DATETIMEOFFSET`. The release also adds bounded `XML_EXISTS`/`XMLEXISTS` and
`XML_VALUE` XPath 1.0 querying with secure parsing and explicit resource
limits. Compatibility handling preserves legacy descriptor-less integer data
as `BIGINT` and upgrades legacy rowversion allocation safely.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

None linked.

## Testing

Validation for this release-flow simplification is complete locally. The
tag-triggered hosted release qualification is not claimed yet.

- [ ] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: invalid release state and
  unsupported workflow paths)
- [x] Manual verification performed (if applicable)

This pull request:

- Focused workflow and publisher contract tests passed: **31/31 passed**, covering
  the exact-tag publisher preflight, the single hosted qualification shape, the
  pinned v4.5.1 baseline, removal of status/waiver paths, and publication
  ordering.
- The focused migration release-asset workflow contract passed: **1/1 passed**.
- Modified PowerShell release scripts passed parser validation: **2/2 passed**.
- Modified GitHub Actions workflow files passed YAML parsing: **3/3 passed**.
- Public documentation validation passed with
  `./scripts/Test-Documentation.ps1`, and the changed files passed the Git
  whitespace/error check.
- Final hosted release qualification remains pending and must pass before
  release.

Earlier v4.5.1 product evidence, retained as tagged/public release context:

- Both paired performance passes used exact v4.4.0 commit
  `86e25435f3c64f47afe2a776c6b03cbe84e56858` as the previous-release baseline
  and exact candidate commit `b2ba3971115bf2b69fe1989ce9a6617fa173196e`
  for scenario `Storage_InMemory_Sql_Batch100_5s`.
- SQL type-coercion and integer-semantics tests passed: **7/7 passed**.
  Coverage includes the allocation-free success path, exact qualified and
  unqualified failure messages, integer ranges, arithmetic, and identity
  exhaustion.
- Paired performance pass 1: **PASS**, with a combined throughput regression
  of **6.77%** and order-stratum effects of **5.43% / 8.08%**.
- Paired performance pass 2: **PASS**, with a combined throughput regression
  of **4.81%** and order-stratum effects of **5.59% / 4.02%**.
- Both performance passes reported **0 invalid**, **0 unstable**,
  **0 order-sensitive**, and **0 regression** rows.
- The Release solution build passed with **0 warnings** and **0 errors**.
- The serialized full solution matrix passed across 24 test projects:
  **6,023 passed**, **4 expected live/opt-in skips**, and **0 failed**.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- Review this branch's release-flow simplification separately from the tagged
  and public release contents. The public v4.4.0-to-v4.5.1 delta includes all
  previously prepared 4.5 SQL type and XML functionality because v4.5.0 was
  not published.
- The earlier performance fix only defers construction of assignment-error
  context until an error occurs. It does not bypass declared-type coercion,
  integer range validation, or primary-key validation.
- The `4.5.1` migration capability catalog is current. The immutable `4.5.0`
  catalog is retained only as deterministic replay history; its presence does
  not indicate that a v4.5.0 release was published.
- `Publish-ReleaseTag.ps1` does not run or require local performance evidence.
  The tag-triggered hosted workflow must pass before package or release
  publication begins.
- Do not move or recreate the v4.5.0 tag. Publish v4.5.1 from its own exact tag
  only after the remaining full validation succeeds.
