### PR TITLE
Prepare v4.6.1 release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,10 @@ jobs:
     with:
       release_version: ${{ inputs.release_tag }}
       release_commit: ${{ inputs.release_commit }}
-      # v4.5.0 was tagged but never published, so v4.5.1 must measure the
-      # cumulative public delta from the last published release, v4.4.0.
-      previous_release_ref: ${{ inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}
+      # v4.6.0 was tagged but never published, so v4.6.1 must measure from the
+      # published v4.5.1 commit. v4.5.0 was also tagged but never published, so
+      # retain the equivalent v4.5.1-to-v4.4.0 case.
+      previous_release_ref: ${{ inputs.release_tag == 'v4.6.1' && '2f141433298bcd3137e2bcaa2930c796c4222092' || inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}
 
   publish-nuget:
     name: Publish NuGet

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,18 @@
 # What's New
 
-## CSharpDB 4.6.0
+## CSharpDB 4.6.1
 
-CSharpDB 4.6.0 adds an end-to-end observability and diagnostics platform for
+CSharpDB 4.6.1 adds an end-to-end observability and diagnostics platform for
 embedded databases, API and daemon hosts, sharded clients, and CSharpDB Admin.
 The release introduces safe structured events, bounded runtime diagnostics,
 OpenTelemetry traces and metrics, Prometheus export, health and readiness
 signals, and a dedicated Admin workspace while keeping exporter dependencies
 out of the database engine.
+
+The `v4.6.0` tag is retained as release-attempt history, but its workflow
+stopped before any NuGet package or GitHub Release was published because the
+tagged source still declared package version 4.5.1. Version 4.6.1 carries the
+intended 4.6 release contents from a new, correctly versioned tag.
 
 ### Observability Contracts and Safe Defaults
 

--- a/docs/releases/v4.6.1-pr-notes.md
+++ b/docs/releases/v4.6.1-pr-notes.md
@@ -1,0 +1,77 @@
+## Summary
+
+Prepare CSharpDB 4.6.1 as the first publishable release in the 4.6 line. The
+`v4.6.0` Git tag is retained as release-attempt history, but its workflow
+failed the tag-to-package-version check before any NuGet package or GitHub
+Release was published.
+
+### Recovery delta: v4.6.0 tag to v4.6.1
+
+- Advance the package, migration capability catalog, release notes, and
+  migration-archive default to 4.6.1 so a new tag can pass the release target
+  and package identity checks.
+- Preserve the failed `v4.6.0` tag exactly where it is. Do not move, recreate,
+  or publish from it.
+- Pin the v4.6.1 hosted comparison to exact published v4.5.1 commit
+  `2f141433298bcd3137e2bcaa2930c796c4222092`. Because v4.6.0 was not
+  published, it is not a valid previous-release performance baseline.
+- Retain the historical v4.5.1 exception that compares against published
+  v4.4.0 because v4.5.0 was also tagged but not published.
+
+### Public delta: v4.5.1 to v4.6.1
+
+The public release delta is the intended 4.6 observability and diagnostics
+feature set described in `RELEASE_NOTES.md`. It includes the BCL-only
+observability contracts, safe structured events, bounded runtime diagnostics,
+OpenTelemetry and Prometheus integration, health and readiness endpoints,
+daemon gRPC health support, and the Admin observability workspace.
+
+The recovery changes do not add a second product feature delta beyond those
+4.6 contents. They correct release identity and baseline selection so the
+normal fail-closed workflow can qualify and publish a new immutable tag.
+
+## Type of Change
+
+- [x] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [x] Documentation update
+- [x] Refactor / maintenance
+- [ ] Tests only
+
+## Related Issues
+
+None linked.
+
+## Testing
+
+Local validation covers the recovery metadata and release contracts. The
+tag-triggered hosted release qualification is not claimed by this pull request
+and must pass for the exact v4.6.1 tag before publication begins.
+
+- [ ] `dotnet build CSharpDB.slnx`
+- [x] Relevant release workflow and packaging contract tests executed
+- [x] Modified PowerShell scripts passed parser validation
+- [x] Modified workflow YAML passed parser validation
+- [x] Git whitespace/error check passed
+
+## Checklist
+
+- [x] I followed the project style and conventions.
+- [x] I added or updated tests for behavior changes.
+- [x] I covered the failed-tag recovery path.
+- [x] I updated release-facing documentation.
+- [x] I verified no sensitive data was added.
+
+## Notes for Reviewers
+
+- Treat `v4.6.0` only as immutable failed-attempt history. Its existence does
+  not indicate a published 4.6 release.
+- The exact v4.5.1 commit is deliberately hard-coded only for the v4.6.1
+  recovery comparison; ordinary future tags continue to use the workflow's
+  normal previous-release resolution.
+- Create and push `v4.6.1` only through `Publish-ReleaseTag.ps1` after this
+  recovery change is merged to a clean, current `main` and all local
+  qualification is complete.
+- NuGet publication and GitHub Release creation remain downstream of all
+  hosted qualification and archive jobs.

--- a/scripts/Publish-CSharpDbMigrationRelease.ps1
+++ b/scripts/Publish-CSharpDbMigrationRelease.ps1
@@ -56,7 +56,7 @@ $Version = (Read-Host 'Release version without the v prefix').Trim()
 #>
 [CmdletBinding()]
 param(
-    [string] $Version = '4.5.1',
+    [string] $Version = '4.6.1',
 
     [ValidateSet('win-x64', 'linux-x64', 'osx-arm64')]
     [string[]] $Runtime = @(

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -173,8 +173,10 @@ verifies that the existing tag resolves to the supplied exact commit. It then
 runs one clean functional qualification on each supported operating system and
 one balanced paired hosted-stable performance comparison on Windows. The
 performance job uses `RepeatCount 3`, which covers both previous/candidate
-execution orders in one job. For v4.5.1, the hosted comparison is pinned to the
-last published v4.4.0 commit because v4.5.0 was tagged but not published.
+execution orders in one job. Recovery tags use the last published release as
+their explicit baseline: v4.6.1 is pinned to the exact published v4.5.1 commit
+because v4.6.0 was tagged but not published, while the existing v4.5.1
+exception remains pinned to v4.4.0 because v4.5.0 was likewise not published.
 
 Publication starts only after the hosted gates and all release-archive jobs
 succeed. The workflow publishes the NuGet packages, daemon archives for

--- a/src/CSharpDB.Migration/CSharpDB.Migration.csproj
+++ b/src/CSharpDB.Migration/CSharpDB.Migration.csproj
@@ -32,6 +32,8 @@
                       LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.5.0.json" />
     <EmbeddedResource Include="Capabilities\csharpdb-4.5.1.json"
                       LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.5.1.json" />
+    <EmbeddedResource Include="Capabilities\csharpdb-4.6.1.json"
+                      LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.6.1.json" />
   </ItemGroup>
 
 </Project>

--- a/src/CSharpDB.Migration/CSharpDbCapabilityCatalog.cs
+++ b/src/CSharpDB.Migration/CSharpDbCapabilityCatalog.cs
@@ -102,7 +102,7 @@ public sealed record CSharpDbCapabilityCatalog
 
 public static class CSharpDbCapabilityCatalogLoader
 {
-    public const string CurrentTargetVersion = "4.5.1";
+    public const string CurrentTargetVersion = "4.6.1";
     public const string Format = "csharpdb-target-capabilities/v1";
 
     private static readonly JsonSerializerOptions s_options = CreateOptions();
@@ -112,6 +112,7 @@ public static class CSharpDbCapabilityCatalogLoader
             ["4.3.0"] = CreateCatalog("4.3.0"),
             ["4.4.0"] = CreateCatalog("4.4.0"),
             ["4.5.0"] = CreateCatalog("4.5.0"),
+            ["4.5.1"] = CreateCatalog("4.5.1"),
             [CurrentTargetVersion] = CreateCatalog(CurrentTargetVersion),
         };
 

--- a/src/CSharpDB.Migration/Capabilities/csharpdb-4.6.1.json
+++ b/src/CSharpDB.Migration/Capabilities/csharpdb-4.6.1.json
@@ -1,0 +1,376 @@
+{
+  "format": "csharpdb-target-capabilities/v1",
+  "targetCSharpDbVersion": "4.6.1",
+  "surface": "local-typed-engine",
+  "maxIdentifierLength": 128,
+  "identifiersCaseInsensitive": true,
+  "quotedIdentifiers": true,
+  "engineEnforcesMappedColumnType": true,
+  "valueTypes": [
+    {
+      "type": "null",
+      "isRuntimeValue": true,
+      "isColumnType": false,
+      "representation": "Runtime null tag; not a declarable persistent SQL column type."
+    },
+    {
+      "type": "integer",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Shared signed 64-bit physical carrier. Logical INTEGER is signed 32-bit, BIGINT is signed 64-bit, and BOOLEAN is canonical 0/1."
+    },
+    {
+      "type": "real",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "IEEE 754 binary64 floating-point value."
+    },
+    {
+      "type": "text",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Persisted UTF-8 text."
+    },
+    {
+      "type": "blob",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Raw byte sequence."
+    },
+    {
+      "type": "decimal",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Exact base-10 decimal with an Int64 coefficient and scale up to 18 digits of precision."
+    }
+  ],
+  "rules": [
+    {
+      "ruleId": "CSDB-OBJ-DATABASE-001",
+      "objectKind": "database",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "A migration target is one local CSharpDB database."
+    },
+    {
+      "ruleId": "CSDB-OBJ-NAMESPACE-001",
+      "objectKind": "namespace",
+      "feature": "object",
+      "status": "compatibleWithRewrite",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "CSharpDB has no source-style namespace catalog; names must be flattened deterministically."
+    },
+    {
+      "ruleId": "CSDB-OBJ-TABLE-001",
+      "objectKind": "table",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Typed SQL tables are supported."
+    },
+    {
+      "ruleId": "CSDB-OBJ-COLLECTION-001",
+      "objectKind": "collection",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-COLLECTION",
+      "notes": "Collections use the collection API and serialized document storage rather than SQL DDL."
+    },
+    {
+      "ruleId": "CSDB-OBJ-COLUMN-001",
+      "objectKind": "column",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Persistent columns retain a logical SQL type descriptor over INTEGER, REAL, TEXT, BLOB, or DECIMAL storage."
+    },
+    {
+      "ruleId": "CSDB-OBJ-KEY-001",
+      "objectKind": "key",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-KEYS",
+      "notes": "Primary and unique keys are supported subject to key type and collation rules."
+    },
+    {
+      "ruleId": "CSDB-OBJ-FOREIGNKEY-001",
+      "objectKind": "foreignKey",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "notes": "Single and composite immediate foreign keys are supported with bounded actions."
+    },
+    {
+      "ruleId": "CSDB-OBJ-CHECK-001",
+      "objectKind": "checkConstraint",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CHECKS",
+      "notes": "Deterministic row-local check expressions are supported."
+    },
+    {
+      "ruleId": "CSDB-OBJ-INDEX-001",
+      "objectKind": "index",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-INDEXES",
+      "notes": "Ordinary column indexes are supported subject to type restrictions."
+    },
+    {
+      "ruleId": "CSDB-OBJ-SEQUENCE-001",
+      "objectKind": "sequence",
+      "feature": "object",
+      "status": "unsupported",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "There is no standalone sequence catalog object."
+    },
+    {
+      "ruleId": "CSDB-OBJ-VIEW-001",
+      "objectKind": "view",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "A view body must parse, bind, and pass scratch execution before it is executable evidence."
+    },
+    {
+      "ruleId": "CSDB-OBJ-TRIGGER-001",
+      "objectKind": "trigger",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "Trigger timing, event, and body must be checked; WHEN is rejected with SyntaxError before catalog persistence."
+    },
+    {
+      "ruleId": "CSDB-OBJ-ROUTINE-001",
+      "objectKind": "routine",
+      "feature": "object",
+      "status": "unsupported",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Source database routines do not have a general automatic CSharpDB lowering contract."
+    },
+    {
+      "ruleId": "CSDB-OBJ-OTHER-001",
+      "objectKind": "other",
+      "feature": "object",
+      "status": "unknown",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Provider-specific objects require an explicit capability rule."
+    },
+    {
+      "ruleId": "CSDB-IDENTIFIER-001",
+      "objectKind": "database",
+      "feature": "identifier",
+      "status": "compatible",
+      "maxCount": 128,
+      "evidenceId": "EVID-IDENTIFIERS",
+      "notes": "Identifiers are quoted when rendered, limited to 128 UTF-16 code units, and compared case-insensitively by catalogs."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-TYPE-001",
+      "objectKind": "column",
+      "feature": "columnType",
+      "status": "compatible",
+      "allowedTypes": ["integer", "real", "text", "blob", "decimal"],
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Logical SQL declarations map to these persistent storage types; declared facets are retained and enforced."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-NULLABLE-001",
+      "objectKind": "column",
+      "feature": "nullable",
+      "status": "compatible",
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Nullable and NOT NULL columns are supported."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-DEFAULT-001",
+      "objectKind": "column",
+      "feature": "defaultValue",
+      "status": "conditional",
+      "allowedValues": ["null", "typed-literal"],
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Defaults must be NULL or compatible typed literals; arbitrary source expressions require analysis."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-IDENTITY-001",
+      "objectKind": "column",
+      "feature": "identity",
+      "status": "conditional",
+      "allowedTypes": ["integer"],
+      "maxCount": 1,
+      "evidenceId": "EVID-COLUMN",
+      "notes": "IDENTITY is limited to logical INTEGER or BIGINT and implies a primary key. INTEGER generation stops at 2147483647; BIGINT generation stops at 9223372036854775807."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-ROWVERSION-001",
+      "objectKind": "column",
+      "feature": "rowVersion",
+      "status": "conditional",
+      "allowedTypes": ["blob"],
+      "maxCount": 1,
+      "evidenceId": "EVID-ROWVERSION",
+      "notes": "At most one generated ROWVERSION column is permitted per table. Tokens come from a durable database-wide counter and the column cannot participate in keys, foreign keys, or indexes."
+    },
+    {
+      "ruleId": "CSDB-KEY-PRIMARY-001",
+      "objectKind": "key",
+      "feature": "primaryKey",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "evidenceId": "EVID-KEYS",
+      "notes": "Single or composite INTEGER/TEXT primary keys are supported."
+    },
+    {
+      "ruleId": "CSDB-KEY-UNIQUE-001",
+      "objectKind": "key",
+      "feature": "uniqueConstraint",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "evidenceId": "EVID-KEYS",
+      "notes": "Single or composite INTEGER/TEXT unique keys are supported; tuples containing NULL do not conflict."
+    },
+    {
+      "ruleId": "CSDB-FOREIGNKEY-001",
+      "objectKind": "foreignKey",
+      "feature": "foreignKey",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "allowedValues": [
+        "immediate",
+        "match-simple",
+        "on-delete-cascade",
+        "on-delete-no-action",
+        "on-delete-restrict",
+        "on-delete-set-null",
+        "on-delete-set-default",
+        "on-update-cascade",
+        "on-update-no-action",
+        "on-update-restrict",
+        "on-update-set-null",
+        "on-update-set-default"
+      ],
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "notes": "Child and ordered parent key types/collations must match. SET NULL requires every child column to be nullable and outside the primary key. SET DEFAULT requires a proven compatible literal default, or proven no/NULL default on a nullable non-key child column. Deferred matching remains unsupported."
+    },
+    {
+      "ruleId": "CSDB-CHECK-001",
+      "objectKind": "checkConstraint",
+      "feature": "checkConstraint",
+      "status": "conditional",
+      "allowedValues": ["deterministic", "row-local"],
+      "evidenceId": "EVID-CHECKS",
+      "notes": "Functions, subqueries, and parameters are not accepted in check expressions."
+    },
+    {
+      "ruleId": "CSDB-INDEX-001",
+      "objectKind": "index",
+      "feature": "index",
+      "status": "conditional",
+      "allowedTypes": ["integer", "real", "text"],
+      "allowedValues": ["column-only", "composite", "equality", "nonunique", "unique"],
+      "evidenceId": "EVID-INDEXES",
+      "notes": "Column-only INTEGER/TEXT/REAL equality indexes are supported. REAL components use hashed equality and do not provide ordered or range scans. BLOB/rowversion, expression, partial, included-column, and sort-direction indexes are unsupported."
+    },
+    {
+      "ruleId": "CSDB-VIEW-BODY-001",
+      "objectKind": "view",
+      "feature": "viewBody",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "The body must parse, bind, scratch-apply, and catalog-compare."
+    },
+    {
+      "ruleId": "CSDB-TRIGGER-BODY-001",
+      "objectKind": "trigger",
+      "feature": "triggerBody",
+      "status": "conditional",
+      "allowedValues": ["after-delete", "after-insert", "after-update", "before-delete", "before-insert", "before-update"],
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "Trigger bodies are bounded to INSERT, UPDATE, and DELETE statements."
+    },
+    {
+      "ruleId": "CSDB-TRIGGER-WHEN-001",
+      "objectKind": "trigger",
+      "feature": "triggerWhen",
+      "status": "unsupported",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "WHEN is represented by the parser and rejected with SyntaxError before catalog persistence."
+    },
+    {
+      "ruleId": "CSDB-COLLECTION-INDEX-001",
+      "objectKind": "collection",
+      "feature": "collectionIndex",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "allowedValues": ["array-element-path", "nested-path", "nonunique", "scalar-path"],
+      "evidenceId": "EVID-COLLECTION",
+      "notes": "Collection indexes are nonunique; range scans exclude array-element paths."
+    },
+    {
+      "ruleId": "CSDB-TARGET-TYPE-ENFORCEMENT-001",
+      "objectKind": "column",
+      "feature": "targetTypeEnforcement",
+      "status": "compatible",
+      "evidenceId": "EVID-INSERT-BATCH",
+      "notes": "Every row assignment is coerced and validated against the column's logical SQL type descriptor before persistence."
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "EVID-CATALOG",
+      "source": "CSharpDB.Engine catalog implementations and CSharpDB.Sql.Parser",
+      "assertion": "The installed source defines the target object catalog and supported SQL DDL forms."
+    },
+    {
+      "evidenceId": "EVID-CHECKS",
+      "source": "CSharpDB.Engine.RowConstraintValidator and DefaultCheckConstraintTests",
+      "assertion": "Check expressions are deterministic and row-local with bounded syntax."
+    },
+    {
+      "evidenceId": "EVID-COLLECTION",
+      "source": "CSharpDB.Engine.Collection and CollectionIndexBinding; CollectionIndexTests",
+      "assertion": "Collections use document storage with bounded scalar, nested, and array-element index behavior."
+    },
+    {
+      "evidenceId": "EVID-COLUMN",
+      "source": "CSharpDB.Primitives.DbType, CSharpDB.Sql.Parser, and CSharpDB.Storage.Serialization.RecordEncoder",
+      "assertion": "Runtime tags include Null, Integer, Real, Text, Blob, and exact Decimal; persistent columns retain validated logical SQL type descriptors, including signed 32-bit INTEGER, BIGINT, BOOLEAN, temporal, and bit-string distinctions."
+    },
+    {
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "source": "CSharpDB.Engine.QueryPlanner and ForeignKeyIntegrationTests",
+      "assertion": "Foreign keys require compatible ordered parent keys and support immediate MATCH SIMPLE with RESTRICT, NO ACTION, CASCADE, eligible-child SET NULL, or proven-literal SET DEFAULT behavior for delete and update actions."
+    },
+    {
+      "evidenceId": "EVID-IDENTIFIERS",
+      "source": "CSharpDB.Primitives.SqlIdentifierRules",
+      "assertion": "Quoted identifiers support embedded quotes, reject NUL, and are limited to 128 UTF-16 code units."
+    },
+    {
+      "evidenceId": "EVID-INDEXES",
+      "source": "CSharpDB.Engine.QueryPlanner and CSharpDB.Sql.Ast.CreateIndexStatement",
+      "assertion": "Indexes are column-only and constrained to INTEGER/TEXT/REAL key components with supported collations; REAL components use equality-only hashed keys while ordered and range access remains limited to supported INTEGER/TEXT shapes."
+    },
+    {
+      "evidenceId": "EVID-INSERT-BATCH",
+      "source": "CSharpDB.Execution.RowConstraintValidator and SqlTypeCoercion",
+      "assertion": "All write paths validate and normalize values against the persisted logical SQL type descriptor before storage."
+    },
+    {
+      "evidenceId": "EVID-KEYS",
+      "source": "CSharpDB.Engine.QueryPlanner and LogicalKeyConstraintTests",
+      "assertion": "INTEGER/TEXT primary and unique keys support single and composite forms with documented NULL tuple semantics."
+    },
+    {
+      "evidenceId": "EVID-ROWVERSION",
+      "source": "CSharpDB.Engine.RowConstraintValidator, QueryPlanner, and RowVersionIntegrationTests",
+      "assertion": "A table may contain one generated ROWVERSION excluded from keys, foreign keys, and indexes; inserts and updates allocate durable database-wide tokens."
+    },
+    {
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "source": "CSharpDB.Sql.Parser, CSharpDB.Execution.QueryPlanner, and UnsupportedSqlFeatureDiagnosticTests",
+      "assertion": "Views and bounded triggers exist, while trigger WHEN is rejected with SyntaxError before catalog persistence."
+    }
+  ]
+}

--- a/src/CSharpDB.Migration/README.md
+++ b/src/CSharpDB.Migration/README.md
@@ -26,9 +26,10 @@ core:
 - source-neutral catalog objects with explicit containment, set-like
   dependencies, ordered role-qualified schema members, and safe source identity;
 - stable compatibility, evidence, diagnostic, and mapping states;
-- an embedded, digested CSharpDB 4.5.1 capability catalog tied to the installed
-  Migration and Primitives binaries, plus immutable 4.5.0, 4.4.0, and 4.3.0
-  catalogs for independently replaying plans created against those versions;
+- an embedded, digested CSharpDB 4.6.1 capability catalog tied to the installed
+  Migration and Primitives binaries, plus immutable 4.5.1, 4.5.0, 4.4.0, and
+  4.3.0 catalogs for independently replaying plans created against those
+  versions;
 - target plans bound to the source-catalog digest, capability digest, naming
   algorithm, and versioned mapping policy;
 - detailed target-capability evaluation for columns, keys, foreign keys,

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>4.5.1</Version>
+    <Version>4.6.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />

--- a/tests/CSharpDB.Cli.Tests/MigrationDdlPreviewCommandRunnerTests.cs
+++ b/tests/CSharpDB.Cli.Tests/MigrationDdlPreviewCommandRunnerTests.cs
@@ -41,7 +41,7 @@ public sealed class MigrationDdlPreviewCommandRunnerTests
             string jsonDigest = Sha256(first);
             Assert.True(
                 string.Equals(
-                    "375fe8237dafb75418b308124b6041e441cd373e66bd8275a2e767b2230f945d",
+                    "62d04a5d0cc699dd2156575fa016877a1797cb8458ae063c45a98bdc7c53f0f1",
                     jsonDigest,
                     StringComparison.Ordinal),
                 $"JSON preview digest: {jsonDigest}");
@@ -92,7 +92,7 @@ public sealed class MigrationDdlPreviewCommandRunnerTests
             string textDigest = Sha256(text);
             Assert.True(
                 string.Equals(
-                    "258cf8a0a56f7373ba4ab05d21516d2dfc3746005f785d5c8b55bdf77e6143d2",
+                    "09120d770ef0ea1e9b0d2d39acfe1b59fee27fce34d3ab73f99a9fd22643d24e",
                     textDigest,
                     StringComparison.Ordinal),
                 $"Text preview digest: {textDigest}");

--- a/tests/CSharpDB.Cli.Tests/MigrationReleasePackagingTests.cs
+++ b/tests/CSharpDB.Cli.Tests/MigrationReleasePackagingTests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using CSharpDB.Migration;
 
 namespace CSharpDB.Cli.Tests;
 
@@ -152,7 +154,7 @@ public sealed class MigrationReleasePackagingTests
             "Publish-CSharpDbMigrationRelease.ps1");
 
         Assert.Contains(
-            "[string] $Version = '4.5.1'",
+            "[string] $Version = '4.6.1'",
             script,
             StringComparison.Ordinal);
         Assert.Contains("win-x64", script, StringComparison.Ordinal);
@@ -262,6 +264,47 @@ public sealed class MigrationReleasePackagingTests
             tarModeCheckIndex > tarCreateIndex &&
             archiveRegistrationIndex > tarModeCheckIndex,
             "A POSIX tarball must pass its exact mode check before checksum registration.");
+    }
+
+    [Fact]
+    public void ReleaseVersionSurfaces_AreAlignedBeforeTagging()
+    {
+        string repoRoot = FindRepoRoot();
+        XDocument buildProps = XDocument.Load(Path.Combine(
+            repoRoot,
+            "src",
+            "Directory.Build.props"));
+        string packageVersion = Assert.Single(
+            buildProps.Descendants("Version")).Value.Trim();
+        string releaseNotes = Read(repoRoot, "RELEASE_NOTES.md");
+        Match releaseHeading = Assert.Single(Regex.Matches(
+            releaseNotes,
+            @"(?m)^## CSharpDB (?<version>[^\r\n]+)$",
+            RegexOptions.CultureInvariant));
+        string migrationReleaseScript = Read(
+            repoRoot,
+            "scripts",
+            "Publish-CSharpDbMigrationRelease.ps1");
+        string capabilityCatalogPath = Path.Combine(
+            repoRoot,
+            "src",
+            "CSharpDB.Migration",
+            "Capabilities",
+            $"csharpdb-{packageVersion}.json");
+
+        Assert.Equal(packageVersion, releaseHeading.Groups["version"].Value);
+        Assert.Equal(CSharpDbCapabilityCatalogLoader.CurrentTargetVersion, packageVersion);
+        Assert.Contains(
+            $"[string] $Version = '{packageVersion}'",
+            migrationReleaseScript,
+            StringComparison.Ordinal);
+        Assert.True(
+            File.Exists(capabilityCatalogPath),
+            $"The current migration capability catalog is missing: {capabilityCatalogPath}");
+        Assert.Contains(
+            $"\"targetCSharpDbVersion\": \"{packageVersion}\"",
+            File.ReadAllText(capabilityCatalogPath),
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
@@ -445,7 +445,8 @@ public sealed class DaemonPackagingAssetsTests
             "release_commit: ${{ inputs.release_commit }}",
             normalized);
         Assert.Contains(
-            "previous_release_ref: ${{ inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}",
+            "previous_release_ref: ${{ inputs.release_tag == 'v4.6.1' && '2f141433298bcd3137e2bcaa2930c796c4222092' || " +
+            "inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}",
             normalized);
         Assert.Contains("verify-release-target:", normalized);
         Assert.Contains("name: Verify exact release target", normalized);
@@ -486,7 +487,7 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
-    public void ReleaseWorkflow_V451HostedBaselineUsesLastPublishedV440Only()
+    public void ReleaseWorkflow_RecoveryTagsUseTheirLastPublishedBaselinesOnly()
     {
         string repoRoot = FindRepoRoot();
         string implementation = File.ReadAllText(Path.Combine(
@@ -496,10 +497,15 @@ public sealed class DaemonPackagingAssetsTests
             "release.yml")).ReplaceLineEndings("\n");
 
         const string expectedBaselineInput =
-            "previous_release_ref: ${{ inputs.release_tag == 'v4.5.1' && " +
+            "previous_release_ref: ${{ inputs.release_tag == 'v4.6.1' && " +
+            "'2f141433298bcd3137e2bcaa2930c796c4222092' || " +
+            "inputs.release_tag == 'v4.5.1' && " +
             "'86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}";
 
-        Assert.Contains("v4.5.0 was tagged but never published", implementation);
+        Assert.Contains("v4.6.0 was tagged but never published", implementation);
+        Assert.Contains("published v4.5.1 commit", implementation);
+        Assert.Contains("v4.5.1-to-v4.4.0", implementation);
+        Assert.Contains("v4.5.0 was also tagged but never published", implementation);
         Assert.Contains(expectedBaselineInput, implementation);
         Assert.Single(
             System.Text.RegularExpressions.Regex.Matches(

--- a/tests/CSharpDB.Migration.Files.Tests/CsvMigrationDataSourceTests.cs
+++ b/tests/CSharpDB.Migration.Files.Tests/CsvMigrationDataSourceTests.cs
@@ -225,7 +225,7 @@ public sealed class CsvMigrationDataSourceTests
 
             const string expectedCursor =
                 "csharpdb-csv-cursor-v1/1/1/" +
-                "dbb2f0bc0ef913611e67f78c62a2e831961ff9fc5807d88e4e17b6343a602dc4";
+                "a56108f642a77cca8f417c861631c0e2c73872b5f4d3bd168866ee1ffdc8af6f";
             Assert.True(
                 string.Equals(expectedCursor, first.NextCursor, StringComparison.Ordinal),
                 $"CSV cursor golden changed. Actual value: {first.NextCursor}");

--- a/tests/CSharpDB.Migration.MySql.Tests/MySqlCatalogBuilderTests.cs
+++ b/tests/CSharpDB.Migration.MySql.Tests/MySqlCatalogBuilderTests.cs
@@ -6,7 +6,7 @@ namespace CSharpDB.Migration.MySql.Tests;
 public sealed class MySqlCatalogBuilderTests
 {
     private const string GoldenCatalogDigest =
-        "9d9423184603ce469c2d70a306a63bafe329d8adbe20f0a7173d3e34f664ee41";
+        "4d49a3557299cbf4551e823c4f5d1c5677c1bff252079cd8aea11b745bfbadf5";
     private const string GoldenSourceFingerprint =
         "sha256:3e8b79eed8a2f36c0962a6e252404180d715dbbaab46d1fec4f1af61b75e383c";
 

--- a/tests/CSharpDB.Migration.SqlServer.Tests/SqlServerCatalogBuilderTests.cs
+++ b/tests/CSharpDB.Migration.SqlServer.Tests/SqlServerCatalogBuilderTests.cs
@@ -6,7 +6,7 @@ namespace CSharpDB.Migration.SqlServer.Tests;
 public sealed partial class SqlServerCatalogBuilderTests
 {
     private const string GoldenCatalogDigest =
-        "629716b9dd229f9ca370be2b20f97398d4f3e7e732a8c617272909a08f2bcfe2";
+        "d9c7afba06cec81ed5376dbfda4f6b45dd34571db6b785c261e163ce03cbba18";
     private const string GoldenSourceFingerprint =
         "sha256:9ca68e4d38d4caa4d6feeb034355a7ad75da5af6c7456d9bdefa7270f9a92c21";
 

--- a/tests/CSharpDB.Migration.Tests/CSharpDbValidationActivationTests.cs
+++ b/tests/CSharpDB.Migration.Tests/CSharpDbValidationActivationTests.cs
@@ -250,7 +250,7 @@ public sealed class CSharpDbValidationActivationTests
 
         string expectedIdentity =
             $"staged-target:{GoldenTargetIdentity}:awaiting-validation:outcomes:" +
-            "b59bddbbf8b078a5de71c2660905d686f809ba8827822f0c97e039f6d0faedd6";
+            "3c41ab5e383a96e154e85a2c32df96d498cd983dd50a3f824fbdc1901f0a9a0c";
         Assert.True(
             string.Equals(expectedIdentity, snapshot.SnapshotIdentity, StringComparison.Ordinal),
             $"Validation snapshot golden identity changed. Actual value: {snapshot.SnapshotIdentity}");

--- a/tests/CSharpDB.Migration.Tests/Fixtures/catalog-v1.golden.json
+++ b/tests/CSharpDB.Migration.Tests/Fixtures/catalog-v1.golden.json
@@ -1,9 +1,9 @@
 {
   "format": "csharpdb-migration-catalog/v1",
   "digestAlgorithm": "sha256",
-  "digest": "3f4e60759e6b1e795b931fd3cecce9b8a6e5701c14d477aa92fa0e7fa50feaea",
+  "digest": "4573019633a62d256f1ef036e5fc273f5ab5e696b8f5580b4eea93e9a8dc4f13",
   "payload": {
-    "targetCSharpDbVersion": "4.5.1",
+    "targetCSharpDbVersion": "4.6.1",
     "source": {
       "kind": "synthetic",
       "identity": "fixture:awkward-v1",

--- a/tests/CSharpDB.Migration.Tests/Fixtures/synthetic-planning-v1.golden.json
+++ b/tests/CSharpDB.Migration.Tests/Fixtures/synthetic-planning-v1.golden.json
@@ -1,5 +1,5 @@
 {
-  "catalogDigest": "7e09fa94acc96486b474ddd345b73158c1d7856b6d8ccf313c4ca1336d4f6f4b",
-  "preservePlanDigest": "679a3f4cdcaddd68ade9546b892788abd620933d1ceeae4a529141efaa77b8e8",
-  "queryablePlanDigest": "68a3b6b0a6ec7a28436febd9ae649e8fa69c02bc7d1936ca3f3b5d547acff659"
+  "catalogDigest": "e8571472a3c26eec60bbd5e6a9c3189c05a84549de00177d9a9df23e588e0367",
+  "preservePlanDigest": "abb3be1e1e0576cba493384e59aad2878e11df9f3d76c6667f6462c8c20e5b24",
+  "queryablePlanDigest": "550ecd009eda327bbb86cb9b8ae1eb693510b11fbee33d75b4fb3875020a8c0e"
 }

--- a/tests/CSharpDB.Migration.Tests/MigrationPlannerTests.cs
+++ b/tests/CSharpDB.Migration.Tests/MigrationPlannerTests.cs
@@ -11,7 +11,7 @@ public sealed class MigrationPlannerTests
     {
         CSharpDbCapabilityCatalog capabilities = CSharpDbCapabilityCatalogLoader.LoadEmbedded();
 
-        Assert.Equal("4.5.1", capabilities.TargetCSharpDbVersion);
+        Assert.Equal("4.6.1", capabilities.TargetCSharpDbVersion);
         Assert.Equal("local-typed-engine", capabilities.Surface);
         Assert.Equal(SqlIdentifierRules.MaxLength, capabilities.MaxIdentifierLength);
         Assert.Equal(64, capabilities.Digest.Length);
@@ -49,9 +49,9 @@ public sealed class MigrationPlannerTests
     }
 
     [Fact]
-    public void EmbeddedCapabilities_AreBoundToThe451ReleaseAssembliesAndResource()
+    public void EmbeddedCapabilities_AreBoundToThe461ReleaseAssembliesAndResource()
     {
-        const string expectedVersion = "4.5.1";
+        const string expectedVersion = "4.6.1";
         Assembly migrationAssembly = typeof(CSharpDbCapabilityCatalogLoader).Assembly;
         Assembly primitivesAssembly = typeof(DbType).Assembly;
 
@@ -72,28 +72,34 @@ public sealed class MigrationPlannerTests
             CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.4.0");
         CSharpDbCapabilityCatalog tagged =
             CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.5.0");
+        CSharpDbCapabilityCatalog previousRelease =
+            CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.5.1");
         CSharpDbCapabilityCatalog current =
             CSharpDbCapabilityCatalogLoader.LoadEmbedded();
 
         Assert.Equal(
-            ["4.3.0", "4.4.0", "4.5.0", "4.5.1"],
+            ["4.3.0", "4.4.0", "4.5.0", "4.5.1", "4.6.1"],
             CSharpDbCapabilityCatalogLoader.SupportedTargetVersions);
         Assert.Equal("4.3.0", oldest.TargetCSharpDbVersion);
         Assert.Equal("4.4.0", previous.TargetCSharpDbVersion);
         Assert.Equal("4.5.0", tagged.TargetCSharpDbVersion);
-        Assert.Equal("4.5.1", current.TargetCSharpDbVersion);
+        Assert.Equal("4.5.1", previousRelease.TargetCSharpDbVersion);
+        Assert.Equal("4.6.1", current.TargetCSharpDbVersion);
         Assert.False(oldest.IsColumnType(DbType.Decimal));
         Assert.False(previous.IsColumnType(DbType.Decimal));
         Assert.True(tagged.IsColumnType(DbType.Decimal));
+        Assert.True(previousRelease.IsColumnType(DbType.Decimal));
         Assert.True(current.IsColumnType(DbType.Decimal));
         Assert.False(oldest.EngineEnforcesMappedColumnType);
         Assert.False(previous.EngineEnforcesMappedColumnType);
         Assert.True(tagged.EngineEnforcesMappedColumnType);
+        Assert.True(previousRelease.EngineEnforcesMappedColumnType);
         Assert.True(current.EngineEnforcesMappedColumnType);
         Assert.NotEqual(previous.Digest, current.Digest);
         Assert.NotEqual(tagged.Digest, current.Digest);
+        Assert.NotEqual(previousRelease.Digest, current.Digest);
         Assert.Equal(
-            JsonSerializer.Serialize(tagged with
+            JsonSerializer.Serialize(previousRelease with
             {
                 TargetCSharpDbVersion = current.TargetCSharpDbVersion,
             }),


### PR DESCRIPTION
## Summary

Prepare CSharpDB 4.6.1 as the first publishable release in the 4.6 line. The
`v4.6.0` Git tag is retained as release-attempt history, but its workflow
failed the tag-to-package-version check before any NuGet package or GitHub
Release was published.

### Recovery delta: v4.6.0 tag to v4.6.1

- Advance the package, migration capability catalog, release notes, and
  migration-archive default to 4.6.1 so a new tag can pass the release target
  and package identity checks.
- Preserve the failed `v4.6.0` tag exactly where it is. Do not move, recreate,
  or publish from it.
- Pin the v4.6.1 hosted comparison to exact published v4.5.1 commit
  `2f141433298bcd3137e2bcaa2930c796c4222092`. Because v4.6.0 was not
  published, it is not a valid previous-release performance baseline.
- Retain the historical v4.5.1 exception that compares against published
  v4.4.0 because v4.5.0 was also tagged but not published.

### Public delta: v4.5.1 to v4.6.1

The public release delta is the intended 4.6 observability and diagnostics
feature set described in `RELEASE_NOTES.md`. It includes the BCL-only
observability contracts, safe structured events, bounded runtime diagnostics,
OpenTelemetry and Prometheus integration, health and readiness endpoints,
daemon gRPC health support, and the Admin observability workspace.

The recovery changes do not add a second product feature delta beyond those
4.6 contents. They correct release identity and baseline selection so the
normal fail-closed workflow can qualify and publish a new immutable tag.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

None linked.

## Testing

Local validation covers the exact clean recovery commit, the complete Release
qualification, and the final 18-package candidate graph. The tag-triggered
cross-platform hosted qualification must still pass for the exact v4.6.1 tag
before publication begins.

- [x] `dotnet build CSharpDB.slnx` (Release, 0 warnings, 0 errors)
- [x] Full Release qualifier passed: 6,969 tests passed, 4 expected live-provider skips, 0 failures
- [x] All 18 NuGet candidates passed clean-consumer, exact dependency-graph, metadata, and hash checks
- [x] NuGet.org preflight confirmed 4.6.1 is absent for all 18 package IDs
- [x] Relevant release workflow and packaging contract tests executed
- [x] Modified PowerShell scripts passed parser validation
- [x] Modified workflow YAML passed parser validation
- [x] Git whitespace/error check passed

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered the failed-tag recovery path.
- [x] I updated release-facing documentation.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- Treat `v4.6.0` only as immutable failed-attempt history. Its existence does
  not indicate a published 4.6 release.
- The exact v4.5.1 commit is deliberately hard-coded only for the v4.6.1
  recovery comparison; ordinary future tags continue to use the workflow's
  normal previous-release resolution.
- Create and push `v4.6.1` only through `Publish-ReleaseTag.ps1` after this
  recovery change is merged to a clean, current `main` and all local
  qualification is complete.
- NuGet publication and GitHub Release creation remain downstream of all
  hosted qualification and archive jobs.

