### PR TITLE
Stabilize Windows API test host cleanup

### DIFF
--- a/tests/CSharpDB.Api.Tests/HttpTransportClientTests.cs
+++ b/tests/CSharpDB.Api.Tests/HttpTransportClientTests.cs
@@ -17,6 +17,10 @@ namespace CSharpDB.Api.Tests;
 
 public sealed class HttpTransportClientTests : IAsyncLifetime
 {
+    private static readonly TimeSpan FileCleanupTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan FileCleanupRetryDelay = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan ReadinessTimeout = TimeSpan.FromSeconds(10);
+
     private string _dbPath = null!;
     private TestApiFactory _factory = null!;
     private HttpClient _httpClient = null!;
@@ -24,7 +28,7 @@ public sealed class HttpTransportClientTests : IAsyncLifetime
 
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
-    public ValueTask InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _dbPath = Path.Combine(Path.GetTempPath(), $"csharpdb_api_http_{Guid.NewGuid():N}.db");
         _factory = new TestApiFactory(_dbPath);
@@ -36,7 +40,7 @@ public sealed class HttpTransportClientTests : IAsyncLifetime
             HttpClient = _httpClient,
         });
 
-        return ValueTask.CompletedTask;
+        await WaitForReadinessAsync(_httpClient, Ct);
     }
 
     public async ValueTask DisposeAsync()
@@ -208,6 +212,44 @@ public sealed class HttpTransportClientTests : IAsyncLifetime
             await captureClient.DisposeAsync();
             await DeleteIfExistsAsync(dbPath);
             await DeleteIfExistsAsync(dbPath + ".wal");
+        }
+    }
+
+    [Fact]
+    public async Task DeleteIfExistsAsync_RetriesPastLegacyTwoSecondWindowsLock()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"csharpdb_api_cleanup_{Guid.NewGuid():N}.db");
+        FileStream? lockStream = null;
+        try
+        {
+            lockStream = new FileStream(
+                path,
+                FileMode.CreateNew,
+                FileAccess.ReadWrite,
+                FileShare.None);
+            Task deletion = DeleteIfExistsAsync(path).AsTask();
+
+            await Task.Delay(TimeSpan.FromMilliseconds(2250), Ct);
+            Assert.False(deletion.IsCompleted);
+
+            await lockStream.DisposeAsync();
+            lockStream = null;
+            await deletion.WaitAsync(TimeSpan.FromSeconds(5), Ct);
+
+            Assert.False(File.Exists(path));
+        }
+        finally
+        {
+            if (lockStream is not null)
+                await lockStream.DisposeAsync();
+
+            if (File.Exists(path))
+                File.Delete(path);
         }
     }
 
@@ -2409,11 +2451,11 @@ public sealed class HttpTransportClientTests : IAsyncLifetime
                 File.Delete(path);
                 return;
             }
-            catch (IOException ex) when (sw.Elapsed < TimeSpan.FromSeconds(2))
+            catch (IOException ex)
             {
                 lastException = ex;
             }
-            catch (UnauthorizedAccessException ex) when (sw.Elapsed < TimeSpan.FromSeconds(2))
+            catch (UnauthorizedAccessException ex)
             {
                 lastException = ex;
             }
@@ -2421,12 +2463,40 @@ public sealed class HttpTransportClientTests : IAsyncLifetime
             if (!File.Exists(path))
                 return;
 
-            if (sw.Elapsed >= TimeSpan.FromSeconds(2))
+            TimeSpan remaining = FileCleanupTimeout - sw.Elapsed;
+            if (remaining <= TimeSpan.Zero)
                 break;
 
-            await Task.Delay(25);
+            TimeSpan delay = remaining < FileCleanupRetryDelay
+                ? remaining
+                : FileCleanupRetryDelay;
+            await Task.Delay(delay, CancellationToken.None);
         }
 
         throw new IOException($"Failed to delete temporary database file '{path}' within the cleanup timeout.", lastException);
+    }
+
+    private static async Task WaitForReadinessAsync(
+        HttpClient httpClient,
+        CancellationToken cancellationToken)
+    {
+        var timeout = System.Diagnostics.Stopwatch.StartNew();
+        HttpStatusCode? lastStatus = null;
+        while (timeout.Elapsed < ReadinessTimeout)
+        {
+            using HttpResponseMessage response = await httpClient.GetAsync(
+                "/health/ready",
+                cancellationToken);
+            lastStatus = response.StatusCode;
+            if (response.StatusCode == HttpStatusCode.OK)
+                return;
+
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+            await Task.Delay(TimeSpan.FromMilliseconds(25), cancellationToken);
+        }
+
+        throw new TimeoutException(
+            $"The API test host did not become ready within {ReadinessTimeout}. " +
+            $"Last status: {lastStatus?.ToString() ?? "none"}.");
     }
 }


### PR DESCRIPTION
## Summary

Stabilize the Windows API test lifecycle after the post-merge CI failure in
[run 31722303071](https://github.com/MaxAkbar/CSharpDB/actions/runs/31722303071).

The failing request-cancellation test completed successfully, but its class
fixture teardown could not delete the otherwise-unused default test database
within the former two-second retry window. API initialization now happens in a
background readiness service, so a test that never touches the default client
can begin teardown while the tail of initialization is settling on Windows.

This change:

- waits for the real `/health/ready` signal before the fixture enters a test;
- uses a bounded ten-second cleanup retry with a monotonic deadline;
- keeps cleanup cancellation-resistant and preserves the final exception on a
  real leak; and
- adds a Windows regression that holds an exclusive file lock beyond the old
  two-second deadline before releasing it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

- Fixes the Windows failure in CI run 31722303071.

## Testing

- [x] `dotnet build CSharpDB.slnx -c Release --no-restore` — 0 warnings, 0 errors
- [x] `dotnet test tests/CSharpDB.Api.Tests/CSharpDB.Api.Tests.csproj -c Release --no-restore` — 187/187 passed
- [x] Original failing test repeated 20 times — 20/20 passed
- [x] Deterministic Windows lock regression passed
- [x] Independent source review found no blocker

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [ ] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- The failure was in test teardown, not request execution or production
  database disposal.
- Ubuntu, macOS, NativeAOT, and all published-host jobs passed in the failed
  main-branch run.
- The unrelated local `samples/observability-host/Properties/` directory is
  intentionally excluded from this PR.
