### PR TITLE
Fix Windows published-host smoke cleanup race

### DIFF
--- a/scripts/CSharpDbHostQualificationCleanup.ps1
+++ b/scripts/CSharpDbHostQualificationCleanup.ps1
@@ -1,0 +1,49 @@
+function Remove-CSharpDbDirectoryWithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$LiteralPath,
+
+        [ValidateRange(0, 60000)]
+        [int]$TimeoutMilliseconds = 10000,
+
+        [ValidateRange(1, 10000)]
+        [int]$RetryDelayMilliseconds = 250
+    )
+
+    if (-not (Test-Path -LiteralPath $LiteralPath)) {
+        return
+    }
+
+    if (-not $IsWindows) {
+        Remove-Item -LiteralPath $LiteralPath -Recurse -Force
+        return
+    }
+
+    $timer = [Diagnostics.Stopwatch]::StartNew()
+    while ($true) {
+        try {
+            Remove-Item `
+                -LiteralPath $LiteralPath `
+                -Recurse `
+                -Force `
+                -ErrorAction Stop
+            return
+        }
+        catch {
+            if (-not (Test-Path -LiteralPath $LiteralPath)) {
+                return
+            }
+            if ($timer.ElapsedMilliseconds -ge $TimeoutMilliseconds) {
+                throw
+            }
+
+            $remainingMilliseconds =
+                $TimeoutMilliseconds - [int]$timer.ElapsedMilliseconds
+            $delayMilliseconds = [Math]::Min(
+                $RetryDelayMilliseconds,
+                [Math]::Max(1, $remainingMilliseconds))
+            Start-Sleep -Milliseconds $delayMilliseconds
+        }
+    }
+}

--- a/scripts/Test-CSharpDbPublishedHostObservability.ps1
+++ b/scripts/Test-CSharpDbPublishedHostObservability.ps1
@@ -26,6 +26,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+. (Join-Path $PSScriptRoot 'CSharpDbHostQualificationCleanup.ps1')
 $projectPath = Join-Path $repoRoot "src/CSharpDB.$HostName/CSharpDB.$HostName.csproj"
 $executableName = if ($Runtime -eq 'win-x64') {
     "CSharpDB.$HostName.exe"
@@ -267,7 +268,7 @@ catch {
     }
     if (-not $KeepWorkingDirectory -and
         (Test-Path -LiteralPath $qualificationRoot)) {
-        Remove-Item -LiteralPath $qualificationRoot -Recurse -Force
+        Remove-CSharpDbDirectoryWithRetry -LiteralPath $qualificationRoot
     }
     throw
 }
@@ -376,13 +377,13 @@ finally {
         Write-Host "Host qualification working directory retained at $qualificationRoot"
     }
     elseif (Test-Path -LiteralPath $qualificationRoot) {
-        Remove-Item -LiteralPath $qualificationRoot -Recurse -Force
+        Remove-CSharpDbDirectoryWithRetry -LiteralPath $qualificationRoot
     }
 
     if (-not $KeepWorkingDirectory -and
         $createdPublishRoot -and
         -not [string]::IsNullOrWhiteSpace($publishRoot) -and
         (Test-Path -LiteralPath $publishRoot)) {
-        Remove-Item -LiteralPath $publishRoot -Recurse -Force
+        Remove-CSharpDbDirectoryWithRetry -LiteralPath $publishRoot
     }
 }

--- a/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
@@ -70,6 +70,8 @@ public sealed class DaemonPackagingAssetsTests
         Assert.Contains("/api/diagnostics/runtime", qualifier);
         Assert.Contains("private database path canary", qualifier);
         Assert.Contains("Stop-QualifiedHost", qualifier);
+        Assert.Contains("CSharpDbHostQualificationCleanup.ps1", qualifier);
+        Assert.Contains("Remove-CSharpDbDirectoryWithRetry", qualifier);
         Assert.Contains("orderly shutdown", qualifier, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("did not complete orderly shutdown", qualifier);
         Assert.Contains("cleanup only", qualifier, StringComparison.OrdinalIgnoreCase);

--- a/tests/CSharpDB.Daemon.Tests/PublishedHostCleanupScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/PublishedHostCleanupScriptTests.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics;
+
+namespace CSharpDB.Daemon.Tests;
+
+public sealed class PublishedHostCleanupScriptTests
+{
+    [Fact]
+    public async Task WindowsCleanup_RetriesUntilTransientFileLockIsReleased()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        string temporaryRoot = CreateTemporaryRoot();
+        string lockedFile = Path.Combine(temporaryRoot, "CSharpDB.Daemon.exe");
+        await File.WriteAllTextAsync(lockedFile, "fixture", Ct);
+
+        try
+        {
+            using FileStream lockStream = File.Open(
+                lockedFile,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None);
+            using Process process = StartCleanupHarness(temporaryRoot, timeoutMilliseconds: 5000);
+
+            Assert.Equal("READY", await ReadLineAsync(process));
+            await Task.Delay(250, Ct);
+            Assert.False(process.HasExited);
+
+            lockStream.Dispose();
+            await process.WaitForExitAsync(Ct);
+            string stdout = await process.StandardOutput.ReadToEndAsync(Ct);
+            string stderr = await process.StandardError.ReadToEndAsync(Ct);
+
+            Assert.True(process.ExitCode == 0, stdout + Environment.NewLine + stderr);
+            Assert.Contains("DELETED", stdout, StringComparison.Ordinal);
+            Assert.False(Directory.Exists(temporaryRoot));
+        }
+        finally
+        {
+            TryDeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
+    [Fact]
+    public async Task WindowsCleanup_FailsClosedWhenFileLockOutlivesDeadline()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        string temporaryRoot = CreateTemporaryRoot();
+        string lockedFile = Path.Combine(temporaryRoot, "CSharpDB.Daemon.exe");
+        await File.WriteAllTextAsync(lockedFile, "fixture", Ct);
+
+        try
+        {
+            using FileStream lockStream = File.Open(
+                lockedFile,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None);
+            using Process process = StartCleanupHarness(temporaryRoot, timeoutMilliseconds: 300);
+
+            Assert.Equal("READY", await ReadLineAsync(process));
+            await process.WaitForExitAsync(Ct);
+            string stdout = await process.StandardOutput.ReadToEndAsync(Ct);
+            string stderr = await process.StandardError.ReadToEndAsync(Ct);
+
+            Assert.NotEqual(0, process.ExitCode);
+            Assert.DoesNotContain("DELETED", stdout, StringComparison.Ordinal);
+            Assert.True(Directory.Exists(temporaryRoot), stderr);
+        }
+        finally
+        {
+            TryDeleteTemporaryRoot(temporaryRoot);
+        }
+    }
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static Process StartCleanupHarness(string targetPath, int timeoutMilliseconds)
+    {
+        string helperPath = Path.Combine(
+            FindRepoRoot(),
+            "scripts",
+            "CSharpDbHostQualificationCleanup.ps1");
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = "pwsh",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        foreach (string argument in new[]
+        {
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "& { param($helperPath, $targetPath, $timeoutMilliseconds) " +
+                ". $helperPath; Write-Output 'READY'; " +
+                "Remove-CSharpDbDirectoryWithRetry -LiteralPath $targetPath " +
+                "-TimeoutMilliseconds $timeoutMilliseconds -RetryDelayMilliseconds 50; " +
+                "Write-Output 'DELETED' }",
+            helperPath,
+            targetPath,
+            timeoutMilliseconds.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        })
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return Process.Start(startInfo) ??
+            throw new InvalidOperationException("Could not start the cleanup test harness.");
+    }
+
+    private static async Task<string?> ReadLineAsync(Process process)
+    {
+        using CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(Ct);
+        timeout.CancelAfter(TimeSpan.FromSeconds(10));
+        return await process.StandardOutput.ReadLineAsync(timeout.Token);
+    }
+
+    private static string CreateTemporaryRoot()
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            "csharpdb-host-cleanup-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDeleteTemporaryRoot(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "CSharpDB.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test base directory.");
+    }
+}


### PR DESCRIPTION
## Summary

- Retry temporary published-host directory removal on Windows when process teardown leaves a short-lived executable lock.
- Keep Linux and macOS cleanup behavior unchanged and fail closed if the Windows lock outlives the 10-second bound.
- Add deterministic coverage for both a transient lock that clears and a persistent lock that exceeds the deadline.

The Windows Daemon observability job in [CI run 31664526083](https://github.com/MaxAkbar/CSharpDB/actions/runs/31664526083) completed every host check successfully, but failed afterward when cleanup immediately attempted to delete `CSharpDB.Daemon.exe` while Windows still held it open.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance
- [ ] Tests only

## Related Issues

Relates to the failed `Published Daemon observability (win-x64)` job in CI run 31664526083.

## Testing

- [ ] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Validation performed:

- PowerShell parser checks passed for the cleanup helper and published-host qualification script.
- Focused Daemon packaging and cleanup tests passed: 20/20.
- The exact published Windows Daemon observability qualification passed end to end.
- Independent source review found no blocking issues.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [ ] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

The retry applies only to Windows directory cleanup. It retries every 250 milliseconds for at most 10 seconds and rethrows the final deletion error if the lock persists. Non-Windows cleanup remains a single immediate attempt. This changes qualification cleanup only; the observability host checks and shutdown assertions are unchanged.
