### PR TITLE
Simplify release publication and prepare v4.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,44 @@ jobs:
               xUnit.ReporterSwitch=verbose
           fi
 
+  release-baseline-compatibility:
+    name: Release baseline compatibility build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout full release history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: Build synchronized harness against published baseline and candidate
+        shell: pwsh
+        env:
+          COMPATIBILITY_OUTPUT: ${{ runner.temp }}/csharpdb-release-baseline/${{ github.sha }}
+          CANDIDATE_REF: ${{ github.sha }}
+        run: |
+          ./tests/CSharpDB.Benchmarks/scripts/Test-PreviousReleasePerformance.ps1 `
+            -PreviousRef 2f141433298bcd3137e2bcaa2930c796c4222092 `
+            -CandidateRef $env:CANDIDATE_REF `
+            -OutputPath $env:COMPATIBILITY_OUTPUT `
+            -BuildOnly
+
+      - name: Upload compatibility evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-baseline-compatibility-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/csharpdb-release-baseline/${{ github.sha }}/previous-release-performance.md
+            ${{ runner.temp }}/csharpdb-release-baseline/${{ github.sha }}/logs
+          if-no-files-found: warn
+          retention-days: 14
+
   published-host-observability:
     name: Published ${{ matrix.host }} observability (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,26 +1,314 @@
-name: Release
+name: Publish qualified release
+
+run-name: Publish ${{ inputs.release_tag }} from qualification ${{ inputs.qualification_run_id }} (${{ inputs.preflight_only && 'preflight' || 'release' }})
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Exact immutable release tag
+        required: true
+        type: string
+      release_commit:
+        description: Exact commit targeted by release_tag
+        required: true
+        type: string
+      qualification_run_id:
+        description: Successful Release qualification run containing release-bundle
+        required: true
+        type: string
+      preflight_only:
+        description: Verify publication credentials and qualified bundle without publishing
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: publish-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  actions: read
+  contents: write
+  id-token: write
 
 jobs:
-  publish-tag:
-    name: Publish exact release tag
-    permissions:
-      contents: write
-      id-token: write
-    uses: ./.github/workflows/release.yml
-    with:
-      release_tag: ${{ github.ref_name }}
-      release_commit: ${{ github.sha }}
-    secrets:
-      NUGET_USER: ${{ secrets.NUGET_USER }}
+  publish:
+    name: Publish exact qualified bundle
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_COMMIT: ${{ inputs.release_commit }}
+      QUALIFICATION_RUN_ID: ${{ inputs.qualification_run_id }}
+
+    steps:
+      - name: Checkout exact tagged source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_commit }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: Require exact tag and successful qualification run
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:RELEASE_TAG -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+            throw "Release tag is not a supported semantic version: $env:RELEASE_TAG"
+          }
+          if ($env:RELEASE_COMMIT -notmatch '^[0-9a-f]{40}$') {
+            throw "Release commit is not a full lowercase SHA: $env:RELEASE_COMMIT"
+          }
+          if ($env:QUALIFICATION_RUN_ID -notmatch '^[1-9][0-9]*$') {
+            throw "Qualification run ID is invalid: $env:QUALIFICATION_RUN_ID"
+          }
+
+          if ('${{ inputs.preflight_only }}' -ceq 'false') {
+            $tagCommit = (& gh api "repos/$env:GITHUB_REPOSITORY/commits/$env:RELEASE_TAG" --jq .sha).Trim()
+            if ($LASTEXITCODE -ne 0 -or $tagCommit -cne $env:RELEASE_COMMIT) {
+              throw "$env:RELEASE_TAG does not resolve to exact commit $env:RELEASE_COMMIT."
+            }
+          }
+          else {
+            $remoteMain = (& gh api "repos/$env:GITHUB_REPOSITORY/commits/main" --jq .sha).Trim()
+            if ($LASTEXITCODE -ne 0 -or $remoteMain -cne $env:RELEASE_COMMIT) {
+              throw "$env:RELEASE_COMMIT is not exact current main $remoteMain."
+            }
+            $tagRef = @(& git ls-remote --tags origin "refs/tags/$env:RELEASE_TAG" "refs/tags/$env:RELEASE_TAG^{}")
+            if ($LASTEXITCODE -ne 0 -or $tagRef.Count -ne 0) {
+              throw "Preflight requires absent release tag $env:RELEASE_TAG."
+            }
+          }
+
+          $run = & gh api "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:QUALIFICATION_RUN_ID"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect qualification run $env:QUALIFICATION_RUN_ID."
+          }
+          $run = $run | ConvertFrom-Json
+          $expectedTitle = "Qualify release $env:RELEASE_TAG at $env:RELEASE_COMMIT"
+          $workflow = & gh api "repos/$env:GITHUB_REPOSITORY/actions/workflows/$($run.workflow_id)"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect workflow $($run.workflow_id) for qualification run."
+          }
+          $workflow = $workflow | ConvertFrom-Json
+          if ($run.event -cne 'workflow_dispatch' -or
+              $workflow.path -cne '.github/workflows/release.yml' -or
+              $run.head_sha -cne $env:RELEASE_COMMIT -or
+              $run.display_title -cne $expectedTitle -or
+              $run.status -cne 'completed' -or
+              $run.conclusion -cne 'success') {
+            throw "Run $env:QUALIFICATION_RUN_ID is not the successful exact qualification for $env:RELEASE_TAG."
+          }
+
+      - name: Download immutable qualified bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: release-bundle
+          path: artifacts/release-bundle
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification_run_id }}
+
+      - name: Verify downloaded release bundle
+        id: bundle
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = $env:RELEASE_TAG.Substring(1)
+          ./scripts/Test-CSharpDbNuGetReleaseGraph.ps1 `
+            -FeedPath artifacts/release-bundle/nuget `
+            -Version $version `
+            -ValidateExistingManifest
+          $notesPath = Resolve-Path 'artifacts/release-bundle/release-notes-current.md'
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "notes_path=$notesPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Fail when NUGET_USER is missing
+        env:
+          NUGET_USER: ${{ secrets.NUGET_USER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$NUGET_USER" ]]; then
+            echo "Repository secret NUGET_USER is not set." >&2
+            exit 1
+          fi
+
+      - name: Create or refresh draft GitHub Release
+        id: release-stage
+        if: inputs.preflight_only == false
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NOTES_PATH: ${{ steps.bundle.outputs.notes_path }}
+          RELEASE_VERSION: ${{ steps.bundle.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $assets = @(Get-ChildItem -LiteralPath artifacts/release-bundle -Recurse -File |
+            Where-Object { $_.Name -cne 'release-notes-current.md' })
+          if ($assets.Count -eq 0) { throw 'The release bundle contains no assets.' }
+          $duplicateNames = @($assets | Group-Object Name | Where-Object Count -gt 1)
+          if ($duplicateNames.Count -ne 0) {
+            throw "Release asset basenames must be unique: $($duplicateNames.Name -join ', ')"
+          }
+
+          function Assert-ExactReleaseAssets {
+            $releaseView = @(& gh release view $env:RELEASE_TAG --json databaseId 2>$null)
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not resolve GitHub Release $env:RELEASE_TAG."
+            }
+            $releaseId = [long] ((($releaseView -join [Environment]::NewLine) | ConvertFrom-Json).databaseId)
+            if ($releaseId -le 0) {
+              throw "GitHub Release $env:RELEASE_TAG did not have a valid database ID."
+            }
+            $release = & gh api "repos/$env:GITHUB_REPOSITORY/releases/$releaseId"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not inspect GitHub Release $env:RELEASE_TAG by database ID."
+            }
+            $release = $release | ConvertFrom-Json
+            $assetPages = & gh api --paginate --slurp `
+              "repos/$env:GITHUB_REPOSITORY/releases/$releaseId/assets?per_page=100"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not inspect assets for GitHub Release $env:RELEASE_TAG."
+            }
+            $expectedBody = (Get-Content -Raw -LiteralPath $env:RELEASE_NOTES_PATH).TrimEnd()
+            if ($release.tag_name -cne $env:RELEASE_TAG -or
+                $release.target_commitish -cne 'main' -or
+                $release.name -cne "CSharpDB v$env:RELEASE_VERSION" -or
+                ([string] $release.body).TrimEnd() -cne $expectedBody) {
+              throw "GitHub Release $env:RELEASE_TAG metadata does not match the exact qualified notes."
+            }
+            $remoteAssets = @(
+              foreach ($page in @(($assetPages | ConvertFrom-Json))) {
+                foreach ($asset in @($page)) { $asset }
+              }
+            )
+            if ($remoteAssets.Count -ne $assets.Count) {
+              throw "GitHub Release $env:RELEASE_TAG has $($remoteAssets.Count) assets; expected $($assets.Count)."
+            }
+            foreach ($asset in $assets) {
+              $matches = @($remoteAssets | Where-Object name -CEQ $asset.Name)
+              if ($matches.Count -ne 1) {
+                throw "GitHub Release $env:RELEASE_TAG does not contain exactly one $($asset.Name)."
+              }
+              $expectedDigest = "sha256:$((Get-FileHash -LiteralPath $asset.FullName -Algorithm SHA256).Hash.ToLowerInvariant())"
+              if ($matches[0].state -cne 'uploaded' -or
+                  [long] $matches[0].size -ne $asset.Length -or
+                  ([string] $matches[0].digest).ToLowerInvariant() -cne $expectedDigest) {
+                throw "GitHub Release asset $($asset.Name) does not match the exact qualified file."
+              }
+            }
+            return $release
+          }
+
+          $releaseJson = @(& gh release view $env:RELEASE_TAG --json isDraft,tagName,url 2>$null)
+          if ($LASTEXITCODE -eq 0) {
+            $release = ($releaseJson -join [Environment]::NewLine) | ConvertFrom-Json
+            if (-not $release.isDraft) {
+              Assert-ExactReleaseAssets | Out-Null
+              $manifest = Get-Content -Raw -LiteralPath `
+                artifacts/release-bundle/nuget/CSharpDB-PACKAGE-MANIFEST.json |
+                ConvertFrom-Json
+              ./scripts/Wait-NuGetPackageVersion.ps1 `
+                -Version $env:RELEASE_VERSION `
+                -PackageId @($manifest.packages.id)
+              "already_published=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+              Write-Host "Exact GitHub Release $env:RELEASE_TAG and every package are already published."
+              exit 0
+            }
+            & gh release edit $env:RELEASE_TAG `
+              --title "CSharpDB v$env:RELEASE_VERSION" `
+              --notes-file $env:RELEASE_NOTES_PATH `
+              --draft
+          }
+          else {
+            & gh release create $env:RELEASE_TAG `
+              --verify-tag `
+              --target main `
+              --title "CSharpDB v$env:RELEASE_VERSION" `
+              --notes-file $env:RELEASE_NOTES_PATH `
+              --draft
+          }
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not create or refresh draft GitHub Release $env:RELEASE_TAG."
+          }
+
+          & gh release upload $env:RELEASE_TAG @($assets.FullName) --clobber
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not upload the complete asset bundle for $env:RELEASE_TAG."
+          }
+          Assert-ExactReleaseAssets | Out-Null
+          "already_published=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: NuGet login through Trusted Publishing
+        id: nuget-login
+        if: inputs.preflight_only == true || steps.release-stage.outputs.already_published != 'true'
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Require packages to remain absent before tagging
+        if: inputs.preflight_only == true
+        shell: pwsh
+        run: |
+          ./scripts/Test-CSharpDbNuGetCandidateAbsent.ps1 `
+            -ManifestPath artifacts/release-bundle/nuget/CSharpDB-PACKAGE-MANIFEST.json
+
+      - name: Publication preflight complete
+        if: inputs.preflight_only == true
+        run: echo "Qualified bundle and publication credentials are ready; no tag or package was created."
+
+      - name: Publish packages in validated topological order
+        if: inputs.preflight_only == false && steps.release-stage.outputs.already_published != 'true'
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          RELEASE_VERSION: ${{ steps.bundle.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $manifest = Get-Content -Raw -LiteralPath `
+            artifacts/release-bundle/nuget/CSharpDB-PACKAGE-MANIFEST.json |
+            ConvertFrom-Json
+          $ordered = @($manifest.packages | Where-Object { $_.id -ceq 'CSharpDB.Observability' }) +
+            @($manifest.packages | Where-Object { $_.id -cne 'CSharpDB.Observability' })
+          foreach ($package in $ordered) {
+            $packagePath = Join-Path artifacts/release-bundle/nuget $package.file
+            & dotnet nuget push $packagePath `
+              --source 'https://api.nuget.org/v3/index.json' `
+              --api-key $env:NUGET_API_KEY `
+              --skip-duplicate
+            if ($LASTEXITCODE -ne 0) { throw "Failed to publish $($package.id)." }
+            ./scripts/Wait-NuGetPackageVersion.ps1 `
+              -Version $env:RELEASE_VERSION `
+              -PackageId $package.id
+          }
+
+      - name: Verify every package is visible
+        if: inputs.preflight_only == false && steps.release-stage.outputs.already_published != 'true'
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ steps.bundle.outputs.version }}
+        run: |
+          $manifest = Get-Content -Raw -LiteralPath `
+            artifacts/release-bundle/nuget/CSharpDB-PACKAGE-MANIFEST.json |
+            ConvertFrom-Json
+          ./scripts/Wait-NuGetPackageVersion.ps1 `
+            -Version $env:RELEASE_VERSION `
+            -PackageId @($manifest.packages.id)
+
+      - name: Publish the staged GitHub Release
+        if: inputs.preflight_only == false && steps.release-stage.outputs.already_published != 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & gh release edit $env:RELEASE_TAG --draft=false --latest
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not publish GitHub Release $env:RELEASE_TAG."
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,29 @@
-name: Release implementation
+name: Release qualification
+
+run-name: Qualify release ${{ inputs.release_tag }} at ${{ inputs.release_commit }}
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       release_tag:
-        description: Exact existing release tag to publish
+        description: New semantic release tag to create after qualification
         required: true
         type: string
       release_commit:
-        description: Exact commit targeted by release_tag
+        description: Exact main commit to qualify and release
         required: true
         type: string
-    secrets:
-      NUGET_USER:
-        description: NuGet profile name used by Trusted Publishing
-        required: true
+
+concurrency:
+  group: release-${{ inputs.release_tag }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  verify-release-target:
-    name: Verify exact release target
+  verify-release-candidate:
+    name: Verify exact release candidate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,9 +35,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.release_commit }}
 
-      - name: Require the exact existing release tag and commit
+      - name: Require exact untagged main and matching package version
         shell: pwsh
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           RELEASE_COMMIT: ${{ inputs.release_commit }}
         run: |
@@ -53,30 +56,55 @@ jobs:
             throw "Checked-out HEAD $head does not match $env:RELEASE_COMMIT."
           }
 
-          $tagCommit = (& git rev-parse "refs/tags/$($env:RELEASE_TAG)^{commit}").Trim()
-          if ($LASTEXITCODE -ne 0 -or $tagCommit -cne $env:RELEASE_COMMIT) {
-            throw "$env:RELEASE_TAG does not resolve to $env:RELEASE_COMMIT."
+          [xml] $buildProps = Get-Content -Raw -LiteralPath 'src/Directory.Build.props'
+          $versionNodes = @($buildProps.SelectNodes('/Project/PropertyGroup/Version'))
+          if ($versionNodes.Count -ne 1) {
+            throw "Expected exactly one package Version; found $($versionNodes.Count)."
+          }
+          $releaseVersion = $env:RELEASE_TAG.Substring(1)
+          if ($versionNodes[0].InnerText.Trim() -cne $releaseVersion) {
+            throw "Release tag $env:RELEASE_TAG does not match package version $($versionNodes[0].InnerText.Trim())."
+          }
+
+          $remoteMain = (& gh api "repos/$env:GITHUB_REPOSITORY/commits/main" --jq .sha).Trim()
+          if ($LASTEXITCODE -ne 0 -or $remoteMain -cne $env:RELEASE_COMMIT) {
+            throw "Release commit $env:RELEASE_COMMIT is not exact current main $remoteMain."
+          }
+
+          $remoteTag = @(& git ls-remote --tags origin "refs/tags/$($env:RELEASE_TAG)" "refs/tags/$($env:RELEASE_TAG)^{}")
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect remote release tag $env:RELEASE_TAG."
+          }
+          if ($remoteTag.Count -ne 0) {
+            throw "Release tag $env:RELEASE_TAG already exists; qualification requires an untagged version."
+          }
+
+          $releaseTags = @(& gh api --paginate "repos/$env:GITHUB_REPOSITORY/releases" --jq '.[].tag_name')
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect existing GitHub Releases."
+          }
+          if ($releaseTags -ccontains $env:RELEASE_TAG) {
+            throw "A $env:RELEASE_TAG GitHub Release already exists."
           }
 
   build-and-test:
     name: Qualify release source
-    needs: verify-release-target
+    needs: verify-release-candidate
     uses: ./.github/workflows/sql-release-qualification.yml
     with:
       release_version: ${{ inputs.release_tag }}
       release_commit: ${{ inputs.release_commit }}
-      # v4.6.0 was tagged but never published, so v4.6.1 must measure from the
-      # published v4.5.1 commit. v4.5.0 was also tagged but never published, so
-      # retain the equivalent v4.5.1-to-v4.4.0 case.
-      previous_release_ref: ${{ inputs.release_tag == 'v4.6.1' && '2f141433298bcd3137e2bcaa2930c796c4222092' || inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}
+      # v4.6.0 and v4.6.1 were tagged but never published, so v4.6.2 must
+      # measure from the published v4.5.1 commit. Retain historical recovery
+      # mappings for auditability.
+      previous_release_ref: ${{ inputs.release_tag == 'v4.6.2' && '2f141433298bcd3137e2bcaa2930c796c4222092' || inputs.release_tag == 'v4.6.1' && '2f141433298bcd3137e2bcaa2930c796c4222092' || inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}
 
-  publish-nuget:
-    name: Publish NuGet
-    needs: [build-and-test, migration-archives, native-aot, api-host-observability, daemon-archives, admin-desktop-archive]
+  prepare-nuget:
+    name: Prepare NuGet candidate
+    needs: build-and-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     env:
@@ -106,17 +134,6 @@ jobs:
           $packageFileVersion = ./scripts/Get-NuGetPackageIdentityVersion.ps1 -Version $version
           "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "package_file_version=$packageFileVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
-      - name: Fail when NUGET_USER is missing
-        env:
-          NUGET_USER: ${{ secrets.NUGET_USER }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "$NUGET_USER" ]]; then
-            echo "Repository secret NUGET_USER is not set. Set it to the nuget.org username/profile name used by the Trusted Publishing policy." >&2
-            exit 1
-          fi
 
       - name: Rewrite README links for NuGet
         shell: bash
@@ -197,113 +214,16 @@ jobs:
             -FeedPath artifacts/nuget `
             -Version "${{ steps.version.outputs.version }}"
 
-      - name: Revalidate the immutable publication target
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_COMMIT: ${{ inputs.release_commit }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-
-          $resolved = & gh api "repos/$env:GITHUB_REPOSITORY/commits/$env:RELEASE_TAG" --jq .sha
-          if ($LASTEXITCODE -ne 0 -or $resolved.Trim() -cne $env:RELEASE_COMMIT) {
-            throw "$env:RELEASE_TAG no longer resolves to $env:RELEASE_COMMIT."
-          }
-
-          $releaseTags = @(
-            & gh api --paginate "repos/$env:GITHUB_REPOSITORY/releases" --jq '.[].tag_name'
-          )
-          if ($LASTEXITCODE -ne 0) {
-            throw "Could not check for an existing $env:RELEASE_TAG GitHub Release."
-          }
-          if ($releaseTags -ccontains $env:RELEASE_TAG) {
-            throw "A $env:RELEASE_TAG GitHub Release already exists; packages will not be published."
-          }
-
-      - name: NuGet login through Trusted Publishing
-        id: nuget-login
-        uses: NuGet/login@v1
-        with:
-          user: ${{ secrets.NUGET_USER }}
-
       - name: Require an unpublished NuGet candidate version
         shell: pwsh
         run: |
           ./scripts/Test-CSharpDbNuGetCandidateAbsent.ps1 `
             -ManifestPath artifacts/nuget/CSharpDB-PACKAGE-MANIFEST.json
 
-      - name: Push CSharpDB.Observability to NuGet.org
-        shell: bash
-        run: |
-          set -euo pipefail
-          dotnet nuget push "artifacts/nuget/CSharpDB.Observability.${{ steps.version.outputs.package_file_version }}.nupkg" \
-            --source "https://api.nuget.org/v3/index.json" \
-            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
-
-      - name: Wait for CSharpDB.Observability on NuGet.org
-        shell: pwsh
-        run: |
-          ./scripts/Wait-NuGetPackageVersion.ps1 `
-            -Version "${{ steps.version.outputs.version }}" `
-            -PackageId 'CSharpDB.Observability'
-
-      - name: Push remaining packages in validated topological order
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-        run: |
-          $manifest = Get-Content `
-            -Raw `
-            -LiteralPath artifacts/nuget/CSharpDB-PACKAGE-MANIFEST.json |
-              ConvertFrom-Json
-          foreach ($package in $manifest.packages) {
-            if ($package.id -ceq 'CSharpDB.Observability') {
-              continue
-            }
-
-            $packagePath = Join-Path artifacts/nuget $package.file
-            & dotnet nuget push $packagePath `
-              --source 'https://api.nuget.org/v3/index.json' `
-              --api-key $env:NUGET_API_KEY
-            if ($LASTEXITCODE -ne 0) {
-              throw "Failed to push $($package.id)."
-            }
-
-            ./scripts/Wait-NuGetPackageVersion.ps1 `
-              -Version "${{ steps.version.outputs.version }}" `
-              -PackageId $package.id
-          }
-
-      - name: Verify packages are visible on NuGet.org
-        shell: pwsh
-        run: |
-          ./scripts/Wait-NuGetPackageVersion.ps1 `
-            -Version "${{ steps.version.outputs.version }}" `
-            -PackageId @(
-              'CSharpDB.Primitives',
-              'CSharpDB.Observability',
-              'CSharpDB.Sql',
-              'CSharpDB.Storage',
-              'CSharpDB.ImportExport',
-              'CSharpDB.Execution',
-              'CSharpDB.Storage.Diagnostics',
-              'CSharpDB.Engine',
-              'CSharpDB.Pipelines',
-              'CSharpDB.Generators',
-              'CSharpDB.Client',
-              'CSharpDB.CodeModules',
-              'CSharpDB.Data',
-              'CSharpDB.Migration',
-              'CSharpDB.Migration.DualRun',
-              'CSharpDB.EntityFrameworkCore',
-              'CSharpDB.EntityFrameworkCore.Tools',
-              'CSharpDB'
-            )
-
-      - name: Upload NuGet artifacts
+      - name: Upload qualified NuGet candidate
         uses: actions/upload-artifact@v7
         with:
-          name: nuget-packages
+          name: nuget-candidate
           path: |
             artifacts/nuget/*.nupkg
             artifacts/nuget/CSharpDB-PACKAGE-MANIFEST.json
@@ -764,12 +684,12 @@ jobs:
             artifacts/admin-release/archives/ADMIN-SHA256SUMS.txt
           if-no-files-found: error
 
-  create-release:
-    name: Create GitHub Release
-    needs: [publish-nuget, migration-archives, native-aot, daemon-archives, admin-desktop-archive]
+  prepare-release-bundle:
+    name: Prepare final release bundle
+    needs: [prepare-nuget, migration-archives, native-aot, api-host-observability, daemon-archives, admin-desktop-archive]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -781,62 +701,49 @@ jobs:
       - name: Download NuGet artifacts
         uses: actions/download-artifact@v8
         with:
-          name: nuget-packages
-          path: artifacts/nuget
+          name: nuget-candidate
+          path: artifacts/release-bundle/nuget
 
       - name: Download native artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: native-*
-          path: artifacts/native
+          path: artifacts/release-bundle/native
           merge-multiple: true
 
       - name: Download migration artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: migration-*
-          path: artifacts/migration
+          path: artifacts/release-bundle/migration
           merge-multiple: true
 
       - name: Download daemon artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: daemon-*
-          path: artifacts/daemon
+          path: artifacts/release-bundle/daemon
           merge-multiple: true
 
       - name: Download Admin desktop artifacts
         uses: actions/download-artifact@v8
         with:
           name: admin-desktop-win-x64
-          path: artifacts/admin-desktop
+          path: artifacts/release-bundle/admin-desktop
 
       - name: Generate daemon checksums
         shell: bash
         run: |
           set -euo pipefail
-          cd artifacts/daemon
+          cd artifacts/release-bundle/daemon
           sha256sum csharpdb-daemon-v* > SHA256SUMS.txt
 
       - name: Generate migration checksums
         shell: bash
         run: |
           set -euo pipefail
-          cd artifacts/migration
+          cd artifacts/release-bundle/migration
           sha256sum csharpdb-migration-tool-v* > MIGRATION-SHA256SUMS.txt
-
-      - name: Revalidate the immutable release target
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          RELEASE_COMMIT: ${{ inputs.release_commit }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $resolved = & gh api "repos/$env:GITHUB_REPOSITORY/commits/$env:RELEASE_TAG" --jq .sha
-          if ($LASTEXITCODE -ne 0 -or $resolved.Trim() -cne $env:RELEASE_COMMIT) {
-            throw "$env:RELEASE_TAG no longer resolves to $env:RELEASE_COMMIT."
-          }
 
       - name: Resolve release notes
         id: notes
@@ -844,7 +751,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -f RELEASE_NOTES.md ]]; then
-            notes_file="release-notes-current.md"
+            notes_file="artifacts/release-bundle/release-notes-current.md"
             awk '
               /^## / {
                 if (started) exit
@@ -863,58 +770,48 @@ jobs:
             echo "has_notes=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Require the immutable target and absent release before creation
+      - name: Verify complete immutable release bundle
         shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          RELEASE_COMMIT: ${{ inputs.release_commit }}
         run: |
           $ErrorActionPreference = 'Stop'
-
-          $resolved = & gh api "repos/$env:GITHUB_REPOSITORY/commits/$env:RELEASE_TAG" --jq .sha
-          if ($LASTEXITCODE -ne 0 -or $resolved.Trim() -cne $env:RELEASE_COMMIT) {
-            throw "$env:RELEASE_TAG no longer resolves to $env:RELEASE_COMMIT."
+          if ('${{ steps.notes.outputs.has_notes }}' -cne 'true') {
+            throw 'RELEASE_NOTES.md must contain a current release section.'
           }
-
-          $releaseTags = @(
-            & gh api --paginate "repos/$env:GITHUB_REPOSITORY/releases" --jq '.[].tag_name'
+          $expectedHeading = "## CSharpDB ${{ needs.prepare-nuget.outputs.version }}"
+          $actualHeading = Get-Content -LiteralPath `
+            artifacts/release-bundle/release-notes-current.md |
+            Select-Object -First 1
+          if ($actualHeading -cne $expectedHeading) {
+            throw "Release notes begin with '$actualHeading'; expected '$expectedHeading'."
+          }
+          $requiredPatterns = @(
+            'nuget/*.nupkg',
+            'nuget/CSharpDB-PACKAGE-MANIFEST.json',
+            'native/*',
+            'migration/csharpdb-migration-tool-v*',
+            'migration/MIGRATION-SHA256SUMS.txt',
+            'daemon/csharpdb-daemon-v*',
+            'daemon/SHA256SUMS.txt',
+            'admin-desktop/*.zip',
+            'admin-desktop/ADMIN-SHA256SUMS.txt',
+            'release-notes-current.md'
           )
-          if ($LASTEXITCODE -ne 0) {
-            throw "Could not check for an existing $env:RELEASE_TAG GitHub Release."
+          foreach ($pattern in $requiredPatterns) {
+            if (@(Get-ChildItem -Path (Join-Path 'artifacts/release-bundle' $pattern) -File).Count -eq 0) {
+              throw "Release bundle is missing required content: $pattern"
+            }
           }
-          if ($releaseTags -ccontains $env:RELEASE_TAG) {
-            throw "A $env:RELEASE_TAG GitHub Release already exists; publication will not update it."
-          }
+          ./scripts/Test-CSharpDbNuGetReleaseGraph.ps1 `
+            -FeedPath artifacts/release-bundle/nuget `
+            -Version '${{ needs.prepare-nuget.outputs.version }}' `
+            -ValidateExistingManifest
+          ./scripts/Test-CSharpDbNuGetCandidateAbsent.ps1 `
+            -ManifestPath artifacts/release-bundle/nuget/CSharpDB-PACKAGE-MANIFEST.json
 
-      - name: Create release (custom notes)
-        if: steps.notes.outputs.has_notes == 'true'
-        uses: softprops/action-gh-release@v2
+      - name: Upload final release bundle
+        uses: actions/upload-artifact@v7
         with:
-          name: CSharpDB v${{ needs.publish-nuget.outputs.version }}
-          body_path: ${{ steps.notes.outputs.path }}
-          tag_name: ${{ inputs.release_tag }}
-          target_commitish: ${{ inputs.release_commit }}
-          files: |
-            artifacts/nuget/*.nupkg
-            artifacts/nuget/CSharpDB-PACKAGE-MANIFEST.json
-            artifacts/native/*
-            artifacts/migration/*
-            artifacts/daemon/*
-            artifacts/admin-desktop/*
-
-      - name: Create release (auto-generated notes)
-        if: steps.notes.outputs.has_notes == 'false'
-        uses: softprops/action-gh-release@v2
-        with:
-          name: CSharpDB v${{ needs.publish-nuget.outputs.version }}
-          generate_release_notes: true
-          tag_name: ${{ inputs.release_tag }}
-          target_commitish: ${{ inputs.release_commit }}
-          files: |
-            artifacts/nuget/*.nupkg
-            artifacts/nuget/CSharpDB-PACKAGE-MANIFEST.json
-            artifacts/native/*
-            artifacts/migration/*
-            artifacts/daemon/*
-            artifacts/admin-desktop/*
+          name: release-bundle
+          path: artifacts/release-bundle
+          if-no-files-found: error
+          retention-days: 90

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,26 @@
 # What's New
 
-## CSharpDB 4.6.1
+## CSharpDB 4.6.2
 
-CSharpDB 4.6.1 adds an end-to-end observability and diagnostics platform for
+CSharpDB 4.6.2 adds an end-to-end observability and diagnostics platform for
 embedded databases, API and daemon hosts, sharded clients, and CSharpDB Admin.
 The release introduces safe structured events, bounded runtime diagnostics,
 OpenTelemetry traces and metrics, Prometheus export, health and readiness
 signals, and a dedicated Admin workspace while keeping exporter dependencies
 out of the database engine.
 
-The `v4.6.0` tag is retained as release-attempt history, but its workflow
-stopped before any NuGet package or GitHub Release was published because the
-tagged source still declared package version 4.5.1. Version 4.6.1 carries the
-intended 4.6 release contents from a new, correctly versioned tag.
+The `v4.6.0` and `v4.6.1` tags are retained as immutable release-attempt
+history. The first attempt stopped because the tagged source still declared
+package version 4.5.1. The second stopped during previous-release performance
+qualification because the comparison harness referenced an observability
+project that is absent from the published v4.5.1 source. Neither attempt
+published a NuGet package or GitHub Release. Version 4.6.2 carries the intended
+4.6 release contents from a new version.
+
+The recovery uses a tag-last release process: one supported command completes
+release qualification for the exact commit, including its previous-release
+comparison and final bundle, before creating the immutable release tag. It
+then publishes that exact qualified bundle through a resumable hosted step.
 
 ### Observability Contracts and Safe Defaults
 

--- a/docs/releases/v4.6.2-pr-notes.md
+++ b/docs/releases/v4.6.2-pr-notes.md
@@ -1,0 +1,79 @@
+## Summary
+
+Prepare CSharpDB 4.6.2 as the publishable recovery for the 4.6 observability
+release. The `v4.6.0` and `v4.6.1` Git tags remain immutable failed-attempt
+history. Neither attempt published a NuGet package or GitHub Release.
+
+### Recovery delta: failed 4.6 tags to v4.6.2
+
+- Advance package identity, the current migration capability catalog, release
+  notes, and the migration-archive default to 4.6.2.
+- Preserve the immutable 4.6.1 migration capability catalog so plans created
+  against that tagged source remain independently replayable.
+- Preserve both failed Git tags exactly where they are. Do not move, recreate,
+  or publish from either tag.
+- Keep the public product delta equal to the intended 4.6 observability work;
+  this recovery does not add another product feature set.
+
+The v4.6.0 attempt failed because its tagged source still declared package
+version 4.5.1. The v4.6.1 attempt passed current-source qualification but
+failed while preparing the previous-release performance comparison: the
+comparison harness referenced an observability project that does not exist in
+the published v4.5.1 source tree.
+
+The intended release process is tag-last. One supported command runs release
+qualification for the exact candidate commit, including the previous-release
+comparison and final bundle, before creating the immutable v4.6.2 tag. It then
+starts a resumable hosted publication of that exact bundle. These notes
+describe the required boundary without claiming a hosted run has passed before
+it actually does.
+
+### Public delta: v4.5.1 to v4.6.2
+
+The public release delta is the intended 4.6 observability and diagnostics
+feature set described in `RELEASE_NOTES.md`. It includes BCL-only observability
+contracts, safe structured events, bounded runtime diagnostics, OpenTelemetry
+and Prometheus integration, health and readiness endpoints, daemon gRPC health
+support, and the Admin observability workspace.
+
+## Type of Change
+
+- [x] Bug fix
+- [x] New feature
+- [ ] Breaking change
+- [x] Documentation update
+- [x] Refactor / maintenance
+- [ ] Tests only
+
+## Related Issues
+
+None linked.
+
+## Testing
+
+Local validation must cover version alignment, migration catalog retention,
+release metadata, the cross-version benchmark build, and the tag-last workflow
+contracts. Actual external publication is not claimed by this pull request.
+
+- [ ] Strict solution build passes
+- [ ] Relevant release and packaging contract tests pass
+- [ ] Release qualification passes for the exact candidate commit before tag
+- [ ] Modified PowerShell scripts pass parser validation
+- [ ] Git whitespace/error check passes
+
+## Checklist
+
+- [x] I followed the project style and conventions.
+- [x] I added or updated tests for behavior changes.
+- [x] I covered both failed-tag recovery paths.
+- [x] I updated release-facing documentation.
+- [x] I verified no sensitive data was added.
+
+## Notes for Reviewers
+
+- Treat `v4.6.0` and `v4.6.1` only as immutable failed-attempt history. Their
+  existence does not indicate a published 4.6 release.
+- Verify the complete release candidate before creating `v4.6.2`; do not use
+  the tag itself as the first execution of release qualification.
+- NuGet publication and GitHub Release creation must remain downstream of all
+  required qualification.

--- a/docs/security-access-control-plan.md
+++ b/docs/security-access-control-plan.md
@@ -110,8 +110,8 @@ transport-specific security stacks:
   mode, or clearly identify and audit a single service principal for trusted
   local mode.
 - Apply installer hardening under `deploy/daemon`, and release trust changes in
-  `.github/workflows/publish-release.yml`, the reusable
-  `.github/workflows/release.yml` implementation, and the existing packaging scripts.
+  the manually dispatched, tag-last `.github/workflows/release.yml` and the
+  existing packaging scripts.
 
 ## Trust Boundaries And Deployment Profiles
 

--- a/scripts/Publish-CSharpDbMigrationRelease.ps1
+++ b/scripts/Publish-CSharpDbMigrationRelease.ps1
@@ -56,7 +56,7 @@ $Version = (Read-Host 'Release version without the v prefix').Trim()
 #>
 [CmdletBinding()]
 param(
-    [string] $Version = '4.6.1',
+    [string] $Version = '4.6.2',
 
     [ValidateSet('win-x64', 'linux-x64', 'osx-arm64')]
     [string[]] $Runtime = @(

--- a/scripts/Publish-ReleaseTag.ps1
+++ b/scripts/Publish-ReleaseTag.ps1
@@ -11,13 +11,11 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
-$tagValidator = Join-Path $PSScriptRoot 'Test-ReleaseTag.ps1'
 $releaseVersion = $Version.TrimStart('v')
 $releaseTag = "v$releaseVersion"
-
-if (-not (Test-Path -LiteralPath $tagValidator -PathType Leaf)) {
-    throw "Required release script was not found: $tagValidator"
-}
+$qualificationWorkflow = 'release.yml'
+$publicationWorkflow = 'publish-release.yml'
+$tagValidator = Join-Path $PSScriptRoot 'Test-ReleaseTag.ps1'
 
 function Invoke-Git {
     param(
@@ -31,27 +29,41 @@ function Invoke-Git {
     $output = @(& git -C $repositoryRoot @Arguments 2>&1)
     if ($LASTEXITCODE -ne 0) {
         $details = ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
-        if ([string]::IsNullOrWhiteSpace($details)) {
-            throw $FailureMessage
-        }
+        if ([string]::IsNullOrWhiteSpace($details)) { throw $FailureMessage }
         throw "$FailureMessage$([Environment]::NewLine)$details"
     }
-
     return ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
 }
 
-function Resolve-GitCommitOrNull {
+function Invoke-Gh {
     param(
         [Parameter(Mandatory)]
-        [string] $Ref
+        [string[]] $Arguments,
+
+        [Parameter(Mandatory)]
+        [string] $FailureMessage
     )
 
-    $output = @(& git -C $repositoryRoot rev-parse --verify "$Ref`^{commit}" 2>$null)
-    $exitCode = $LASTEXITCODE
-    if ($exitCode -ne 0) {
-        return $null
+    Push-Location $repositoryRoot
+    try {
+        $output = @(& gh @Arguments 2>&1)
+        if ($LASTEXITCODE -ne 0) {
+            $details = ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
+            if ([string]::IsNullOrWhiteSpace($details)) { throw $FailureMessage }
+            throw "$FailureMessage$([Environment]::NewLine)$details"
+        }
+        return ($output | ForEach-Object { [string] $_ }) -join [Environment]::NewLine
     }
+    finally {
+        Pop-Location
+    }
+}
 
+function Resolve-GitCommitOrNull {
+    param([Parameter(Mandatory)][string] $Ref)
+
+    $output = @(& git -C $repositoryRoot rev-parse --verify "$Ref`^{commit}" 2>$null)
+    if ($LASTEXITCODE -ne 0) { return $null }
     $resolved = (($output | ForEach-Object { [string] $_ }) -join '').Trim()
     if ($resolved -cnotmatch '^[0-9a-f]{40}$') {
         throw "Git ref '$Ref' did not resolve to a canonical commit SHA."
@@ -60,10 +72,7 @@ function Resolve-GitCommitOrNull {
 }
 
 function Resolve-RemoteTagCommitOrNull {
-    param(
-        [Parameter(Mandatory)]
-        [string] $TagName
-    )
+    param([Parameter(Mandatory)][string] $TagName)
 
     $output = Invoke-Git `
         -Arguments @(
@@ -73,9 +82,7 @@ function Resolve-RemoteTagCommitOrNull {
             "refs/tags/$TagName",
             "refs/tags/$TagName`^{}") `
         -FailureMessage "Could not inspect remote release tag '$TagName'."
-    if ([string]::IsNullOrWhiteSpace($output)) {
-        return $null
-    }
+    if ([string]::IsNullOrWhiteSpace($output)) { return $null }
 
     $records = @(
         $output -split "`r?`n" |
@@ -84,24 +91,13 @@ function Resolve-RemoteTagCommitOrNull {
                 if ($_ -cnotmatch '^(?<sha>[0-9a-f]{40})\s+(?<ref>refs/tags/.+)$') {
                     throw "Remote tag query returned an invalid record: $_"
                 }
-                [pscustomobject]@{
-                    Sha = $Matches.sha
-                    Ref = $Matches.ref
-                }
+                [pscustomobject]@{ Sha = $Matches.sha; Ref = $Matches.ref }
             }
     )
-    $peeledRef = "refs/tags/$TagName`^{}"
-    $peeled = @($records | Where-Object { $_.Ref -ceq $peeledRef })
-    if ($peeled.Count -gt 1) {
-        throw "Remote release tag '$TagName' returned multiple peeled commits."
-    }
-    if ($peeled.Count -eq 1) {
-        return [string] $peeled[0].Sha
-    }
-
-    $directRef = "refs/tags/$TagName"
-    $direct = @($records | Where-Object { $_.Ref -ceq $directRef })
-    if ($direct.Count -ne 1) {
+    $peeled = @($records | Where-Object { $_.Ref -ceq "refs/tags/$TagName`^{}" })
+    if ($peeled.Count -eq 1) { return [string] $peeled[0].Sha }
+    $direct = @($records | Where-Object { $_.Ref -ceq "refs/tags/$TagName" })
+    if ($peeled.Count -gt 1 -or $direct.Count -ne 1) {
         throw "Remote release tag '$TagName' did not resolve unambiguously."
     }
     return [string] $direct[0].Sha
@@ -112,14 +108,14 @@ function Get-ExactCurrentMainCommit {
         -Arguments @('status', '--porcelain=v1', '--untracked-files=all') `
         -FailureMessage 'Could not inspect the repository worktree.'
     if (-not [string]::IsNullOrWhiteSpace($workingTreeChanges)) {
-        throw 'Release tagging requires a clean repository worktree.'
+        throw 'Release publication requires a clean repository worktree.'
     }
 
     $currentBranch = (Invoke-Git `
         -Arguments @('branch', '--show-current') `
         -FailureMessage 'Could not determine the current branch.').Trim()
     if ($currentBranch -cne 'main') {
-        throw "Release tagging must run from branch 'main'; current branch is '$currentBranch'."
+        throw "Release publication must run from branch 'main'; current branch is '$currentBranch'."
     }
 
     Invoke-Git `
@@ -139,96 +135,266 @@ function Get-ExactCurrentMainCommit {
         -FailureMessage "Could not resolve 'origin/main'.").Trim()
     if ($localMainCommit -cne $remoteMainCommit) {
         throw (
-            "Release tagging requires local main to equal origin/main exactly. " +
+            'Release publication requires local main to equal origin/main exactly. ' +
             "Local HEAD is $localMainCommit; origin/main is $remoteMainCommit.")
     }
-
     return $localMainCommit
 }
 
-$headCommit = Get-ExactCurrentMainCommit
+function Get-WorkflowRuns {
+    param(
+        [Parameter(Mandatory)][string] $Repository,
+        [Parameter(Mandatory)][string] $Commit,
+        [Parameter(Mandatory)][string] $Workflow
+    )
 
-$buildPropsPath = Join-Path $repositoryRoot 'src/Directory.Build.props'
-if (-not (Test-Path -LiteralPath $buildPropsPath -PathType Leaf)) {
-    throw "Shared package properties were not found at '$buildPropsPath'."
-}
-[xml] $buildProps = [IO.File]::ReadAllText($buildPropsPath)
-$versionNodes = @($buildProps.SelectNodes('/Project/PropertyGroup/Version'))
-if ($versionNodes.Count -ne 1) {
-    throw "Expected exactly one Version property in '$buildPropsPath'; found $($versionNodes.Count)."
-}
-$packageVersion = $versionNodes[0].InnerText.Trim()
-if ($packageVersion -cne $releaseVersion) {
-    throw (
-        "Release tag version '$releaseVersion' does not match package version " +
-        "'$packageVersion' in '$buildPropsPath'.")
-}
-
-$currentMainCommit = Get-ExactCurrentMainCommit
-if ($currentMainCommit -cne $headCommit) {
-    throw (
-        "The exact main commit changed during release validation. Validated $headCommit, " +
-        "but current main is $currentMainCommit. Restart release tagging for the current commit.")
+    $json = Invoke-Gh `
+        -Arguments @(
+            'run', 'list',
+            '--repo', $Repository,
+            '--workflow', $Workflow,
+            '--event', 'workflow_dispatch',
+            '--commit', $Commit,
+            '--limit', '30',
+            '--json', 'databaseId,displayTitle,event,headSha,status,conclusion,url') `
+        -FailureMessage 'Could not enumerate hosted release runs.'
+    return @($json | ConvertFrom-Json)
 }
 
-$localTagCommit = Resolve-GitCommitOrNull -Ref "refs/tags/$releaseTag"
-if ($null -ne $localTagCommit -and $localTagCommit -cne $headCommit) {
-    throw (
-        "Local release tag '$releaseTag' points to $localTagCommit, not exact release " +
-        "commit $headCommit.")
+Invoke-Gh -Arguments @('auth', 'status') -FailureMessage 'GitHub CLI authentication is required.' |
+    Out-Null
+$repository = (Invoke-Gh `
+    -Arguments @('repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner') `
+    -FailureMessage 'Could not resolve the GitHub repository identity.').Trim()
+if ([string]::IsNullOrWhiteSpace($repository)) {
+    throw 'GitHub repository identity was empty.'
+}
+
+
+function Get-GitHubReleaseOrNull {
+    $tags = @(
+        (Invoke-Gh `
+            -Arguments @(
+                'api', '--paginate', "repos/$repository/releases", '--jq', '.[].tag_name') `
+            -FailureMessage 'Could not inspect existing GitHub Releases.') `
+            -split "`r?`n" |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($tags -cnotcontains $releaseTag) { return $null }
+    $json = Invoke-Gh `
+        -Arguments @(
+            'release', 'view', $releaseTag, '--repo', $repository,
+            '--json', 'isDraft,tagName,url') `
+        -FailureMessage "Could not inspect GitHub Release '$releaseTag'."
+    return ($json | ConvertFrom-Json)
+}
+
+function Wait-HostedRun {
+    param([Parameter(Mandatory)] $Run, [Parameter(Mandatory)][string] $Kind)
+
+    Push-Location $repositoryRoot
+    try {
+        & gh run watch ([string] $Run.databaseId) `
+            --repo $repository `
+            --compact `
+            --exit-status
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    if ($exitCode -ne 0) {
+        throw "$Kind failed: $($Run.url)"
+    }
+}
+
+function Find-OrDispatchRun {
+    param(
+        [Parameter(Mandatory)][string] $Workflow,
+        [Parameter(Mandatory)][string] $Commit,
+        [Parameter(Mandatory)][string] $Title,
+        [Parameter(Mandatory)][string] $Ref,
+        [Parameter(Mandatory)][string[]] $Fields,
+        [Parameter(Mandatory)][string] $Kind
+    )
+
+    $existing = @(Get-WorkflowRuns -Repository $repository -Commit $Commit -Workflow $Workflow)
+    $active = @($existing | Where-Object {
+        $_.displayTitle -ceq $Title -and $_.status -cne 'completed'
+    })
+    if ($active.Count -gt 1) { throw "Multiple active $Kind runs exist for '$Title'." }
+    if ($active.Count -eq 1) {
+        Write-Host "Reusing active $Kind run $($active[0].databaseId): $($active[0].url)"
+        return $active[0]
+    }
+    if ($Kind -ceq 'release qualification') {
+        $successful = @($existing | Where-Object {
+            $_.displayTitle -ceq $Title -and
+            $_.status -ceq 'completed' -and
+            $_.conclusion -ceq 'success'
+        } | Sort-Object databaseId -Descending)
+        foreach ($candidate in $successful) {
+            $artifactCount = [int] (Invoke-Gh `
+                -Arguments @(
+                    'api',
+                    "repos/$repository/actions/runs/$($candidate.databaseId)/artifacts",
+                    '--jq', '[.artifacts[] | select(.name == "release-bundle" and .expired == false)] | length') `
+                -FailureMessage "Could not inspect artifacts for qualification run $($candidate.databaseId).").Trim()
+            if ($artifactCount -eq 1) {
+                Write-Host "Reusing successful release qualification $($candidate.databaseId): $($candidate.url)"
+                return $candidate
+            }
+        }
+    }
+
+    $knownIds = [Collections.Generic.HashSet[long]]::new()
+    foreach ($known in $existing) { $knownIds.Add([long] $known.databaseId) | Out-Null }
+    $arguments = @('workflow', 'run', $Workflow, '--repo', $repository, '--ref', $Ref)
+    foreach ($field in $Fields) { $arguments += @('--raw-field', $field) }
+    Invoke-Gh -Arguments $arguments -FailureMessage "Could not dispatch the $Kind workflow." |
+        Out-Null
+
+    $deadline = [Diagnostics.Stopwatch]::StartNew()
+    while ($deadline.Elapsed -lt [TimeSpan]::FromMinutes(2)) {
+        $new = @(Get-WorkflowRuns -Repository $repository -Commit $Commit -Workflow $Workflow |
+            Where-Object {
+                $_.displayTitle -ceq $Title -and
+                -not $knownIds.Contains([long] $_.databaseId)
+            })
+        if ($new.Count -gt 1) { throw "$Kind dispatch created multiple matching runs." }
+        if ($new.Count -eq 1) {
+            Write-Host "Dispatched $Kind run $($new[0].databaseId): $($new[0].url)"
+            return $new[0]
+        }
+        Start-Sleep -Seconds 3
+    }
+    throw "The $Kind run did not appear within two minutes."
+}
+
+function Start-PublicationRun {
+    param(
+        [Parameter(Mandatory)][string] $Commit,
+        [Parameter(Mandatory)][long] $QualificationRunId,
+        [Parameter(Mandatory)][bool] $PreflightOnly
+    )
+
+    $mode = if ($PreflightOnly) { 'preflight' } else { 'publication' }
+    $modeLabel = if ($PreflightOnly) { 'preflight' } else { 'release' }
+    $title = "Publish $releaseTag from qualification $QualificationRunId ($modeLabel)"
+    $run = Find-OrDispatchRun `
+        -Workflow $publicationWorkflow `
+        -Commit $Commit `
+        -Title $title `
+        -Ref $(if ($PreflightOnly) { 'main' } else { $releaseTag }) `
+        -Fields @(
+            "release_tag=$releaseTag",
+            "release_commit=$Commit",
+            "qualification_run_id=$QualificationRunId",
+            "preflight_only=$($PreflightOnly.ToString().ToLowerInvariant())") `
+        -Kind "release $mode"
+    Wait-HostedRun -Run $run -Kind "Release $mode"
+    return $run
 }
 
 $remoteTagCommit = Resolve-RemoteTagCommitOrNull -TagName $releaseTag
-if ($null -ne $remoteTagCommit -and $remoteTagCommit -cne $headCommit) {
-    throw (
-        "Remote release tag '$releaseTag' points to $remoteTagCommit, not exact release " +
-        "commit $headCommit.")
-}
-
-if ($null -eq $localTagCommit) {
-    if ($null -ne $remoteTagCommit) {
-        Invoke-Git `
-            -Arguments @(
-                'fetch',
-                '--quiet',
-                'origin',
-                "refs/tags/$releaseTag`:refs/tags/$releaseTag") `
-            -FailureMessage "Could not fetch existing remote release tag '$releaseTag'." |
-            Out-Null
+$qualificationRun = $null
+if ($null -eq $remoteTagCommit) {
+    $headCommit = Get-ExactCurrentMainCommit
+    $buildPropsPath = Join-Path $repositoryRoot 'src/Directory.Build.props'
+    [xml] $buildProps = [IO.File]::ReadAllText($buildPropsPath)
+    $versionNodes = @($buildProps.SelectNodes('/Project/PropertyGroup/Version'))
+    if ($versionNodes.Count -ne 1) {
+        throw "Expected exactly one Version property; found $($versionNodes.Count)."
     }
-    else {
-        Invoke-Git `
-            -Arguments @('tag', $releaseTag, $headCommit) `
-            -FailureMessage "Could not create local release tag '$releaseTag'." |
-            Out-Null
+    if ($versionNodes[0].InnerText.Trim() -cne $releaseVersion) {
+        throw "Requested release '$releaseVersion' does not match the package version."
     }
 
     $localTagCommit = Resolve-GitCommitOrNull -Ref "refs/tags/$releaseTag"
-    if ($localTagCommit -cne $headCommit) {
-        throw "Local release tag '$releaseTag' was not created at exact commit $headCommit."
+    if ($null -ne $localTagCommit -and $localTagCommit -cne $headCommit) {
+        throw "Local release tag '$releaseTag' does not target exact main $headCommit."
     }
-}
-else {
-    Write-Host "Reusing local release tag '$releaseTag' at exact commit $headCommit."
-}
 
-& $tagValidator -Version $releaseTag -TagCommit $headCommit
+    $qualificationTitle = "Qualify release $releaseTag at $headCommit"
+    $qualificationRun = Find-OrDispatchRun `
+        -Workflow $qualificationWorkflow `
+        -Commit $headCommit `
+        -Title $qualificationTitle `
+        -Ref 'main' `
+        -Fields @("release_tag=$releaseTag", "release_commit=$headCommit") `
+        -Kind 'release qualification'
+    Write-Host 'Every reversible gate runs before tag creation. A qualification failure leaves the version retryable.'
+    Wait-HostedRun -Run $qualificationRun -Kind 'Release qualification'
 
-if ($null -eq $remoteTagCommit) {
-    Invoke-Git `
-        -Arguments @(
-            'push',
-            'origin',
-            "refs/tags/$releaseTag`:refs/tags/$releaseTag") `
-        -FailureMessage "Could not push release tag '$releaseTag'." |
+    Start-PublicationRun `
+        -Commit $headCommit `
+        -QualificationRunId ([long] $qualificationRun.databaseId) `
+        -PreflightOnly $true |
         Out-Null
 
+    if ((Get-ExactCurrentMainCommit) -cne $headCommit) {
+        throw 'Main changed while qualification ran; rerun the command for current main.'
+    }
+    & $tagValidator -Version $releaseTag -TagCommit $headCommit -AllowMissingTag
+    if ($null -eq $localTagCommit) {
+        Invoke-Git -Arguments @('tag', $releaseTag, $headCommit) `
+            -FailureMessage "Could not create local release tag '$releaseTag'." |
+            Out-Null
+    }
+    Invoke-Git `
+        -Arguments @('push', 'origin', "refs/tags/$releaseTag`:refs/tags/$releaseTag") `
+        -FailureMessage "Could not push qualified release tag '$releaseTag'." |
+        Out-Null
     $remoteTagCommit = Resolve-RemoteTagCommitOrNull -TagName $releaseTag
     if ($remoteTagCommit -cne $headCommit) {
-        throw "Remote release tag '$releaseTag' was not published at exact commit $headCommit."
+        throw "Remote release tag '$releaseTag' was not created at exact commit $headCommit."
     }
-    Write-Host "Published release tag '$releaseTag' at exact commit $headCommit."
 }
 else {
-    Write-Host "Remote release tag '$releaseTag' already points to exact commit $headCommit."
+    $headCommit = $remoteTagCommit
+    $publishRuns = @(
+        Get-WorkflowRuns -Repository $repository -Commit $headCommit -Workflow $publicationWorkflow |
+            Where-Object {
+                $_.displayTitle -match "^Publish $([regex]::Escape($releaseTag)) from qualification (?<id>[1-9][0-9]*) \(preflight\)$" -and
+                $_.status -ceq 'completed' -and
+                $_.conclusion -ceq 'success'
+            }
+    )
+    $qualificationIds = @($publishRuns | ForEach-Object {
+        if ($_.displayTitle -match 'qualification (?<id>[1-9][0-9]*) \(preflight\)$') { [long] $Matches.id }
+    } | Sort-Object -Unique)
+    if ($qualificationIds.Count -ne 1) {
+        throw "Existing tag '$releaseTag' is not bound to exactly one qualification run."
+    }
+    $qualificationId = $qualificationIds[0]
+    $qualificationRun = @(
+        Get-WorkflowRuns -Repository $repository -Commit $headCommit -Workflow $qualificationWorkflow |
+            Where-Object {
+                [long] $_.databaseId -eq $qualificationId -and
+                $_.displayTitle -ceq "Qualify release $releaseTag at $headCommit" -and
+                $_.status -ceq 'completed' -and
+                $_.conclusion -ceq 'success'
+            }
+    ) | Select-Object -First 1
+    if ($null -eq $qualificationRun) {
+        throw "Existing tag '$releaseTag' is not bound to a successful exact qualification run."
+    }
+    Write-Host "Resuming publication for qualified tag $releaseTag."
 }
+
+Start-PublicationRun `
+    -Commit $headCommit `
+    -QualificationRunId ([long] $qualificationRun.databaseId) `
+    -PreflightOnly $false |
+    Out-Null
+
+$remoteTagCommit = Resolve-RemoteTagCommitOrNull -TagName $releaseTag
+if ($remoteTagCommit -cne $headCommit) {
+    throw "Release tag '$releaseTag' no longer targets exact commit $headCommit."
+}
+$release = Get-GitHubReleaseOrNull
+if ($null -eq $release -or $release.isDraft) {
+    throw "Successful publication did not create a published GitHub Release '$releaseTag'."
+}
+Write-Host "Published $releaseTag at exact commit $headCommit."
+Write-Host "GitHub Release: $($release.url)"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,12 +12,12 @@ and are included in daemon release archives.
 
 The release and local workflow notes are grouped by audience:
 
-- Release maintainers use `scripts/Publish-ReleaseTag.ps1` to validate the exact
-  merged `main` commit and publish its release tag. The tag push starts the
-  hosted release qualification and publication workflow. Maintainers can use
+- Release maintainers use `scripts/Publish-ReleaseTag.ps1` as one command to
+  validate the exact merged `main` commit, run hosted qualification, create the
+  protected tag only after every reversible gate passes, and drive resumable
+  hosted publication. Maintainers can use
   `scripts/Publish-CSharpDbDaemonRelease.ps1` directly for local packaging
-  checks. The GitHub Release workflow also uses the daemon publisher after the
-  guarded `v*` tag is pushed.
+  checks. The hosted release workflows also use the daemon publisher.
 - Store release maintainers use
   `scripts/Publish-CSharpDbAdminStorePackage.ps1` on Windows to produce the
   CSharpDB Studio MSIX and `.msixupload` artifacts for Partner Center.
@@ -154,35 +154,45 @@ if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za
 .\scripts\Publish-ReleaseTag.ps1 -Version $Version
 ```
 
-`Publish-ReleaseTag.ps1` is the only supported way to create a release tag. Do
-not create release tags in the GitHub UI or with raw `git tag` / `git push`
-commands; those unsupported paths bypass the clean-main, version, and tag
-preflight. The publisher requires a clean, checked-out `main`, fetches
-`origin/main`, and requires local `HEAD` to equal that remote commit. It
-also validates that the requested version matches the package version and that
-the local or remote tag is absent or already points to that exact commit. It
-rechecks `main` before validating and pushing the tag. It does not build, test,
-benchmark, inspect a commit status, or accept a local-performance waiver.
+`Publish-ReleaseTag.ps1` is the only supported release command. Do not create
+release tags in the GitHub UI or with raw `git tag` / `git push` commands. The
+publisher requires a clean, checked-out `main`, requires local `HEAD` to equal
+`origin/main`, validates the package version, and waits for both hosted stages.
+Those branch requirements apply before tag creation. After the exact qualified
+tag exists, the command binds recovery to that immutable tag and its original
+qualification bundle, so publication can resume without rebuilding even if
+`main` has advanced.
 
-The command is idempotent for the same version and exact commit. It safely
-reuses an existing local or remote tag at that commit and rejects a same-named
-tag that points elsewhere.
-
-The `v*` tag push starts the fail-closed Release workflow. The workflow first
-verifies that the existing tag resolves to the supplied exact commit. It then
-runs one clean functional qualification on each supported operating system and
-one balanced paired hosted-stable performance comparison on Windows. The
+The qualification workflow runs every reversible gate before creating a tag:
+clean functional qualification on each supported operating system, the real previous-release
+compatibility build and balanced hosted-stable comparison, NativeAOT and host
+smokes, all archives, the final NuGet graph, the complete release bundle, a
+NuGet Trusted Publishing preflight, and the 18-package absence check. If any
+check fails, the version remains untagged and the same command can be retried
+after a fix is merged. Only after they all pass does the command create the
+protected immutable tag with the maintainer's authenticated Git identity and
+start a resumable hosted publication of the exact qualified bundle. The
 performance job uses `RepeatCount 3`, which covers both previous/candidate
 execution orders in one job. Recovery tags use the last published release as
-their explicit baseline: v4.6.1 is pinned to the exact published v4.5.1 commit
-because v4.6.0 was tagged but not published, while the existing v4.5.1
+their explicit baseline: v4.6.2 is pinned to the exact published v4.5.1 commit
+because v4.6.0 and v4.6.1 were tagged but not published, while the existing v4.5.1
 exception remains pinned to v4.4.0 because v4.5.0 was likewise not published.
 
 Publication starts only after the hosted gates and all release-archive jobs
-succeed. The workflow publishes the NuGet packages, daemon archives for
-`win-x64`, `linux-x64`, and `osx-arm64`, migration and NativeAOT artifacts, and
-the Admin desktop archive, then creates the GitHub Release with the combined
-checksums and smoke-tested assets.
+succeed. It creates or refreshes a draft GitHub Release and uploads the exact
+qualified assets first, then publishes the NuGet packages in validated order,
+verifies all versions are visible, and finally makes the draft public. A
+retry reuses the original qualification bundle, the exact tag, and the draft.
+Package pushes use NuGet's duplicate-safe mode so an interrupted publication
+can resume. The exact bound bundle is proven wholly absent immediately before
+tag creation, and the workflow is serialized per tag; under this supported
+single-publisher path, a duplicate can only be a package already accepted by an
+earlier partial attempt for that tag. Do not upload release candidates outside
+this command.
+The GitHub Release commands verify the existing remote tag and store `main` as
+the Release target (GitHub does not move an already-existing tag). Recovery
+therefore remains tied to the immutable tag and qualified bundle while Release
+updates continue to use the default-branch workflow authorization context.
 
 ### Optional local durable diagnostics
 
@@ -458,7 +468,8 @@ The check validates public documentation, NuGet package closure, EF Core
 version consistency, the full solution restore/build/test sequence, SQL Server
 and MySQL provider isolation, the Windows-only Access isolation boundary, and
 the packaged EF migration tool. Supplying both `-ReleaseVersion` and
-`-ReleaseCommit` additionally validates an existing release tag.
+`-ReleaseCommit` additionally validates the exact release candidate; the tag
+may still be absent in the tag-last workflow.
 
 ```powershell
 $OutputPath = Join-Path `

--- a/scripts/Test-CSharpDbNuGetReleaseGraph.ps1
+++ b/scripts/Test-CSharpDbNuGetReleaseGraph.ps1
@@ -4,7 +4,9 @@ param(
 
     [string]$Version,
 
-    [string]$ManifestPath
+    [string]$ManifestPath,
+
+    [switch]$ValidateExistingManifest
 )
 
 Set-StrictMode -Version Latest
@@ -319,9 +321,23 @@ if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
 else {
     $ManifestPath = Resolve-RepoPath $ManifestPath
 }
-$manifestDirectory = Split-Path -Parent $ManifestPath
-New-Item -ItemType Directory -Path $manifestDirectory -Force | Out-Null
-$manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $ManifestPath -Encoding utf8
+$manifestJson = $manifest | ConvertTo-Json -Depth 10
+if ($ValidateExistingManifest) {
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        throw "The existing package manifest was not found: $ManifestPath"
+    }
+    $existingJson = (Get-Content -Raw -LiteralPath $ManifestPath | ConvertFrom-Json) |
+        ConvertTo-Json -Depth 10
+    if ($existingJson -cne $manifestJson) {
+        throw "The existing package manifest does not match the qualified package graph: $ManifestPath"
+    }
+}
+else {
+    $manifestDirectory = Split-Path -Parent $ManifestPath
+    New-Item -ItemType Directory -Path $manifestDirectory -Force | Out-Null
+    $manifestJson | Set-Content -LiteralPath $ManifestPath -Encoding utf8
+}
 
 Write-Host "Candidate package graph, metadata, dependency policy, and hashes passed for $($candidatePackages.Count) packages."
-Write-Host "Deterministic package manifest: $ManifestPath"
+$manifestAction = if ($ValidateExistingManifest) { 'Validated' } else { 'Wrote' }
+Write-Host "$manifestAction deterministic package manifest: $ManifestPath"

--- a/scripts/Test-ReleaseTag.ps1
+++ b/scripts/Test-ReleaseTag.ps1
@@ -6,7 +6,9 @@ param(
 
     [Parameter(Mandatory)]
     [ValidatePattern('^[0-9a-f]{40}$')]
-    [string]$TagCommit
+    [string]$TagCommit,
+
+    [switch]$AllowMissingTag
 )
 
 Set-StrictMode -Version Latest
@@ -47,9 +49,14 @@ if ($LASTEXITCODE -ne 0 -or $headCommit -cne $resolvedTagCommit) {
 
 $releaseTagName = "v$releaseVersion"
 $resolvedReleaseTagCommit = (& git -C $repoRoot rev-parse "$releaseTagName^{commit}" 2>$null)
-if ($LASTEXITCODE -ne 0 -or
-    [string]::IsNullOrWhiteSpace($resolvedReleaseTagCommit) -or
-    $resolvedReleaseTagCommit.Trim() -cne $resolvedTagCommit) {
+$tagExists = $LASTEXITCODE -eq 0 -and
+    -not [string]::IsNullOrWhiteSpace($resolvedReleaseTagCommit)
+if ($tagExists) {
+    if ($resolvedReleaseTagCommit.Trim() -cne $resolvedTagCommit) {
+        throw "Release tag '$releaseTagName' must point to tag commit '$resolvedTagCommit'."
+    }
+}
+elseif (-not $AllowMissingTag) {
     throw "Release tag '$releaseTagName' must point to tag commit '$resolvedTagCommit'."
 }
 
@@ -105,4 +112,5 @@ if (-not [string]::IsNullOrWhiteSpace($previousTag)) {
     }
 }
 
-Write-Host "Release tag validation passed for v$releaseVersion at $resolvedTagCommit."
+$validationKind = if ($tagExists) { 'tag' } else { 'untagged candidate' }
+Write-Host "Release $validationKind validation passed for v$releaseVersion at $resolvedTagCommit."

--- a/scripts/Test-SqlReleaseQualification.ps1
+++ b/scripts/Test-SqlReleaseQualification.ps1
@@ -200,7 +200,7 @@ try {
 
     if ($hasReleaseVersion) {
         Invoke-QualificationCommand `
-            -StepName 'release-tag' `
+            -StepName 'release-candidate' `
             -FilePath 'pwsh' `
             -ArgumentList @(
                 '-NoLogo',
@@ -210,7 +210,8 @@ try {
                 '-Version',
                 $ReleaseVersion,
                 '-TagCommit',
-                $ReleaseCommit)
+                $ReleaseCommit,
+                '-AllowMissingTag')
     }
 
     Invoke-QualificationCommand `

--- a/src/CSharpDB.Migration/CSharpDB.Migration.csproj
+++ b/src/CSharpDB.Migration/CSharpDB.Migration.csproj
@@ -34,6 +34,8 @@
                       LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.5.1.json" />
     <EmbeddedResource Include="Capabilities\csharpdb-4.6.1.json"
                       LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.6.1.json" />
+    <EmbeddedResource Include="Capabilities\csharpdb-4.6.2.json"
+                      LogicalName="CSharpDB.Migration.Capabilities.csharpdb-4.6.2.json" />
   </ItemGroup>
 
 </Project>

--- a/src/CSharpDB.Migration/CSharpDbCapabilityCatalog.cs
+++ b/src/CSharpDB.Migration/CSharpDbCapabilityCatalog.cs
@@ -102,7 +102,7 @@ public sealed record CSharpDbCapabilityCatalog
 
 public static class CSharpDbCapabilityCatalogLoader
 {
-    public const string CurrentTargetVersion = "4.6.1";
+    public const string CurrentTargetVersion = "4.6.2";
     public const string Format = "csharpdb-target-capabilities/v1";
 
     private static readonly JsonSerializerOptions s_options = CreateOptions();
@@ -113,6 +113,7 @@ public static class CSharpDbCapabilityCatalogLoader
             ["4.4.0"] = CreateCatalog("4.4.0"),
             ["4.5.0"] = CreateCatalog("4.5.0"),
             ["4.5.1"] = CreateCatalog("4.5.1"),
+            ["4.6.1"] = CreateCatalog("4.6.1"),
             [CurrentTargetVersion] = CreateCatalog(CurrentTargetVersion),
         };
 

--- a/src/CSharpDB.Migration/Capabilities/csharpdb-4.6.2.json
+++ b/src/CSharpDB.Migration/Capabilities/csharpdb-4.6.2.json
@@ -1,0 +1,376 @@
+{
+  "format": "csharpdb-target-capabilities/v1",
+  "targetCSharpDbVersion": "4.6.2",
+  "surface": "local-typed-engine",
+  "maxIdentifierLength": 128,
+  "identifiersCaseInsensitive": true,
+  "quotedIdentifiers": true,
+  "engineEnforcesMappedColumnType": true,
+  "valueTypes": [
+    {
+      "type": "null",
+      "isRuntimeValue": true,
+      "isColumnType": false,
+      "representation": "Runtime null tag; not a declarable persistent SQL column type."
+    },
+    {
+      "type": "integer",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Shared signed 64-bit physical carrier. Logical INTEGER is signed 32-bit, BIGINT is signed 64-bit, and BOOLEAN is canonical 0/1."
+    },
+    {
+      "type": "real",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "IEEE 754 binary64 floating-point value."
+    },
+    {
+      "type": "text",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Persisted UTF-8 text."
+    },
+    {
+      "type": "blob",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Raw byte sequence."
+    },
+    {
+      "type": "decimal",
+      "isRuntimeValue": true,
+      "isColumnType": true,
+      "representation": "Exact base-10 decimal with an Int64 coefficient and scale up to 18 digits of precision."
+    }
+  ],
+  "rules": [
+    {
+      "ruleId": "CSDB-OBJ-DATABASE-001",
+      "objectKind": "database",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "A migration target is one local CSharpDB database."
+    },
+    {
+      "ruleId": "CSDB-OBJ-NAMESPACE-001",
+      "objectKind": "namespace",
+      "feature": "object",
+      "status": "compatibleWithRewrite",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "CSharpDB has no source-style namespace catalog; names must be flattened deterministically."
+    },
+    {
+      "ruleId": "CSDB-OBJ-TABLE-001",
+      "objectKind": "table",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Typed SQL tables are supported."
+    },
+    {
+      "ruleId": "CSDB-OBJ-COLLECTION-001",
+      "objectKind": "collection",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-COLLECTION",
+      "notes": "Collections use the collection API and serialized document storage rather than SQL DDL."
+    },
+    {
+      "ruleId": "CSDB-OBJ-COLUMN-001",
+      "objectKind": "column",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Persistent columns retain a logical SQL type descriptor over INTEGER, REAL, TEXT, BLOB, or DECIMAL storage."
+    },
+    {
+      "ruleId": "CSDB-OBJ-KEY-001",
+      "objectKind": "key",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-KEYS",
+      "notes": "Primary and unique keys are supported subject to key type and collation rules."
+    },
+    {
+      "ruleId": "CSDB-OBJ-FOREIGNKEY-001",
+      "objectKind": "foreignKey",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "notes": "Single and composite immediate foreign keys are supported with bounded actions."
+    },
+    {
+      "ruleId": "CSDB-OBJ-CHECK-001",
+      "objectKind": "checkConstraint",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-CHECKS",
+      "notes": "Deterministic row-local check expressions are supported."
+    },
+    {
+      "ruleId": "CSDB-OBJ-INDEX-001",
+      "objectKind": "index",
+      "feature": "object",
+      "status": "compatible",
+      "evidenceId": "EVID-INDEXES",
+      "notes": "Ordinary column indexes are supported subject to type restrictions."
+    },
+    {
+      "ruleId": "CSDB-OBJ-SEQUENCE-001",
+      "objectKind": "sequence",
+      "feature": "object",
+      "status": "unsupported",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "There is no standalone sequence catalog object."
+    },
+    {
+      "ruleId": "CSDB-OBJ-VIEW-001",
+      "objectKind": "view",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "A view body must parse, bind, and pass scratch execution before it is executable evidence."
+    },
+    {
+      "ruleId": "CSDB-OBJ-TRIGGER-001",
+      "objectKind": "trigger",
+      "feature": "object",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "Trigger timing, event, and body must be checked; WHEN is rejected with SyntaxError before catalog persistence."
+    },
+    {
+      "ruleId": "CSDB-OBJ-ROUTINE-001",
+      "objectKind": "routine",
+      "feature": "object",
+      "status": "unsupported",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Source database routines do not have a general automatic CSharpDB lowering contract."
+    },
+    {
+      "ruleId": "CSDB-OBJ-OTHER-001",
+      "objectKind": "other",
+      "feature": "object",
+      "status": "unknown",
+      "evidenceId": "EVID-CATALOG",
+      "notes": "Provider-specific objects require an explicit capability rule."
+    },
+    {
+      "ruleId": "CSDB-IDENTIFIER-001",
+      "objectKind": "database",
+      "feature": "identifier",
+      "status": "compatible",
+      "maxCount": 128,
+      "evidenceId": "EVID-IDENTIFIERS",
+      "notes": "Identifiers are quoted when rendered, limited to 128 UTF-16 code units, and compared case-insensitively by catalogs."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-TYPE-001",
+      "objectKind": "column",
+      "feature": "columnType",
+      "status": "compatible",
+      "allowedTypes": ["integer", "real", "text", "blob", "decimal"],
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Logical SQL declarations map to these persistent storage types; declared facets are retained and enforced."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-NULLABLE-001",
+      "objectKind": "column",
+      "feature": "nullable",
+      "status": "compatible",
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Nullable and NOT NULL columns are supported."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-DEFAULT-001",
+      "objectKind": "column",
+      "feature": "defaultValue",
+      "status": "conditional",
+      "allowedValues": ["null", "typed-literal"],
+      "evidenceId": "EVID-COLUMN",
+      "notes": "Defaults must be NULL or compatible typed literals; arbitrary source expressions require analysis."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-IDENTITY-001",
+      "objectKind": "column",
+      "feature": "identity",
+      "status": "conditional",
+      "allowedTypes": ["integer"],
+      "maxCount": 1,
+      "evidenceId": "EVID-COLUMN",
+      "notes": "IDENTITY is limited to logical INTEGER or BIGINT and implies a primary key. INTEGER generation stops at 2147483647; BIGINT generation stops at 9223372036854775807."
+    },
+    {
+      "ruleId": "CSDB-COLUMN-ROWVERSION-001",
+      "objectKind": "column",
+      "feature": "rowVersion",
+      "status": "conditional",
+      "allowedTypes": ["blob"],
+      "maxCount": 1,
+      "evidenceId": "EVID-ROWVERSION",
+      "notes": "At most one generated ROWVERSION column is permitted per table. Tokens come from a durable database-wide counter and the column cannot participate in keys, foreign keys, or indexes."
+    },
+    {
+      "ruleId": "CSDB-KEY-PRIMARY-001",
+      "objectKind": "key",
+      "feature": "primaryKey",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "evidenceId": "EVID-KEYS",
+      "notes": "Single or composite INTEGER/TEXT primary keys are supported."
+    },
+    {
+      "ruleId": "CSDB-KEY-UNIQUE-001",
+      "objectKind": "key",
+      "feature": "uniqueConstraint",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "evidenceId": "EVID-KEYS",
+      "notes": "Single or composite INTEGER/TEXT unique keys are supported; tuples containing NULL do not conflict."
+    },
+    {
+      "ruleId": "CSDB-FOREIGNKEY-001",
+      "objectKind": "foreignKey",
+      "feature": "foreignKey",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "allowedValues": [
+        "immediate",
+        "match-simple",
+        "on-delete-cascade",
+        "on-delete-no-action",
+        "on-delete-restrict",
+        "on-delete-set-null",
+        "on-delete-set-default",
+        "on-update-cascade",
+        "on-update-no-action",
+        "on-update-restrict",
+        "on-update-set-null",
+        "on-update-set-default"
+      ],
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "notes": "Child and ordered parent key types/collations must match. SET NULL requires every child column to be nullable and outside the primary key. SET DEFAULT requires a proven compatible literal default, or proven no/NULL default on a nullable non-key child column. Deferred matching remains unsupported."
+    },
+    {
+      "ruleId": "CSDB-CHECK-001",
+      "objectKind": "checkConstraint",
+      "feature": "checkConstraint",
+      "status": "conditional",
+      "allowedValues": ["deterministic", "row-local"],
+      "evidenceId": "EVID-CHECKS",
+      "notes": "Functions, subqueries, and parameters are not accepted in check expressions."
+    },
+    {
+      "ruleId": "CSDB-INDEX-001",
+      "objectKind": "index",
+      "feature": "index",
+      "status": "conditional",
+      "allowedTypes": ["integer", "real", "text"],
+      "allowedValues": ["column-only", "composite", "equality", "nonunique", "unique"],
+      "evidenceId": "EVID-INDEXES",
+      "notes": "Column-only INTEGER/TEXT/REAL equality indexes are supported. REAL components use hashed equality and do not provide ordered or range scans. BLOB/rowversion, expression, partial, included-column, and sort-direction indexes are unsupported."
+    },
+    {
+      "ruleId": "CSDB-VIEW-BODY-001",
+      "objectKind": "view",
+      "feature": "viewBody",
+      "status": "conditional",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "The body must parse, bind, scratch-apply, and catalog-compare."
+    },
+    {
+      "ruleId": "CSDB-TRIGGER-BODY-001",
+      "objectKind": "trigger",
+      "feature": "triggerBody",
+      "status": "conditional",
+      "allowedValues": ["after-delete", "after-insert", "after-update", "before-delete", "before-insert", "before-update"],
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "Trigger bodies are bounded to INSERT, UPDATE, and DELETE statements."
+    },
+    {
+      "ruleId": "CSDB-TRIGGER-WHEN-001",
+      "objectKind": "trigger",
+      "feature": "triggerWhen",
+      "status": "unsupported",
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "notes": "WHEN is represented by the parser and rejected with SyntaxError before catalog persistence."
+    },
+    {
+      "ruleId": "CSDB-COLLECTION-INDEX-001",
+      "objectKind": "collection",
+      "feature": "collectionIndex",
+      "status": "conditional",
+      "allowedTypes": ["integer", "text"],
+      "allowedValues": ["array-element-path", "nested-path", "nonunique", "scalar-path"],
+      "evidenceId": "EVID-COLLECTION",
+      "notes": "Collection indexes are nonunique; range scans exclude array-element paths."
+    },
+    {
+      "ruleId": "CSDB-TARGET-TYPE-ENFORCEMENT-001",
+      "objectKind": "column",
+      "feature": "targetTypeEnforcement",
+      "status": "compatible",
+      "evidenceId": "EVID-INSERT-BATCH",
+      "notes": "Every row assignment is coerced and validated against the column's logical SQL type descriptor before persistence."
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "EVID-CATALOG",
+      "source": "CSharpDB.Engine catalog implementations and CSharpDB.Sql.Parser",
+      "assertion": "The installed source defines the target object catalog and supported SQL DDL forms."
+    },
+    {
+      "evidenceId": "EVID-CHECKS",
+      "source": "CSharpDB.Engine.RowConstraintValidator and DefaultCheckConstraintTests",
+      "assertion": "Check expressions are deterministic and row-local with bounded syntax."
+    },
+    {
+      "evidenceId": "EVID-COLLECTION",
+      "source": "CSharpDB.Engine.Collection and CollectionIndexBinding; CollectionIndexTests",
+      "assertion": "Collections use document storage with bounded scalar, nested, and array-element index behavior."
+    },
+    {
+      "evidenceId": "EVID-COLUMN",
+      "source": "CSharpDB.Primitives.DbType, CSharpDB.Sql.Parser, and CSharpDB.Storage.Serialization.RecordEncoder",
+      "assertion": "Runtime tags include Null, Integer, Real, Text, Blob, and exact Decimal; persistent columns retain validated logical SQL type descriptors, including signed 32-bit INTEGER, BIGINT, BOOLEAN, temporal, and bit-string distinctions."
+    },
+    {
+      "evidenceId": "EVID-FOREIGN-KEYS",
+      "source": "CSharpDB.Engine.QueryPlanner and ForeignKeyIntegrationTests",
+      "assertion": "Foreign keys require compatible ordered parent keys and support immediate MATCH SIMPLE with RESTRICT, NO ACTION, CASCADE, eligible-child SET NULL, or proven-literal SET DEFAULT behavior for delete and update actions."
+    },
+    {
+      "evidenceId": "EVID-IDENTIFIERS",
+      "source": "CSharpDB.Primitives.SqlIdentifierRules",
+      "assertion": "Quoted identifiers support embedded quotes, reject NUL, and are limited to 128 UTF-16 code units."
+    },
+    {
+      "evidenceId": "EVID-INDEXES",
+      "source": "CSharpDB.Engine.QueryPlanner and CSharpDB.Sql.Ast.CreateIndexStatement",
+      "assertion": "Indexes are column-only and constrained to INTEGER/TEXT/REAL key components with supported collations; REAL components use equality-only hashed keys while ordered and range access remains limited to supported INTEGER/TEXT shapes."
+    },
+    {
+      "evidenceId": "EVID-INSERT-BATCH",
+      "source": "CSharpDB.Execution.RowConstraintValidator and SqlTypeCoercion",
+      "assertion": "All write paths validate and normalize values against the persisted logical SQL type descriptor before storage."
+    },
+    {
+      "evidenceId": "EVID-KEYS",
+      "source": "CSharpDB.Engine.QueryPlanner and LogicalKeyConstraintTests",
+      "assertion": "INTEGER/TEXT primary and unique keys support single and composite forms with documented NULL tuple semantics."
+    },
+    {
+      "evidenceId": "EVID-ROWVERSION",
+      "source": "CSharpDB.Engine.RowConstraintValidator, QueryPlanner, and RowVersionIntegrationTests",
+      "assertion": "A table may contain one generated ROWVERSION excluded from keys, foreign keys, and indexes; inserts and updates allocate durable database-wide tokens."
+    },
+    {
+      "evidenceId": "EVID-VIEWS-TRIGGERS",
+      "source": "CSharpDB.Sql.Parser, CSharpDB.Execution.QueryPlanner, and UnsupportedSqlFeatureDiagnosticTests",
+      "assertion": "Views and bounded triggers exist, while trigger WHEN is rejected with SyntaxError before catalog persistence."
+    }
+  ]
+}

--- a/src/CSharpDB.Migration/README.md
+++ b/src/CSharpDB.Migration/README.md
@@ -26,10 +26,10 @@ core:
 - source-neutral catalog objects with explicit containment, set-like
   dependencies, ordered role-qualified schema members, and safe source identity;
 - stable compatibility, evidence, diagnostic, and mapping states;
-- an embedded, digested CSharpDB 4.6.1 capability catalog tied to the installed
-  Migration and Primitives binaries, plus immutable 4.5.1, 4.5.0, 4.4.0, and
-  4.3.0 catalogs for independently replaying plans created against those
-  versions;
+- an embedded, digested CSharpDB 4.6.2 capability catalog tied to the installed
+  Migration and Primitives binaries, plus immutable 4.6.1, 4.5.1, 4.5.0,
+  4.4.0, and 4.3.0 catalogs for independently replaying plans created against
+  those versions;
 - target plans bound to the source-catalog digest, capability digest, naming
   algorithm, and versioned mapping policy;
 - detailed target-capability evaluation for columns, keys, foreign keys,

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>4.6.1</Version>
+    <Version>4.6.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />

--- a/tests/CSharpDB.Benchmarks.Tests/ReleaseCoreProjectProfileTests.cs
+++ b/tests/CSharpDB.Benchmarks.Tests/ReleaseCoreProjectProfileTests.cs
@@ -1,0 +1,123 @@
+using System.Xml.Linq;
+
+namespace CSharpDB.Benchmarks.Tests;
+
+public sealed class ReleaseCoreProjectProfileTests
+{
+    private const string ReleaseCorePropertyName = "CSharpDbReleaseCoreOnly";
+    private const string ObservabilityProject =
+        @"..\..\src\CSharpDB.Observability\CSharpDB.Observability.csproj";
+    private const string ObservabilityBenchmark =
+        @"Micro\ObservabilityNoListenerBaselineBenchmarks.cs";
+
+    [Fact]
+    public void DefaultProfile_IncludesObservabilityProjectAndBenchmark()
+    {
+        XDocument project = LoadBenchmarkProject();
+
+        XElement property = project.Descendants(ReleaseCorePropertyName).Single();
+        Assert.Equal("false", property.Value);
+        Assert.Equal(
+            "'$(CSharpDbReleaseCoreOnly)' == ''",
+            (string?)property.Attribute("Condition"));
+
+        XElement observabilityReference = FindItem(
+            project,
+            "ProjectReference",
+            "Include",
+            ObservabilityProject);
+        Assert.Equal(
+            "'$(CSharpDbReleaseCoreOnly)' != 'true'",
+            (string?)observabilityReference.Attribute("Condition"));
+
+        string benchmarkPath = Path.Combine(
+            FindRepoRoot(),
+            "tests",
+            "CSharpDB.Benchmarks",
+            "Micro",
+            "ObservabilityNoListenerBaselineBenchmarks.cs");
+        Assert.True(File.Exists(benchmarkPath));
+    }
+
+    [Fact]
+    public void ReleaseCoreProfile_ExcludesOnlyObservabilityCompatibilitySurface()
+    {
+        XDocument project = LoadBenchmarkProject();
+
+        XElement compileRemoval = FindItem(
+            project,
+            "Compile",
+            "Remove",
+            ObservabilityBenchmark);
+        XElement releaseCoreGroup = Assert.IsType<XElement>(compileRemoval.Parent);
+        Assert.Equal(
+            "'$(CSharpDbReleaseCoreOnly)' == 'true'",
+            (string?)releaseCoreGroup.Attribute("Condition"));
+
+        XElement observabilityContractReference = FindItem(
+            project,
+            "Reference",
+            "Include",
+            "CSharpDB.Observability");
+        Assert.Same(releaseCoreGroup, observabilityContractReference.Parent);
+        Assert.Equal(
+            "Exists('..\\..\\src\\CSharpDB.Observability\\CSharpDB.Observability.csproj')",
+            (string?)observabilityContractReference.Attribute("Condition"));
+        Assert.EndsWith(
+            @"CSharpDB.Observability\bin\$(Configuration)\$(TargetFramework)\CSharpDB.Observability.dll",
+            (string?)observabilityContractReference.Attribute("HintPath"));
+
+        XElement[] conditionalReferences = project
+            .Descendants("ProjectReference")
+            .Where(reference => reference.Attribute("Condition") is not null)
+            .ToArray();
+        XElement observabilityReference = Assert.Single(conditionalReferences);
+        Assert.Equal(
+            ObservabilityProject,
+            (string?)observabilityReference.Attribute("Include"));
+
+        XElement[] compileRemovals = project
+            .Descendants("Compile")
+            .Where(item => item.Attribute("Remove") is not null)
+            .ToArray();
+        Assert.Same(compileRemoval, Assert.Single(compileRemovals));
+    }
+
+    private static XElement FindItem(
+        XDocument project,
+        string itemName,
+        string attributeName,
+        string attributeValue)
+    {
+        return project
+            .Descendants(itemName)
+            .Single(item => string.Equals(
+                (string?)item.Attribute(attributeName),
+                attributeValue,
+                StringComparison.Ordinal));
+    }
+
+    private static XDocument LoadBenchmarkProject()
+    {
+        return XDocument.Load(Path.Combine(
+            FindRepoRoot(),
+            "tests",
+            "CSharpDB.Benchmarks",
+            "CSharpDB.Benchmarks.csproj"));
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "CSharpDB.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate repository root from test base directory.");
+    }
+}

--- a/tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj
+++ b/tests/CSharpDB.Benchmarks/CSharpDB.Benchmarks.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <CSharpDbReleaseCoreOnly Condition="'$(CSharpDbReleaseCoreOnly)' == ''">false</CSharpDbReleaseCoreOnly>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,10 +28,19 @@
     <ProjectReference Include="..\..\src\CSharpDB.Migration\CSharpDB.Migration.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Migration.CSharpDb\CSharpDB.Migration.CSharpDb.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Migration.Files\CSharpDB.Migration.Files.csproj" />
-    <ProjectReference Include="..\..\src\CSharpDB.Observability\CSharpDB.Observability.csproj" />
+    <ProjectReference Include="..\..\src\CSharpDB.Observability\CSharpDB.Observability.csproj"
+                      Condition="'$(CSharpDbReleaseCoreOnly)' != 'true'" />
     <ProjectReference Include="..\..\src\CSharpDB.Sql\CSharpDB.Sql.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Storage\CSharpDB.Storage.csproj" />
     <ProjectReference Include="..\..\src\CSharpDB.Storage.Diagnostics\CSharpDB.Storage.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CSharpDbReleaseCoreOnly)' == 'true'">
+    <Compile Remove="Micro\ObservabilityNoListenerBaselineBenchmarks.cs" />
+    <Reference Include="CSharpDB.Observability"
+               Condition="Exists('..\..\src\CSharpDB.Observability\CSharpDB.Observability.csproj')"
+               HintPath="..\..\src\CSharpDB.Observability\bin\$(Configuration)\$(TargetFramework)\CSharpDB.Observability.dll"
+               Private="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CSharpDB.Benchmarks/README.md
+++ b/tests/CSharpDB.Benchmarks/README.md
@@ -442,7 +442,7 @@ dotnet run -c Release --project .\tests\CSharpDB.Benchmarks\CSharpDB.Benchmarks.
 ```
 
 After the release pull request is merged, update local `main` and use the
-canonical publisher to validate and publish the exact release tag:
+canonical publisher to run and wait for the complete hosted release:
 
 ```powershell
 git switch main
@@ -453,18 +453,15 @@ $Version = (Read-Host 'Release version without the v prefix').Trim()
 ```
 
 Do not create a release tag in the GitHub UI or with raw `git tag` / `git push`
-commands. Those unsupported paths bypass the clean-main, version, and tag
-preflight. `Publish-ReleaseTag.ps1` requires a clean, checked-out `main`, fetches
-`origin/main`, requires local `HEAD` to equal that remote commit, validates the
-package version, and rejects a same-named local or remote tag at another commit.
-It does not run or require a local benchmark or commit status.
-
-The publisher is idempotent for the same version and exact commit. The `v*` tag
-push starts the fail-closed Release workflow, which runs one clean functional
-qualification on each of Windows, Linux, and macOS and one balanced paired
-hosted-stable comparison on Windows. That comparison uses `RepeatCount 3`, so
-one job records three pairs per previous/candidate execution order. Publication
-begins only after those hosted gates and all archive jobs succeed.
+commands. `Publish-ReleaseTag.ps1` requires clean exact `main`, validates the
+package version and unused release identity, dispatches the fail-closed
+qualification workflow, and waits for completion. The workflow runs
+cross-platform functional qualification, the real previous-release
+compatibility build, a balanced paired hosted-stable comparison,
+NativeAOT/host/archive checks, and builds the final release bundle before any
+tag exists. A failed gate therefore leaves the version untagged and retryable.
+The command then creates the protected tag with the maintainer's authenticated
+Git identity and starts a resumable hosted publication of that exact bundle.
 
 ### Optional local durable-write diagnostics
 

--- a/tests/CSharpDB.Benchmarks/scripts/Test-PreviousReleasePerformance.ps1
+++ b/tests/CSharpDB.Benchmarks/scripts/Test-PreviousReleasePerformance.ps1
@@ -66,11 +66,20 @@ param(
         'devenv;msbuild;vbcscompiler;testhost;vstest.console;msiexec;' +
         'trustedinstaller;tiworker;mousocoreworker;usoclient;winget;nuget',
 
-    [switch] $PreflightOnly
+    [switch] $PreflightOnly,
+
+    [switch] $BuildOnly
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+if ($PreflightOnly -and $BuildOnly) {
+    throw 'PreflightOnly and BuildOnly cannot be combined.'
+}
+if ($BuildOnly -and $ShareSameRevisionArtifact) {
+    throw 'BuildOnly must compile both the previous and candidate revisions.'
+}
 
 [string[]] $supportedHybridStorageScenarioNames = @(
     foreach ($prefix in @(
@@ -118,6 +127,7 @@ if ($ShareSameRevisionArtifact -and -not $AllowSameRevision) {
 }
 
 $scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$releaseCoreBuildProperty = 'CSharpDbReleaseCoreOnly=true'
 $repositoryRoot = [IO.Path]::GetFullPath(
     [IO.Path]::Combine($scriptDirectory, '..', '..', '..'))
 $temporaryParent = if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
@@ -802,6 +812,10 @@ $preflight = @(
             '- Blocking latency percentile: P95. P99 remains recorded as a non-blocking diagnostic.'
         }),
     '- Benchmark source harness: candidate benchmark-project files synchronized to both engines; revision-specific effective build inputs are recorded separately during execution',
+    '- Release-core build profile: ``CSharpDbReleaseCoreOnly=true`` excludes candidate-only benchmark dependencies symmetrically',
+    $(if ($BuildOnly) {
+            '- Mode: build-only cross-version compatibility; benchmark measurements are skipped'
+        }),
     "- Previous ref: ``$PreviousRef`` (``$previousCommit``)",
     "- Candidate ref: ``$CandidateRef`` (``$candidateCommit``)",
     "- Planned execution log: ``$executionLogPath``",
@@ -1156,6 +1170,14 @@ function Invoke-BenchmarkBuild {
     )
 
     $project = Get-BenchmarkProject -SourceRoot $SourceRoot
+    [string[]] $buildArguments = @(
+        'build',
+        $project,
+        '-c',
+        'Release',
+        '--nologo',
+        '-p',
+        $releaseCoreBuildProperty)
     $logPath = Join-Path $logRoot "$RunName.log"
     [IO.File]::WriteAllLines(
         $logPath,
@@ -1166,11 +1188,13 @@ function Invoke-BenchmarkBuild {
             "Benchmark source harness manifest: $harnessManifestPath",
             "Revision effective build inputs: $BuildInputsIdentity",
             "Revision effective build inputs manifest: $BuildInputsManifestPath",
+            "MSBuild property: $releaseCoreBuildProperty",
+            "Command: dotnet $($buildArguments -join ' ')",
             ''
         ))
     Push-Location $SourceRoot
     try {
-        & dotnet build $project -c Release --nologo 2>&1 |
+        & dotnet @buildArguments 2>&1 |
             Tee-Object -FilePath $logPath -Append |
             Write-Host
         $buildExitCode = $LASTEXITCODE
@@ -3504,7 +3528,7 @@ try {
                     -HarnessIdentity $candidateHarnessIdentity `
                     -BuildInputsIdentity $previousBuildInputsIdentity `
                     -BuildInputsManifestPath $previousBuildInputsManifestPath
-                if ($Paired) {
+                if ($Paired -and -not $BuildOnly) {
                     $pairedArtifacts['previous'] = Get-BenchmarkArtifactIdentity `
                         -SourceRoot $baselineWorktree
                 }
@@ -3516,13 +3540,30 @@ try {
                     -HarnessIdentity $candidateHarnessIdentity `
                     -BuildInputsIdentity $candidateBuildInputsIdentity `
                     -BuildInputsManifestPath $candidateBuildInputsManifestPath
-                if ($Paired) {
+                if ($Paired -and -not $BuildOnly) {
                     $pairedArtifacts['candidate'] = Get-BenchmarkArtifactIdentity `
                         -SourceRoot $candidateWorktree
                 }
             }
         }
     }
+    if ($BuildOnly) {
+        [IO.File]::WriteAllLines(
+            $reportPath,
+            @(
+                '# Previous-release benchmark compatibility',
+                '',
+                '- Result: **PASS**',
+                '- Mode: build-only; benchmark measurements were not executed',
+                '- MSBuild release-core profile: ``CSharpDbReleaseCoreOnly=true``',
+                "- Previous ref: ``$PreviousRef`` (``$previousCommit``)",
+                "- Candidate ref: ``$CandidateRef`` (``$candidateCommit``)",
+                "- Candidate benchmark harness SHA-256: ``$candidateHarnessIdentity``",
+                "- Previous build log: ``$(Join-Path $logRoot 'previous-release.log')``",
+                "- Candidate build log: ``$(Join-Path $logRoot 'candidate.log')``"
+            ))
+    }
+    else {
     if ($Paired) {
         if ($pairedArtifacts.Count -ne 2 -or
             -not $pairedArtifacts.ContainsKey('previous') -or
@@ -4071,6 +4112,7 @@ try {
             Add-Content -LiteralPath $reportPath -Value $metadata
         }
     }
+    }
 }
 catch {
     $primaryFailure = $_
@@ -4317,5 +4359,10 @@ if ($cleanupFailures.Count -gt 0) {
 }
 
 Assert-CleanRepository
-Write-Host "Previous-release performance qualification passed."
+if ($BuildOnly) {
+    Write-Host 'Previous-release benchmark compatibility builds passed.'
+}
+else {
+    Write-Host 'Previous-release performance qualification passed.'
+}
 Write-Host "Evidence: $reportPath"

--- a/tests/CSharpDB.Cli.Tests/MigrationDdlPreviewCommandRunnerTests.cs
+++ b/tests/CSharpDB.Cli.Tests/MigrationDdlPreviewCommandRunnerTests.cs
@@ -41,7 +41,7 @@ public sealed class MigrationDdlPreviewCommandRunnerTests
             string jsonDigest = Sha256(first);
             Assert.True(
                 string.Equals(
-                    "62d04a5d0cc699dd2156575fa016877a1797cb8458ae063c45a98bdc7c53f0f1",
+                    "57f2843182b70b695fb311c6a8574b13648e49d8f277d8c22798c98ca05c3cec",
                     jsonDigest,
                     StringComparison.Ordinal),
                 $"JSON preview digest: {jsonDigest}");
@@ -92,7 +92,7 @@ public sealed class MigrationDdlPreviewCommandRunnerTests
             string textDigest = Sha256(text);
             Assert.True(
                 string.Equals(
-                    "09120d770ef0ea1e9b0d2d39acfe1b59fee27fce34d3ab73f99a9fd22643d24e",
+                    "3d5f424dc0cd24d9f55f9cbe17e4f4cc9a417592b5f3f0a183f893576c9555c9",
                     textDigest,
                     StringComparison.Ordinal),
                 $"Text preview digest: {textDigest}");

--- a/tests/CSharpDB.Cli.Tests/MigrationReleasePackagingTests.cs
+++ b/tests/CSharpDB.Cli.Tests/MigrationReleasePackagingTests.cs
@@ -154,7 +154,7 @@ public sealed class MigrationReleasePackagingTests
             "Publish-CSharpDbMigrationRelease.ps1");
 
         Assert.Contains(
-            "[string] $Version = '4.6.1'",
+            "[string] $Version = '4.6.2'",
             script,
             StringComparison.Ordinal);
         Assert.Contains("win-x64", script, StringComparison.Ordinal);
@@ -339,7 +339,7 @@ public sealed class MigrationReleasePackagingTests
             workflow,
             StringComparison.Ordinal);
         Assert.Contains(
-            "needs: [publish-nuget, migration-archives,",
+            "needs: [prepare-nuget, migration-archives, native-aot, api-host-observability, daemon-archives, admin-desktop-archive]",
             workflow,
             StringComparison.Ordinal);
         Assert.Contains("pattern: migration-*", workflow, StringComparison.Ordinal);
@@ -348,7 +348,7 @@ public sealed class MigrationReleasePackagingTests
             workflow,
             StringComparison.Ordinal);
         Assert.Contains(
-            "artifacts/migration/*",
+            "artifacts/release-bundle/migration",
             workflow,
             StringComparison.Ordinal);
 
@@ -359,7 +359,7 @@ public sealed class MigrationReleasePackagingTests
             "name: migration-${{ matrix.rid }}",
             StringComparison.Ordinal);
         int releaseIndex = workflow.IndexOf(
-            "artifacts/migration/*",
+            "artifacts/release-bundle/migration",
             StringComparison.Ordinal);
         Assert.True(
             publishIndex >= 0 &&

--- a/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/DaemonPackagingAssetsTests.cs
@@ -33,6 +33,25 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
+    public void Ci_BuildsTheSynchronizedReleaseHarnessAgainstThePublishedBaseline()
+    {
+        string repoRoot = FindRepoRoot();
+        string workflow = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "ci.yml"));
+
+        Assert.Contains("release-baseline-compatibility:", workflow);
+        Assert.Contains("fetch-depth: 0", workflow);
+        Assert.Contains("Test-PreviousReleasePerformance.ps1", workflow);
+        Assert.Contains("-PreviousRef 2f141433298bcd3137e2bcaa2930c796c4222092", workflow);
+        Assert.Contains("-CandidateRef $env:CANDIDATE_REF", workflow);
+        Assert.Contains("-BuildOnly", workflow);
+        Assert.Contains("previous-release-performance.md", workflow);
+    }
+
+    [Fact]
     public void CiAndRelease_QualifyPublishedApiAndDaemonObservabilityOnEverySupportedHost()
     {
         string repoRoot = FindRepoRoot();
@@ -46,6 +65,11 @@ public sealed class DaemonPackagingAssetsTests
             ".github",
             "workflows",
             "release.yml"));
+        string publisher = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "publish-release.yml"));
         string qualifier = File.ReadAllText(Path.Combine(
             repoRoot,
             "scripts",
@@ -100,6 +124,11 @@ public sealed class DaemonPackagingAssetsTests
             ".github",
             "workflows",
             "release.yml"));
+        string publisher = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "publish-release.yml"));
 
         Assert.Contains("Test-ExactCandidateRange", script);
         Assert.Contains("$normalized -ceq \"[$CandidateVersion]\"", script);
@@ -117,11 +146,17 @@ public sealed class DaemonPackagingAssetsTests
         Assert.Contains("CSharpDB-PACKAGE-MANIFEST.json", ci);
         Assert.Contains("CSharpDB-PACKAGE-MANIFEST.json", release);
         Assert.Contains("Test-CSharpDbNuGetCandidateAbsent.ps1", release);
-        Assert.DoesNotContain("--skip-duplicate", release);
+        Assert.Contains("-ValidateExistingManifest", release);
+        Assert.Contains("--skip-duplicate", publisher);
+        Assert.Contains("--target main", publisher);
+        Assert.Contains("$release.target_commitish -cne 'main'", publisher);
+        Assert.Contains("--json databaseId", publisher);
+        Assert.Contains("releases/$releaseId/assets?per_page=100", publisher);
+        Assert.DoesNotContain("releases/tags/$env:RELEASE_TAG", publisher);
         Assert.Contains(
-            "Push remaining packages in validated topological order",
-            release);
-        Assert.Contains("foreach ($package in $manifest.packages)", release);
+            "Publish packages in validated topological order",
+            publisher);
+        Assert.Contains("foreach ($package in $ordered)", publisher);
         Assert.DoesNotContain(
             "for package in artifacts/nuget/*.nupkg",
             release);
@@ -137,34 +172,30 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
-    public void ReleaseWorkflow_PublishesObservabilityBeforeDependentPackages()
+    public void PublicationWorkflow_PublishesObservabilityBeforeDependentPackages()
     {
         string repoRoot = FindRepoRoot();
-        string workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "release.yml"));
+        string workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "publish-release.yml"));
 
         int observabilityPushIndex = workflow.IndexOf(
-            "- name: Push CSharpDB.Observability to NuGet.org",
-            StringComparison.Ordinal);
-        int observabilityWaitIndex = workflow.IndexOf(
-            "- name: Wait for CSharpDB.Observability on NuGet.org",
+            "@($manifest.packages | Where-Object { $_.id -ceq 'CSharpDB.Observability' })",
             StringComparison.Ordinal);
         int dependentPushIndex = workflow.IndexOf(
-            "- name: Push remaining packages in validated topological order",
+            "@($manifest.packages | Where-Object { $_.id -cne 'CSharpDB.Observability' })",
+            StringComparison.Ordinal);
+        int observabilityWaitIndex = workflow.IndexOf(
+            "Wait-NuGetPackageVersion.ps1",
+            dependentPushIndex,
             StringComparison.Ordinal);
 
-        Assert.True(observabilityPushIndex >= 0, "The observability package must be pushed explicitly.");
+        Assert.True(observabilityPushIndex >= 0, "Observability must be first in the release order.");
+        Assert.True(
+            dependentPushIndex > observabilityPushIndex,
+            "Dependent packages must be ordered after observability.");
         Assert.True(
             observabilityWaitIndex > observabilityPushIndex,
-            "NuGet visibility must be confirmed after pushing observability.");
-        Assert.True(
-            dependentPushIndex > observabilityWaitIndex,
-            "Dependent packages must not be pushed until observability is visible.");
-        Assert.Contains(
-            "CSharpDB.Observability.${{ steps.version.outputs.package_file_version }}.nupkg",
-            workflow);
-        Assert.Contains(
-            "foreach ($package in $manifest.packages)",
-            workflow);
+            "The ordered publication loop must verify package visibility.");
+        Assert.Contains("foreach ($package in $ordered)", workflow);
         Assert.Contains("-PackageId $package.id", workflow);
 
         string versionResolver = File.ReadAllText(Path.Combine(
@@ -186,13 +217,17 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
-    public void ReleaseWorkflow_VerifiesNuGetPackagesBeforeCreatingGitHubRelease()
+    public void PublicationWorkflow_StagesAssetsThenVerifiesPackagesBeforeFinalizingRelease()
     {
         string repoRoot = FindRepoRoot();
-        string workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "release.yml"));
+        string workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "publish-release.yml"));
+
+        int draftIndex = workflow.IndexOf(
+            "- name: Create or refresh draft GitHub Release",
+            StringComparison.Ordinal);
 
         int verifyStepIndex = workflow.IndexOf(
-            "- name: Verify packages are visible on NuGet.org",
+            "- name: Verify every package is visible",
             StringComparison.Ordinal);
         int verifyIndex = verifyStepIndex < 0
             ? -1
@@ -200,64 +235,48 @@ public sealed class DaemonPackagingAssetsTests
                 "Wait-NuGetPackageVersion.ps1",
                 verifyStepIndex,
                 StringComparison.Ordinal);
-        int releaseIndex = workflow.IndexOf("softprops/action-gh-release", StringComparison.Ordinal);
+        int releaseIndex = workflow.IndexOf(
+            "- name: Publish the staged GitHub Release",
+            StringComparison.Ordinal);
 
+        Assert.True(draftIndex >= 0);
         Assert.True(
             verifyIndex > verifyStepIndex,
             "The final package-visibility step must call the NuGet verification script.");
         Assert.True(releaseIndex > verifyIndex, "NuGet verification must run before the GitHub Release is created.");
 
-        string[] packageIds =
-        [
-            "CSharpDB",
-            "CSharpDB.Observability",
-            "CSharpDB.Primitives",
-            "CSharpDB.Sql",
-            "CSharpDB.Storage",
-            "CSharpDB.Execution",
-            "CSharpDB.Engine",
-            "CSharpDB.Pipelines",
-            "CSharpDB.Data",
-            "CSharpDB.EntityFrameworkCore",
-            "CSharpDB.Storage.Diagnostics",
-            "CSharpDB.Client",
-        ];
-
-        foreach (string packageId in packageIds)
-            Assert.Contains($"'{packageId}'", workflow);
+        Assert.Contains("-PackageId @($manifest.packages.id)", workflow);
     }
 
     [Fact]
-    public void ReleaseTrigger_UsesFreshRegistrationAndTrustedPublishingImplementation()
+    public void ReleaseWorkflows_AreManualTagLastAndUseTrustedPublishing()
     {
         string repoRoot = FindRepoRoot();
-        string trigger = File.ReadAllText(Path.Combine(
-            repoRoot,
-            ".github",
-            "workflows",
-            "publish-release.yml")).ReplaceLineEndings("\n");
         string implementation = File.ReadAllText(Path.Combine(
             repoRoot,
             ".github",
             "workflows",
             "release.yml")).ReplaceLineEndings("\n");
+        string publication = File.ReadAllText(Path.Combine(
+            repoRoot,
+            ".github",
+            "workflows",
+            "publish-release.yml")).ReplaceLineEndings("\n");
 
-        Assert.Contains("name: Release\n", trigger);
-        Assert.Contains("      - \"v*\"", trigger);
-        Assert.DoesNotContain("workflow_dispatch:", trigger);
-        Assert.Contains("group: release-${{ github.ref }}", trigger);
-        Assert.Contains("uses: ./.github/workflows/release.yml", trigger);
-        Assert.Contains("NUGET_USER: ${{ secrets.NUGET_USER }}", trigger);
-        Assert.DoesNotContain("secrets: inherit", trigger);
-        Assert.DoesNotContain("waive_local_durable", trigger);
-        Assert.Contains("contents: write", trigger);
-        Assert.DoesNotContain("statuses:", trigger);
-        Assert.Contains("id-token: write", trigger);
-        Assert.Contains("cancel-in-progress: false", trigger);
-
-        Assert.Contains("workflow_call:", implementation);
-        Assert.DoesNotContain("tags:", implementation);
-        Assert.Contains("uses: NuGet/login@v1", implementation);
+        Assert.Contains("name: Release qualification\n", implementation);
+        Assert.Contains("workflow_dispatch:", implementation);
+        Assert.Contains("run-name: Qualify release ${{ inputs.release_tag }} at ${{ inputs.release_commit }}", implementation);
+        Assert.Contains("group: release-${{ inputs.release_tag }}", implementation);
+        Assert.DoesNotContain("push:\n    tags:", implementation);
+        Assert.DoesNotContain("workflow_call:", implementation);
+        Assert.DoesNotContain("git/refs", implementation);
+        Assert.Contains("cancel-in-progress: false", implementation);
+        Assert.Contains("name: Publish qualified release\n", publication);
+        Assert.Contains("workflow_dispatch:", publication);
+        Assert.Contains("preflight_only:", publication);
+        Assert.Contains("uses: NuGet/login@v1", publication);
+        Assert.Contains("id-token: write", publication);
+        Assert.DoesNotContain("push:\n    tags:", publication);
     }
 
     [Fact]
@@ -445,21 +464,17 @@ public sealed class DaemonPackagingAssetsTests
             "release_commit: ${{ inputs.release_commit }}",
             normalized);
         Assert.Contains(
-            "previous_release_ref: ${{ inputs.release_tag == 'v4.6.1' && '2f141433298bcd3137e2bcaa2930c796c4222092' || " +
+            "previous_release_ref: ${{ inputs.release_tag == 'v4.6.2' && '2f141433298bcd3137e2bcaa2930c796c4222092' || " +
+            "inputs.release_tag == 'v4.6.1' && '2f141433298bcd3137e2bcaa2930c796c4222092' || " +
             "inputs.release_tag == 'v4.5.1' && '86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}",
             normalized);
-        Assert.Contains("verify-release-target:", normalized);
-        Assert.Contains("name: Verify exact release target", normalized);
+        Assert.Contains("verify-release-candidate:", normalized);
+        Assert.Contains("name: Verify exact release candidate", normalized);
         Assert.DoesNotContain("statuses:", normalized);
         Assert.DoesNotContain("LOCAL_DURABLE_ATTESTOR", normalized);
         Assert.Contains("- name: Checkout exact release source", normalized);
         Assert.Contains("uses: actions/checkout@v7", normalized);
-        Assert.Contains(
-            """
-                  - name: Require the exact existing release tag and commit
-                    shell: pwsh
-            """.ReplaceLineEndings("\n"),
-            normalized);
+        Assert.Contains("- name: Require exact untagged main and matching package version", normalized);
         Assert.DoesNotContain("Test-LocalDurableStatus.ps1", normalized);
         Assert.DoesNotContain("waive_local_durable", normalized);
         Assert.DoesNotContain("github.ref_name", normalized);
@@ -470,20 +485,20 @@ public sealed class DaemonPackagingAssetsTests
                 normalized,
                 @"(?m)^          ref: \$\{\{ inputs\.release_commit \}\}$").Count);
         Assert.Equal(
-            5,
+            6,
             System.Text.RegularExpressions.Regex.Matches(
                 normalized,
                 @"(?m)^    needs: build-and-test$").Count);
         Assert.Contains(
-            "needs: [build-and-test, migration-archives, native-aot, api-host-observability, daemon-archives, admin-desktop-archive]",
+            "needs: [prepare-nuget, migration-archives, native-aot, api-host-observability, daemon-archives, admin-desktop-archive]",
             normalized);
         Assert.Contains(
-            "needs: [publish-nuget, migration-archives, native-aot, daemon-archives, admin-desktop-archive]",
+            "needs: [prepare-nuget, migration-archives, native-aot, api-host-observability, daemon-archives, admin-desktop-archive]",
             normalized);
         Assert.Single(
             System.Text.RegularExpressions.Regex.Matches(
                 normalized,
-                @"(?m)^    needs: verify-release-target$"));
+                @"(?m)^    needs: verify-release-candidate$"));
     }
 
     [Fact]
@@ -497,15 +512,15 @@ public sealed class DaemonPackagingAssetsTests
             "release.yml")).ReplaceLineEndings("\n");
 
         const string expectedBaselineInput =
-            "previous_release_ref: ${{ inputs.release_tag == 'v4.6.1' && " +
+            "previous_release_ref: ${{ inputs.release_tag == 'v4.6.2' && " +
+            "'2f141433298bcd3137e2bcaa2930c796c4222092' || " +
+            "inputs.release_tag == 'v4.6.1' && " +
             "'2f141433298bcd3137e2bcaa2930c796c4222092' || " +
             "inputs.release_tag == 'v4.5.1' && " +
             "'86e25435f3c64f47afe2a776c6b03cbe84e56858' || '' }}";
 
-        Assert.Contains("v4.6.0 was tagged but never published", implementation);
+        Assert.Contains("v4.6.0 and v4.6.1 were tagged but never published", implementation);
         Assert.Contains("published v4.5.1 commit", implementation);
-        Assert.Contains("v4.5.1-to-v4.4.0", implementation);
-        Assert.Contains("v4.5.0 was also tagged but never published", implementation);
         Assert.Contains(expectedBaselineInput, implementation);
         Assert.Single(
             System.Text.RegularExpressions.Regex.Matches(
@@ -515,54 +530,33 @@ public sealed class DaemonPackagingAssetsTests
     }
 
     [Fact]
-    public void ReleaseWorkflow_IsTagOnlyAndHasNoManualRecoveryOrDurableWaiver()
+    public void ReleaseWorkflow_IsTagLastAndHasNoManualTagTriggerOrWaiver()
     {
         string repoRoot = FindRepoRoot();
-        string trigger = File.ReadAllText(Path.Combine(
-            repoRoot,
-            ".github",
-            "workflows",
-            "publish-release.yml")).ReplaceLineEndings("\n");
         string implementation = File.ReadAllText(Path.Combine(
             repoRoot,
             ".github",
             "workflows",
             "release.yml")).ReplaceLineEndings("\n");
 
-        Assert.Contains("      - \"v*\"", trigger);
-        Assert.Contains("group: release-${{ github.ref }}", trigger);
-        Assert.Contains("release_tag: ${{ github.ref_name }}", trigger);
-        Assert.Contains("release_commit: ${{ github.sha }}", trigger);
-        Assert.Contains("NUGET_USER: ${{ secrets.NUGET_USER }}", trigger);
-        Assert.DoesNotContain("workflow_dispatch:", trigger);
-        Assert.DoesNotContain("recovery", trigger, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("waive", trigger, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("v4.5.0", trigger);
-        Assert.DoesNotContain("statuses: write", trigger);
-        Assert.DoesNotContain("secrets: inherit", trigger);
-
-        Assert.Contains("- name: Require the exact existing release tag and commit", implementation);
+        Assert.Contains("workflow_dispatch:", implementation);
+        Assert.DoesNotContain("push:\n    tags:", implementation);
+        Assert.Contains("- name: Require exact untagged main and matching package version", implementation);
+        Assert.Contains("prepare-release-bundle:", implementation);
+        Assert.Contains("name: Prepare final release bundle", implementation);
+        Assert.Contains("needs: [prepare-nuget, migration-archives, native-aot, api-host-observability, daemon-archives, admin-desktop-archive]", implementation);
+        Assert.Contains("- name: Verify complete immutable release bundle", implementation);
+        Assert.Contains("-ValidateExistingManifest", implementation);
+        Assert.Contains("$expectedHeading = \"## CSharpDB ${{ needs.prepare-nuget.outputs.version }}\"", implementation);
         Assert.DoesNotContain("matching-commit local performance status", implementation);
         Assert.DoesNotContain("Test-LocalDurableStatus.ps1", implementation);
-        Assert.DoesNotContain("workflow_dispatch", implementation);
         Assert.DoesNotContain("waive", implementation, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("7aeb66031237283c3643e73849618bf299729ed6", implementation);
-        Assert.Contains("- name: Revalidate the immutable publication target", implementation);
-        Assert.Contains("- name: Require the immutable target and absent release before creation", implementation);
-        Assert.Contains("packages will not be published", implementation);
-        Assert.Contains("publication will not update it", implementation);
         Assert.DoesNotContain("Publish-DurableCarryForwardStatus.ps1", implementation);
         Assert.DoesNotContain("statuses: write", implementation);
-        Assert.Equal(
-            2,
-            System.Text.RegularExpressions.Regex.Matches(
-                implementation,
-                @"(?m)^          tag_name: \$\{\{ inputs\.release_tag \}\}$").Count);
-        Assert.Equal(
-            2,
-            System.Text.RegularExpressions.Regex.Matches(
-                implementation,
-                @"(?m)^          target_commitish: \$\{\{ inputs\.release_commit \}\}$").Count);
+        Assert.DoesNotContain("git/refs", implementation);
+        Assert.DoesNotContain("dotnet nuget push", implementation);
+        Assert.DoesNotContain("softprops/action-gh-release", implementation);
     }
 
     [Fact]

--- a/tests/CSharpDB.Daemon.Tests/GrpcHealthHostTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/GrpcHealthHostTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using CSharpDbHealthHostExtensions =
     CSharpDbApi::CSharpDB.Api.CSharpDbHealthHostExtensions;
 using CSharpDbHostReadinessCoordinator =
@@ -124,7 +125,9 @@ public sealed class GrpcHealthHostTests
         string dbPath = NewTempDbPath();
         try
         {
-            await using var factory = new HealthDaemonFactory(dbPath);
+            await using var factory = new HealthDaemonFactory(
+                dbPath,
+                publishHealthManually: true);
             using HttpClient client = factory.CreateDefaultClient();
             await WaitUntilReadyAsync(client);
             CSharpDbHostReadinessCoordinator readiness = factory.Services
@@ -137,24 +140,34 @@ public sealed class GrpcHealthHostTests
                     DisposeHttpClient = false,
                 });
             var health = new Health.HealthClient(channel);
+            HealthCheckService healthChecks = factory.Services
+                .GetRequiredService<HealthCheckService>();
+            IHealthCheckPublisher healthPublisher = Assert.Single(
+                factory.Services.GetServices<IHealthCheckPublisher>());
+
+            await PublishHealthAsync(healthChecks, healthPublisher);
+            using AsyncServerStreamingCall<HealthCheckResponse> watch =
+                health.Watch(
+                    new HealthCheckRequest
+                    {
+                        Service = CSharpDbHealthHostExtensions
+                            .DatabaseGrpcServiceName,
+                    },
+                    // Keep the streaming call bounded if a transition is
+                    // ever lost or the publisher fails to notify watchers.
+                    deadline: DateTime.UtcNow.AddSeconds(20),
+                    cancellationToken: Ct);
+            Assert.True(await watch.ResponseStream.MoveNext(Ct));
+            Assert.Equal(
+                HealthCheckResponse.Types.ServingStatus.Serving,
+                watch.ResponseStream.Current.Status);
 
             IDisposable lease = readiness.EnterNotReady(
                 CSharpDB.Observability.CSharpDbReadinessReason
                     .ExclusiveMaintenance);
             try
             {
-                using AsyncServerStreamingCall<HealthCheckResponse> watch =
-                    health.Watch(
-                        new HealthCheckRequest
-                        {
-                            Service = CSharpDbHealthHostExtensions
-                                .DatabaseGrpcServiceName,
-                        },
-                        // The health publisher has a one-second cadence. Keep
-                        // the watch bounded while allowing for cross-project
-                        // CI contention during the full solution matrix.
-                        deadline: DateTime.UtcNow.AddSeconds(20),
-                        cancellationToken: Ct);
+                await PublishHealthAsync(healthChecks, healthPublisher);
                 Assert.True(await watch.ResponseStream.MoveNext(Ct));
                 Assert.Equal(
                     HealthCheckResponse.Types.ServingStatus.NotServing,
@@ -183,6 +196,7 @@ public sealed class GrpcHealthHostTests
                     database.Status);
 
                 lease.Dispose();
+                await PublishHealthAsync(healthChecks, healthPublisher);
                 Assert.True(await watch.ResponseStream.MoveNext(Ct));
                 Assert.Equal(
                     HealthCheckResponse.Types.ServingStatus.Serving,
@@ -290,6 +304,14 @@ public sealed class GrpcHealthHostTests
         throw new TimeoutException("The daemon did not become ready.");
     }
 
+    private static async Task PublishHealthAsync(
+        HealthCheckService healthChecks,
+        IHealthCheckPublisher publisher)
+    {
+        HealthReport report = await healthChecks.CheckHealthAsync(Ct);
+        await publisher.PublishAsync(report, Ct);
+    }
+
     private static async Task AssertMinimalStatusOnlyAsync(
         HttpResponseMessage response,
         string expected)
@@ -309,12 +331,15 @@ public sealed class GrpcHealthHostTests
 
     private sealed class HealthDaemonFactory(
         string dbPath,
-        IReadOnlyDictionary<string, string?>? extraConfig = null) :
+        IReadOnlyDictionary<string, string?>? extraConfig = null,
+        bool publishHealthManually = false) :
         WebApplicationFactory<Program>
     {
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.UseEnvironment("Development");
+            if (publishHealthManually)
+                builder.ConfigureLogging(logging => logging.ClearProviders());
             if (extraConfig is not null)
             {
                 foreach (KeyValuePair<string, string?> pair in extraConfig)
@@ -336,8 +361,18 @@ public sealed class GrpcHealthHostTests
                 services.AddHostedService<TestDaemonClientShutdown>();
                 services.Configure<HealthCheckPublisherOptions>(options =>
                 {
-                    options.Delay = TimeSpan.Zero;
-                    options.Period = TimeSpan.FromSeconds(1);
+                    if (publishHealthManually)
+                    {
+                        // Keep the hosted publisher from racing explicit
+                        // transition publications in the streaming test.
+                        options.Delay = TimeSpan.FromHours(1);
+                        options.Period = TimeSpan.FromHours(1);
+                    }
+                    else
+                    {
+                        options.Delay = TimeSpan.Zero;
+                        options.Period = TimeSpan.FromSeconds(1);
+                    }
                 });
             });
             builder.ConfigureAppConfiguration((_, configuration) =>

--- a/tests/CSharpDB.Daemon.Tests/LocalPerformanceEnvironmentMonitorCollection.cs
+++ b/tests/CSharpDB.Daemon.Tests/LocalPerformanceEnvironmentMonitorCollection.cs
@@ -1,0 +1,4 @@
+namespace CSharpDB.Daemon.Tests;
+
+[CollectionDefinition("LocalPerformanceEnvironmentMonitor", DisableParallelization = true)]
+public sealed class LocalPerformanceEnvironmentMonitorCollection;

--- a/tests/CSharpDB.Daemon.Tests/LocalPerformanceEnvironmentMonitorTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/LocalPerformanceEnvironmentMonitorTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 
 namespace CSharpDB.Daemon.Tests;
 
+[Collection("LocalPerformanceEnvironmentMonitor")]
 public sealed class LocalPerformanceEnvironmentMonitorTests
 {
     [Fact]

--- a/tests/CSharpDB.Daemon.Tests/PreviousReleasePerformanceScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/PreviousReleasePerformanceScriptTests.cs
@@ -1926,7 +1926,21 @@ public sealed class PreviousReleasePerformanceScriptTests
             Assert.False(Directory.Exists(Path.Combine(evidence, "candidate-source")));
 
             string[] invocations = File.ReadAllLines(invocationLog);
-            Assert.Equal(2, invocations.Count(line => line.Contains("|build", StringComparison.Ordinal)));
+            string[] builds = invocations
+                .Where(line => line.Contains("|build|", StringComparison.Ordinal))
+                .ToArray();
+            Assert.Collection(
+                builds,
+                line =>
+                {
+                    Assert.Contains("candidate-source|build|", line);
+                    Assert.Contains("-p CSharpDbReleaseCoreOnly=true", line);
+                },
+                line =>
+                {
+                    Assert.Contains("baseline-source|build|", line);
+                    Assert.Contains("-p CSharpDbReleaseCoreOnly=true", line);
+                });
             string[] runs = invocations
                 .Where(line => line.Contains("|run|", StringComparison.Ordinal))
                 .ToArray();
@@ -2006,6 +2020,53 @@ public sealed class PreviousReleasePerformanceScriptTests
                 line => Assert.Contains(
                     "candidate-source|run|hybrid-cold-open|repeat=3",
                     line));
+
+            string buildOnlyEvidence = Path.Combine(temporaryRoot, "build-only-evidence");
+            string buildOnlyInvocationLog = Path.Combine(
+                temporaryRoot,
+                "build-only-fake-dotnet.log");
+            var buildOnlyEnvironment = new Dictionary<string, string>(environment)
+            {
+                ["FAKE_DOTNET_LOG"] = buildOnlyInvocationLog,
+            };
+            ProcessResult buildOnly = await RunProcessWithEnvironmentAsync(
+                "pwsh",
+                buildOnlyEnvironment,
+                "-NoLogo",
+                "-NoProfile",
+                "-File",
+                Path.Combine(scriptRoot, "Test-PreviousReleasePerformance.ps1"),
+                "-PreviousRef",
+                "v4.3.0",
+                "-CandidateRef",
+                "HEAD",
+                "-OutputPath",
+                buildOnlyEvidence,
+                "-BuildOnly");
+
+            Assert.True(buildOnly.ExitCode == 0, buildOnly.CombinedOutput);
+            string[] buildOnlyInvocations = File.ReadAllLines(buildOnlyInvocationLog);
+            Assert.Equal(2, buildOnlyInvocations.Length);
+            Assert.All(
+                buildOnlyInvocations,
+                line => Assert.Contains("-p CSharpDbReleaseCoreOnly=true", line));
+            Assert.DoesNotContain(
+                buildOnlyInvocations,
+                line => line.Contains("|run|", StringComparison.Ordinal));
+            string buildOnlyReport = File.ReadAllText(Path.Combine(
+                buildOnlyEvidence,
+                "previous-release-performance.md"));
+            Assert.Contains("- Result: **PASS**", buildOnlyReport);
+            Assert.Contains(
+                "- Mode: build-only; benchmark measurements were not executed",
+                buildOnlyReport);
+            Assert.Contains("CSharpDbReleaseCoreOnly=true", buildOnlyReport);
+            Assert.False(Directory.Exists(Path.Combine(
+                buildOnlyEvidence,
+                "baseline-source")));
+            Assert.False(Directory.Exists(Path.Combine(
+                buildOnlyEvidence,
+                "candidate-source")));
 
             string duplicateEvidence = Path.Combine(temporaryRoot, "duplicate-evidence");
             environment["FAKE_DOTNET_DUPLICATE_SUITE"] = "master-table";
@@ -2179,7 +2240,19 @@ public sealed class PreviousReleasePerformanceScriptTests
             $command = $CommandArgs[0]
             $sourceName = Split-Path -Leaf (Get-Location).Path
             if ($command -eq 'build') {
-                Add-Content -LiteralPath $env:FAKE_DOTNET_LOG -Value "$sourceName|build"
+                $propertySwitchIndex = [Array]::IndexOf($CommandArgs, '-p')
+                if ($propertySwitchIndex -lt 0 -or
+                    $propertySwitchIndex + 1 -ge $CommandArgs.Count -or
+                    $CommandArgs[$propertySwitchIndex + 1] -cne
+                        'CSharpDbReleaseCoreOnly=true') {
+                    Write-Error (
+                        'Release-core MSBuild property is missing. Arguments: ' +
+                        ($CommandArgs -join ' '))
+                    exit 1
+                }
+                Add-Content `
+                    -LiteralPath $env:FAKE_DOTNET_LOG `
+                    -Value "$sourceName|build|$($CommandArgs -join ' ')"
                 Write-Output "Fake build: $sourceName"
                 exit 0
             }

--- a/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
@@ -6,6 +6,7 @@ public sealed class ReleaseStatusScriptTests
 {
     private const string CandidateCommit =
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static readonly TimeSpan PublisherProcessTimeout = TimeSpan.FromMinutes(3);
 
     [Fact]
     public async Task Verifier_AcceptsLatestCanonicalStatusForExactCommit()
@@ -716,6 +717,7 @@ public sealed class ReleaseStatusScriptTests
             return RunProcessAsync(
                 "pwsh",
                 environment,
+                PublisherProcessTimeout,
                 "-NoLogo",
                 "-NoProfile",
                 "-File",
@@ -1494,6 +1496,19 @@ public sealed class ReleaseStatusScriptTests
         IReadOnlyDictionary<string, string> environment,
         params string[] arguments)
     {
+        return await RunProcessAsync(
+            fileName,
+            environment,
+            TimeSpan.FromSeconds(30),
+            arguments);
+    }
+
+    private static async Task<ProcessResult> RunProcessAsync(
+        string fileName,
+        IReadOnlyDictionary<string, string> environment,
+        TimeSpan timeoutDuration,
+        params string[] arguments)
+    {
         ProcessStartInfo startInfo = new()
         {
             FileName = fileName,
@@ -1511,21 +1526,43 @@ public sealed class ReleaseStatusScriptTests
         Assert.True(process.Start(), $"Could not start {fileName}.");
         Task<string> standardOutput = process.StandardOutput.ReadToEndAsync();
         Task<string> standardError = process.StandardError.ReadToEndAsync();
-        using CancellationTokenSource timeout = new(TimeSpan.FromSeconds(30));
+        using CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        timeout.CancelAfter(timeoutDuration);
         try
         {
             await process.WaitForExitAsync(timeout.Token);
         }
         catch (OperationCanceledException)
+            when (!TestContext.Current.CancellationToken.IsCancellationRequested)
         {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException($"{fileName} did not finish within 30 seconds.");
+            KillProcessTree(process);
+            throw new TimeoutException(
+                $"{fileName} did not finish within {timeoutDuration.TotalSeconds:N0} seconds.");
+        }
+        catch
+        {
+            KillProcessTree(process);
+            throw;
         }
 
         return new ProcessResult(
             process.ExitCode,
             await standardOutput,
             await standardError);
+    }
+
+    private static void KillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the state check and the kill request.
+        }
     }
 
     private static string CreateTemporaryRoot()

--- a/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/ReleaseStatusScriptTests.cs
@@ -226,17 +226,13 @@ public sealed class ReleaseStatusScriptTests
     }
 
     [Fact]
-    public void PublishReleaseTag_RequiresExactCleanMainAndVersionBeforeExactTagPush()
+    public void PublishReleaseTag_QualifiesThenTagsAndRunsResumablePublication()
     {
         string repoRoot = FindRepoRoot();
         string publisher = File.ReadAllText(Path.Combine(
             repoRoot,
             "scripts",
             "Publish-ReleaseTag.ps1"));
-        string tagValidator = File.ReadAllText(Path.Combine(
-            repoRoot,
-            "scripts",
-            "Test-ReleaseTag.ps1"));
         Assert.Contains(
             "status', '--porcelain=v1', '--untracked-files=all",
             publisher);
@@ -245,13 +241,18 @@ public sealed class ReleaseStatusScriptTests
         Assert.Contains("refs/heads/main:refs/remotes/origin/main", publisher);
         Assert.Contains("origin/main^{commit}", publisher);
         Assert.Contains("local main to equal origin/main exactly", publisher);
-        Assert.Contains("$packageVersion -cne $releaseVersion", publisher);
-        Assert.Contains("$currentMainCommit -cne $headCommit", publisher);
-        Assert.Contains("Test-ReleaseTag.ps1", publisher);
-        Assert.Contains(
-            "& $tagValidator -Version $releaseTag -TagCommit $headCommit",
-            publisher);
+        Assert.Contains("$versionNodes[0].InnerText.Trim() -cne $releaseVersion", publisher);
+        Assert.Contains("(Get-ExactCurrentMainCommit) -cne $headCommit", publisher);
+        Assert.Contains("$qualificationWorkflow = 'release.yml'", publisher);
+        Assert.Contains("$publicationWorkflow = 'publish-release.yml'", publisher);
+        Assert.Contains("-PreflightOnly $true", publisher);
+        Assert.Contains("-PreflightOnly $false", publisher);
+        Assert.Contains("'tag', $releaseTag, $headCommit", publisher);
         Assert.Contains("refs/tags/$releaseTag`:refs/tags/$releaseTag", publisher);
+        Assert.Contains("& gh run watch", publisher);
+        Assert.Contains("--exit-status", publisher);
+        Assert.Contains("Successful publication did not create a published GitHub Release", publisher);
+        Assert.Contains("Every reversible gate runs before tag creation", publisher);
         Assert.DoesNotContain("--force", publisher, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Test-LocalDurableStatus.ps1", publisher);
         Assert.DoesNotContain("Test-LocalDurablePerformance.ps1", publisher);
@@ -259,23 +260,30 @@ public sealed class ReleaseStatusScriptTests
         Assert.DoesNotContain("ConfirmDedicatedFixedSsd", publisher);
         Assert.DoesNotContain("ApproveDurableV2CarryForward", publisher);
         Assert.DoesNotContain("csharpdb/local-durable-performance", publisher);
-        Assert.DoesNotContain("Test-Documentation.ps1", tagValidator);
 
         int exactMainValidation = publisher.IndexOf(
             "$headCommit = Get-ExactCurrentMainCommit",
             StringComparison.Ordinal);
         int versionValidation = publisher.IndexOf(
-            "$packageVersion -cne $releaseVersion",
+            "$versionNodes[0].InnerText.Trim() -cne $releaseVersion",
             StringComparison.Ordinal);
-        int localTagMutation = publisher.IndexOf(
-            "'tag', $releaseTag, $headCommit",
+        int workflowDispatch = publisher.IndexOf(
+            "$qualificationRun = Find-OrDispatchRun",
             StringComparison.Ordinal);
-        int tagValidation = publisher.IndexOf(
-            "& $tagValidator -Version $releaseTag -TagCommit $headCommit",
+        int qualificationWatch = publisher.IndexOf(
+            "Wait-HostedRun -Run $qualificationRun",
             StringComparison.Ordinal);
-        int exactTagPush = publisher.IndexOf(
-            "refs/tags/$releaseTag`:refs/tags/$releaseTag",
-            localTagMutation,
+        int publicationPreflight = publisher.IndexOf(
+            "-PreflightOnly $true",
+            qualificationWatch,
+            StringComparison.Ordinal);
+        int localTagCreation = publisher.IndexOf(
+            "@('tag', $releaseTag, $headCommit)",
+            publicationPreflight,
+            StringComparison.Ordinal);
+        int publication = publisher.IndexOf(
+            "-PreflightOnly $false",
+            localTagCreation,
             StringComparison.Ordinal);
 
         Assert.True(exactMainValidation >= 0, "The exact main commit must be validated.");
@@ -283,14 +291,204 @@ public sealed class ReleaseStatusScriptTests
             versionValidation > exactMainValidation,
             "The package version must be validated after resolving exact main.");
         Assert.True(
-            localTagMutation > versionValidation,
-            "The package version must be validated before a local tag is created.");
+            workflowDispatch > versionValidation,
+            "The package version must be validated before the hosted release is dispatched.");
         Assert.True(
-            tagValidation > localTagMutation,
-            "The exact local tag must be validated before it is pushed.");
+            qualificationWatch > workflowDispatch,
+            "The publisher must wait for hosted qualification after dispatch.");
         Assert.True(
-            exactTagPush > tagValidation,
-            "Only the exact validated tag may be pushed after local validation.");
+            publicationPreflight > qualificationWatch,
+            "Publication credentials must be preflighted after qualification.");
+        Assert.True(
+            localTagCreation > publicationPreflight,
+            "The tag must be created only after qualification and publication preflight.");
+        Assert.True(
+            publication > localTagCreation,
+            "Resumable publication must start only after the exact tag exists.");
+    }
+
+    [Fact]
+    public async Task Publisher_HappyPath_QualifiesPreflightsTagsAndPublishesInOrder()
+    {
+        using PublisherFixture fixture = new("happy");
+
+        ProcessResult result = await fixture.RunAsync();
+
+        Assert.True(result.ExitCode == 0, result.CombinedOutput);
+        AssertDiagnosticContains($"Published {fixture.ReleaseTag} at exact commit {CandidateCommit}", result.CombinedOutput);
+        Assert.True(fixture.RemoteTagExists);
+        Assert.True(fixture.ReleaseExists);
+        AssertAuditOrder(
+            fixture.AuditLines,
+            "gh|workflow|run|release.yml|",
+            "gh|run|watch|301|",
+            "gh|workflow|run|publish-release.yml|*preflight_only=true",
+            "gh|run|watch|302|",
+            $"git|*|tag|{fixture.ReleaseTag}|{CandidateCommit}",
+            $"git|*|push|origin|refs/tags/{fixture.ReleaseTag}:refs/tags/{fixture.ReleaseTag}",
+            "gh|workflow|run|publish-release.yml|*preflight_only=false",
+            "gh|run|watch|303|");
+    }
+
+    [Fact]
+    public async Task Publisher_QualificationFailure_DoesNotCreateOrPushTag()
+    {
+        using PublisherFixture fixture = new("qualification-failure");
+
+        ProcessResult result = await fixture.RunAsync();
+
+        Assert.NotEqual(0, result.ExitCode);
+        AssertDiagnosticContains("Release qualification failed", result.CombinedOutput);
+        Assert.False(fixture.RemoteTagExists);
+        Assert.False(fixture.ReleaseExists);
+        Assert.DoesNotContain(fixture.GitLines, IsTagMutation);
+        Assert.DoesNotContain(
+            fixture.GitHubLines,
+            line => line.Contains("preflight_only=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Publisher_PublicationPreflightFailure_DoesNotCreateOrPushTag()
+    {
+        using PublisherFixture fixture = new("preflight-failure");
+
+        ProcessResult result = await fixture.RunAsync();
+
+        Assert.NotEqual(0, result.ExitCode);
+        AssertDiagnosticContains("Release preflight failed", result.CombinedOutput);
+        Assert.False(fixture.RemoteTagExists);
+        Assert.False(fixture.ReleaseExists);
+        Assert.DoesNotContain(fixture.GitLines, IsTagMutation);
+        Assert.Contains(
+            fixture.GitHubLines,
+            line => line.Contains("preflight_only=true", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            fixture.GitHubLines,
+            line => line.Contains("preflight_only=false", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Publisher_ReusesSuccessfulExactQualificationWithLiveArtifactAfterInterruption()
+    {
+        using PublisherFixture fixture = new("reuse-qualification");
+
+        ProcessResult result = await fixture.RunAsync();
+
+        Assert.True(result.ExitCode == 0, result.CombinedOutput);
+        Assert.Contains(
+            fixture.GitHubLines,
+            line => line.Contains("actions/runs/201/artifacts", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            fixture.GitHubLines,
+            line => line.Contains("workflow|run|release.yml|", StringComparison.Ordinal));
+        Assert.Contains(
+            fixture.GitHubLines,
+            line => line.Contains("qualification_run_id=201", StringComparison.Ordinal));
+        Assert.True(fixture.RemoteTagExists);
+        Assert.True(fixture.ReleaseExists);
+    }
+
+    [Fact]
+    public async Task Publisher_ExistingExactTag_ResumesOriginalBindingAfterMainAdvances()
+    {
+        using PublisherFixture fixture = new(
+            "existing-binding",
+            exactTagExists: true,
+            originMainCommit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+        ProcessResult result = await fixture.RunAsync();
+
+        Assert.True(result.ExitCode == 0, result.CombinedOutput);
+        Assert.DoesNotContain(
+            fixture.GitHubLines,
+            line => line.Contains("workflow|run|release.yml|", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            fixture.GitHubLines,
+            line => line.Contains("preflight_only=true", StringComparison.Ordinal));
+        Assert.Contains(
+            fixture.GitHubLines,
+            line => line.Contains("qualification_run_id=201", StringComparison.Ordinal) &&
+                line.Contains("preflight_only=false", StringComparison.Ordinal));
+        Assert.DoesNotContain(fixture.GitLines, IsTagMutation);
+        Assert.DoesNotContain(
+            fixture.GitLines,
+            line => line.Contains("origin/main", StringComparison.Ordinal));
+        Assert.True(fixture.ReleaseExists);
+    }
+
+    [Fact]
+    public async Task Publisher_ExistingTag_IgnoresFailedPreflightForUnrelatedQualification()
+    {
+        using PublisherFixture fixture = new("failed-unrelated-preflight", exactTagExists: true);
+
+        ProcessResult result = await fixture.RunAsync();
+
+        Assert.True(result.ExitCode == 0, result.CombinedOutput);
+        Assert.Contains(
+            fixture.GitHubLines,
+            line => line.Contains("qualification_run_id=201", StringComparison.Ordinal) &&
+                line.Contains("preflight_only=false", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            fixture.GitHubLines,
+            line => line.Contains("qualification_run_id=999", StringComparison.Ordinal) &&
+                line.Contains("workflow|run|", StringComparison.Ordinal));
+        Assert.DoesNotContain(fixture.GitLines, IsTagMutation);
+    }
+
+    [Fact]
+    public async Task Publisher_ExistingTag_RejectsMultipleSuccessfulPreflightBindings()
+    {
+        using PublisherFixture fixture = new("multiple-successful-preflights", exactTagExists: true);
+
+        ProcessResult result = await fixture.RunAsync();
+
+        Assert.NotEqual(0, result.ExitCode);
+        AssertDiagnosticContains(
+            $"Existing tag '{fixture.ReleaseTag}' is not bound to exactly one qualification run",
+            result.CombinedOutput);
+        Assert.DoesNotContain(
+            fixture.GitHubLines,
+            line => line.Contains("workflow|run|", StringComparison.Ordinal));
+        Assert.DoesNotContain(fixture.GitLines, IsTagMutation);
+        Assert.False(fixture.ReleaseExists);
+    }
+
+    [Fact]
+    public async Task Publisher_FailedPublication_RetriesWithSameBoundQualificationId()
+    {
+        using PublisherFixture fixture = new("publication-retry");
+
+        ProcessResult first = await fixture.RunAsync();
+        int firstGitLineCount = fixture.GitLines.Length;
+        int firstGitHubLineCount = fixture.GitHubLines.Length;
+
+        Assert.NotEqual(0, first.ExitCode);
+        AssertDiagnosticContains("Release publication failed", first.CombinedOutput);
+        Assert.True(fixture.RemoteTagExists);
+        Assert.False(fixture.ReleaseExists);
+
+        ProcessResult second = await fixture.RunAsync();
+
+        Assert.True(second.ExitCode == 0, second.CombinedOutput);
+        Assert.True(fixture.ReleaseExists);
+        string[] secondGitLines = fixture.GitLines[firstGitLineCount..];
+        string[] secondGitHubLines = fixture.GitHubLines[firstGitHubLineCount..];
+        Assert.DoesNotContain(secondGitLines, IsTagMutation);
+        Assert.DoesNotContain(
+            secondGitHubLines,
+            line => line.Contains("workflow|run|release.yml|", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            secondGitHubLines,
+            line => line.Contains("preflight_only=true", StringComparison.Ordinal));
+        Assert.Contains(
+            secondGitHubLines,
+            line => line.Contains("qualification_run_id=301", StringComparison.Ordinal) &&
+                line.Contains("preflight_only=false", StringComparison.Ordinal));
+        Assert.Equal(
+            2,
+            fixture.GitHubLines.Count(line =>
+                line.Contains("qualification_run_id=301", StringComparison.Ordinal) &&
+                line.Contains("preflight_only=false", StringComparison.Ordinal)));
     }
 
     [Fact]
@@ -385,6 +583,516 @@ public sealed class ReleaseStatusScriptTests
             "Installer contamination after a pass must stop the second pass.");
     }
 
+    private static bool IsTagMutation(string line) =>
+        System.Text.RegularExpressions.Regex.IsMatch(
+            line,
+            "\\|tag\\|v[0-9]",
+            System.Text.RegularExpressions.RegexOptions.CultureInvariant) ||
+        line.Contains("|push|origin|refs/tags/", StringComparison.Ordinal);
+
+    private static void AssertAuditOrder(
+        IReadOnlyList<string> auditLines,
+        params string[] orderedPatterns)
+    {
+        int previousIndex = -1;
+        foreach (string pattern in orderedPatterns)
+        {
+            int foundIndex = -1;
+            for (int index = previousIndex + 1; index < auditLines.Count; index++)
+            {
+                if (MatchesAuditPattern(auditLines[index], pattern))
+                {
+                    foundIndex = index;
+                    break;
+                }
+            }
+
+            Assert.True(
+                foundIndex >= 0,
+                $"Could not find audit pattern '{pattern}' after line {previousIndex}." +
+                Environment.NewLine + string.Join(Environment.NewLine, auditLines));
+            previousIndex = foundIndex;
+        }
+    }
+
+    private static bool MatchesAuditPattern(string value, string pattern)
+    {
+        int offset = 0;
+        foreach (string part in pattern.Split('*'))
+        {
+            if (part.Length == 0)
+                continue;
+            int match = value.IndexOf(part, offset, StringComparison.Ordinal);
+            if (match < 0)
+                return false;
+            offset = match + part.Length;
+        }
+        return true;
+    }
+
+    private sealed class PublisherFixture : IDisposable
+    {
+        private readonly string temporaryRoot;
+        private readonly string toolRoot;
+        private readonly string auditLog;
+        private readonly string gitLog;
+        private readonly string gitHubLog;
+        private readonly string eventLog;
+        private readonly string localTagMarker;
+        private readonly string remoteTagMarker;
+        private readonly string releaseMarker;
+        private readonly string scenario;
+        private readonly string originMainCommit;
+
+        public PublisherFixture(
+            string scenario,
+            bool exactTagExists = false,
+            string? originMainCommit = null)
+        {
+            this.scenario = scenario;
+            this.originMainCommit = originMainCommit ?? CandidateCommit;
+            temporaryRoot = CreateTemporaryRoot();
+            toolRoot = Directory.CreateDirectory(
+                Path.Combine(temporaryRoot, "fake-release-tools")).FullName;
+            auditLog = Path.Combine(temporaryRoot, "audit.log");
+            gitLog = Path.Combine(temporaryRoot, "git.log");
+            gitHubLog = Path.Combine(temporaryRoot, "gh.log");
+            eventLog = Path.Combine(temporaryRoot, "events.log");
+            localTagMarker = Path.Combine(temporaryRoot, "local-tag.txt");
+            remoteTagMarker = Path.Combine(temporaryRoot, "remote-tag.txt");
+            releaseMarker = Path.Combine(temporaryRoot, "release.txt");
+            File.WriteAllText(auditLog, string.Empty);
+            File.WriteAllText(gitLog, string.Empty);
+            File.WriteAllText(gitHubLog, string.Empty);
+            File.WriteAllText(eventLog, string.Empty);
+
+            string propsPath = Path.Combine(FindRepoRoot(), "src", "Directory.Build.props");
+            System.Xml.Linq.XDocument props = System.Xml.Linq.XDocument.Load(propsPath);
+            ReleaseVersion = props.Descendants("Version").Single().Value.Trim();
+            ReleaseTag = "v" + ReleaseVersion;
+
+            if (exactTagExists)
+            {
+                File.WriteAllText(localTagMarker, CandidateCommit);
+                File.WriteAllText(remoteTagMarker, CandidateCommit);
+            }
+
+            CreateFakeReleaseGit();
+            CreateFakeReleaseGitHubCli();
+        }
+
+        public string ReleaseVersion { get; }
+
+        public string ReleaseTag { get; }
+
+        public bool RemoteTagExists => File.Exists(remoteTagMarker);
+
+        public bool ReleaseExists => File.Exists(releaseMarker);
+
+        public string[] AuditLines => File.ReadAllLines(auditLog);
+
+        public string[] GitLines => File.ReadAllLines(gitLog);
+
+        public string[] GitHubLines => File.ReadAllLines(gitHubLog);
+
+        public Task<ProcessResult> RunAsync()
+        {
+            Dictionary<string, string> environment = new()
+            {
+                ["FAKE_RELEASE_AUDIT_LOG"] = auditLog,
+                ["FAKE_RELEASE_COMMIT"] = CandidateCommit,
+                ["FAKE_RELEASE_EVENT_LOG"] = eventLog,
+                ["FAKE_RELEASE_GH_LOG"] = gitHubLog,
+                ["FAKE_RELEASE_GIT_LOG"] = gitLog,
+                ["FAKE_RELEASE_LOCAL_TAG"] = localTagMarker,
+                ["FAKE_RELEASE_ORIGIN_MAIN_COMMIT"] = originMainCommit,
+                ["FAKE_RELEASE_RELEASE"] = releaseMarker,
+                ["FAKE_RELEASE_REMOTE_TAG"] = remoteTagMarker,
+                ["FAKE_RELEASE_SCENARIO"] = scenario,
+                ["FAKE_RELEASE_TAG"] = ReleaseTag,
+                ["PATH"] = toolRoot + Path.PathSeparator +
+                    (Environment.GetEnvironmentVariable("PATH") ?? string.Empty),
+            };
+            return RunProcessAsync(
+                "pwsh",
+                environment,
+                "-NoLogo",
+                "-NoProfile",
+                "-File",
+                Path.Combine(FindRepoRoot(), "scripts", "Publish-ReleaseTag.ps1"),
+                "-Version",
+                ReleaseVersion);
+        }
+
+        public void Dispose() => DeleteTemporaryRoot(temporaryRoot);
+
+        private void CreateFakeReleaseGit()
+        {
+            File.WriteAllText(
+                Path.Combine(toolRoot, "fake-release-git.ps1"),
+                """
+                param(
+                    [Alias('C')]
+                    [string] $RepositoryRoot,
+
+                    [Alias('e')]
+                    [switch] $ObjectExists,
+
+                    [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
+                    [string[]] $RemainingArguments)
+
+                $ErrorActionPreference = 'Stop'
+                if ($ObjectExists -and $RemainingArguments.Count -ge 1) {
+                    $RemainingArguments = @($RemainingArguments[0], '-e') +
+                        @($RemainingArguments[1..($RemainingArguments.Count - 1)])
+                }
+                $CliArguments = if ([string]::IsNullOrWhiteSpace($RepositoryRoot)) {
+                    @($RemainingArguments)
+                }
+                else {
+                    @('-C', $RepositoryRoot) + @($RemainingArguments)
+                }
+                $raw = $CliArguments -join '|'
+                Add-Content -LiteralPath $env:FAKE_RELEASE_GIT_LOG -Value $raw
+                Add-Content -LiteralPath $env:FAKE_RELEASE_AUDIT_LOG -Value "git|$raw"
+
+                $effective = @($CliArguments)
+                if ($effective.Count -ge 3 -and $effective[0] -ceq '-C') {
+                    $effective = @($effective[2..($effective.Count - 1)])
+                }
+                if ($effective.Count -eq 0) {
+                    Write-Error 'Fake git received no command.'
+                    exit 1
+                }
+
+                $command = $effective[0]
+                $commit = $env:FAKE_RELEASE_COMMIT
+                $tag = $env:FAKE_RELEASE_TAG
+                switch ($command) {
+                    'status' { exit 0 }
+                    'branch' {
+                        if ($effective -contains '--show-current') {
+                            'main'
+                            exit 0
+                        }
+                    }
+                    'fetch' { exit 0 }
+                    'cat-file' {
+                        if ($effective.Count -eq 3 -and
+                            $effective[1] -ceq '-e' -and
+                            $effective[2] -in @("$commit`^{commit}", "$commit{commit}")) {
+                            exit 0
+                        }
+                    }
+                    'rev-parse' {
+                        $ref = $effective[-1]
+                        if ($ref -in @(
+                            'HEAD^{commit}',
+                            'HEAD{commit}',
+                            "$commit`^{commit}",
+                            "$commit{commit}")) {
+                            $commit
+                            exit 0
+                        }
+                        if ($ref -in @('origin/main^{commit}', 'origin/main{commit}')) {
+                            $env:FAKE_RELEASE_ORIGIN_MAIN_COMMIT
+                            exit 0
+                        }
+                        if ($ref -in @(
+                            "refs/tags/$tag`^{commit}",
+                            "refs/tags/$tag{commit}",
+                            "$tag`^{commit}",
+                            "$tag{commit}")) {
+                            if (Test-Path -LiteralPath $env:FAKE_RELEASE_LOCAL_TAG) {
+                                $commit
+                                exit 0
+                            }
+                            exit 1
+                        }
+                    }
+                    'tag' {
+                        if ($effective -contains '--list' -or
+                            $effective -contains '--points-at') {
+                            exit 0
+                        }
+                        if ($effective.Count -eq 3 -and
+                            $effective[1] -ceq $tag -and
+                            $effective[2] -ceq $commit) {
+                            Set-Content -LiteralPath $env:FAKE_RELEASE_LOCAL_TAG -Value $commit
+                            exit 0
+                        }
+                    }
+                    'describe' { exit 1 }
+                    'ls-remote' {
+                        if (Test-Path -LiteralPath $env:FAKE_RELEASE_REMOTE_TAG) {
+                            "$commit`trefs/tags/$tag"
+                        }
+                        exit 0
+                    }
+                    'push' {
+                        if (-not (Test-Path -LiteralPath $env:FAKE_RELEASE_LOCAL_TAG)) {
+                            Write-Error 'Cannot push a tag that does not exist locally.'
+                            exit 1
+                        }
+                        Set-Content -LiteralPath $env:FAKE_RELEASE_REMOTE_TAG -Value $commit
+                        exit 0
+                    }
+                }
+
+                Write-Error "Unexpected fake git invocation: $($CliArguments -join ' ')"
+                exit 1
+                """);
+            CreateToolLauncher(toolRoot, "git", "fake-release-git.ps1");
+        }
+
+        private void CreateFakeReleaseGitHubCli()
+        {
+            File.WriteAllText(
+                Path.Combine(toolRoot, "fake-release-gh.ps1"),
+                """
+                param(
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [string[]] $CliArguments)
+
+                $ErrorActionPreference = 'Stop'
+                $raw = $CliArguments -join '|'
+                Add-Content -LiteralPath $env:FAKE_RELEASE_GH_LOG -Value $raw
+                Add-Content -LiteralPath $env:FAKE_RELEASE_AUDIT_LOG -Value "gh|$raw"
+
+                function New-FakeRecord {
+                    param(
+                        [long] $Id,
+                        [string] $Workflow,
+                        [string] $Kind,
+                        [long] $QualificationId,
+                        [string] $Conclusion,
+                        [bool] $Artifact = $false)
+
+                    [pscustomobject]@{
+                        Id = $Id
+                        Workflow = $Workflow
+                        Kind = $Kind
+                        QualificationId = $QualificationId
+                        Conclusion = $Conclusion
+                        Artifact = $Artifact
+                    }
+                }
+
+                function Get-SeedRecords {
+                    switch ($env:FAKE_RELEASE_SCENARIO) {
+                        'reuse-qualification' {
+                            New-FakeRecord 201 'release.yml' 'qualification' 0 'success' $true
+                        }
+                        'existing-binding' {
+                            New-FakeRecord 201 'release.yml' 'qualification' 0 'success' $true
+                            New-FakeRecord 202 'publish-release.yml' 'preflight' 201 'success'
+                        }
+                        'failed-unrelated-preflight' {
+                            New-FakeRecord 201 'release.yml' 'qualification' 0 'success' $true
+                            New-FakeRecord 202 'publish-release.yml' 'preflight' 999 'failure'
+                            New-FakeRecord 203 'publish-release.yml' 'preflight' 201 'success'
+                        }
+                        'multiple-successful-preflights' {
+                            New-FakeRecord 201 'release.yml' 'qualification' 0 'success' $true
+                            New-FakeRecord 202 'release.yml' 'qualification' 0 'success' $true
+                            New-FakeRecord 203 'publish-release.yml' 'preflight' 201 'success'
+                            New-FakeRecord 204 'publish-release.yml' 'preflight' 202 'success'
+                        }
+                    }
+                }
+
+                function Get-EventRecords {
+                    foreach ($line in @(Get-Content -LiteralPath $env:FAKE_RELEASE_EVENT_LOG)) {
+                        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+                        $fields = $line -split '\|', 6
+                        New-FakeRecord `
+                            ([long] $fields[0]) `
+                            $fields[1] `
+                            $fields[2] `
+                            ([long] $fields[3]) `
+                            $fields[4] `
+                            ([bool]::Parse($fields[5]))
+                    }
+                }
+
+                function Get-AllRecords {
+                    $records = [Collections.Generic.List[object]]::new()
+                    foreach ($record in @(Get-SeedRecords)) { $records.Add($record) | Out-Null }
+                    foreach ($record in @(Get-EventRecords)) { $records.Add($record) | Out-Null }
+                    return @($records)
+                }
+
+                function ConvertTo-FakeRun {
+                    param([Parameter(Mandatory)] $Record)
+
+                    $title = switch ($Record.Kind) {
+                        'qualification' {
+                            "Qualify release $($env:FAKE_RELEASE_TAG) at $($env:FAKE_RELEASE_COMMIT)"
+                        }
+                        'preflight' {
+                            "Publish $($env:FAKE_RELEASE_TAG) from qualification $($Record.QualificationId) (preflight)"
+                        }
+                        'publication' {
+                            "Publish $($env:FAKE_RELEASE_TAG) from qualification $($Record.QualificationId) (release)"
+                        }
+                    }
+                    [pscustomobject]@{
+                        databaseId = $Record.Id
+                        displayTitle = $title
+                        event = 'workflow_dispatch'
+                        headSha = $env:FAKE_RELEASE_COMMIT
+                        status = 'completed'
+                        conclusion = $Record.Conclusion
+                        url = "https://example.invalid/actions/runs/$($Record.Id)"
+                    }
+                }
+
+                function Get-ArgumentValue {
+                    param([string] $Name)
+                    $index = [Array]::IndexOf($CliArguments, $Name)
+                    if ($index -lt 0 -or $index + 1 -ge $CliArguments.Count) { return $null }
+                    return $CliArguments[$index + 1]
+                }
+
+                if ($CliArguments.Count -ge 2 -and
+                    $CliArguments[0] -ceq 'auth' -and
+                    $CliArguments[1] -ceq 'status') {
+                    exit 0
+                }
+
+                if ($CliArguments.Count -ge 2 -and
+                    $CliArguments[0] -ceq 'repo' -and
+                    $CliArguments[1] -ceq 'view') {
+                    'example/csharpdb'
+                    exit 0
+                }
+
+                if ($CliArguments.Count -ge 2 -and
+                    $CliArguments[0] -ceq 'run' -and
+                    $CliArguments[1] -ceq 'list') {
+                    $workflow = Get-ArgumentValue '--workflow'
+                    $runs = @(
+                        Get-AllRecords |
+                            Where-Object { $_.Workflow -ceq $workflow } |
+                            ForEach-Object { ConvertTo-FakeRun $_ }
+                    )
+                    ConvertTo-Json -InputObject @($runs) -Depth 10 -Compress
+                    exit 0
+                }
+
+                if ($CliArguments.Count -ge 3 -and
+                    $CliArguments[0] -ceq 'workflow' -and
+                    $CliArguments[1] -ceq 'run') {
+                    $workflow = $CliArguments[2]
+                    $fields = @{}
+                    for ($index = 3; $index -lt $CliArguments.Count - 1; $index++) {
+                        if ($CliArguments[$index] -cne '--raw-field') { continue }
+                        $pair = $CliArguments[$index + 1] -split '=', 2
+                        $fields[$pair[0]] = $pair[1]
+                        $index++
+                    }
+
+                    if ($workflow -ceq 'release.yml') {
+                        $kind = 'qualification'
+                        $qualificationId = 0
+                    }
+                    elseif ($workflow -ceq 'publish-release.yml' -and
+                        $fields.preflight_only -ceq 'true') {
+                        $kind = 'preflight'
+                        $qualificationId = [long] $fields.qualification_run_id
+                    }
+                    elseif ($workflow -ceq 'publish-release.yml' -and
+                        $fields.preflight_only -ceq 'false') {
+                        $kind = 'publication'
+                        $qualificationId = [long] $fields.qualification_run_id
+                    }
+                    else {
+                        Write-Error "Unexpected fake workflow dispatch: $raw"
+                        exit 1
+                    }
+
+                    $eventRecords = @(Get-EventRecords)
+                    $id = 301 + $eventRecords.Count
+                    $conclusion = 'success'
+                    if ($env:FAKE_RELEASE_SCENARIO -ceq 'qualification-failure' -and
+                        $kind -ceq 'qualification') {
+                        $conclusion = 'failure'
+                    }
+                    elseif ($env:FAKE_RELEASE_SCENARIO -ceq 'preflight-failure' -and
+                        $kind -ceq 'preflight') {
+                        $conclusion = 'failure'
+                    }
+                    elseif ($env:FAKE_RELEASE_SCENARIO -ceq 'publication-retry' -and
+                        $kind -ceq 'publication' -and
+                        @($eventRecords | Where-Object Kind -ceq 'publication').Count -eq 0) {
+                        $conclusion = 'failure'
+                    }
+                    $artifact = $kind -ceq 'qualification' -and $conclusion -ceq 'success'
+                    Add-Content `
+                        -LiteralPath $env:FAKE_RELEASE_EVENT_LOG `
+                        -Value "$id|$workflow|$kind|$qualificationId|$conclusion|$artifact"
+                    exit 0
+                }
+
+                if ($CliArguments.Count -ge 3 -and
+                    $CliArguments[0] -ceq 'run' -and
+                    $CliArguments[1] -ceq 'watch') {
+                    $id = [long] $CliArguments[2]
+                    $record = @(Get-AllRecords | Where-Object Id -eq $id) | Select-Object -First 1
+                    if ($null -eq $record) {
+                        Write-Error "Unknown fake run $id."
+                        exit 1
+                    }
+                    if ($record.Conclusion -cne 'success') {
+                        Write-Error "Simulated $($record.Kind) failure for run $id."
+                        exit 1
+                    }
+                    if ($record.Kind -ceq 'publication') {
+                        Set-Content -LiteralPath $env:FAKE_RELEASE_RELEASE -Value $env:FAKE_RELEASE_TAG
+                    }
+                    exit 0
+                }
+
+                if ($CliArguments.Count -ge 2 -and $CliArguments[0] -ceq 'api') {
+                    $apiPath = @($CliArguments | Where-Object { $_ -like 'repos/*' }) |
+                        Select-Object -First 1
+                    if ($apiPath -match '/actions/runs/(?<id>[0-9]+)/artifacts$') {
+                        $id = [long] $Matches.id
+                        $record = @(Get-AllRecords | Where-Object Id -eq $id) |
+                            Select-Object -First 1
+                        if ($null -ne $record -and $record.Artifact) { '1' } else { '0' }
+                        exit 0
+                    }
+                    if ($apiPath -ceq 'repos/example/csharpdb/releases') {
+                        if (Test-Path -LiteralPath $env:FAKE_RELEASE_RELEASE) {
+                            $env:FAKE_RELEASE_TAG
+                        }
+                        exit 0
+                    }
+                }
+
+                if ($CliArguments.Count -ge 3 -and
+                    $CliArguments[0] -ceq 'release' -and
+                    $CliArguments[1] -ceq 'view') {
+                    if (-not (Test-Path -LiteralPath $env:FAKE_RELEASE_RELEASE)) {
+                        Write-Error 'Fake release does not exist.'
+                        exit 1
+                    }
+                    [pscustomobject]@{
+                        isDraft = $false
+                        tagName = $env:FAKE_RELEASE_TAG
+                        url = "https://example.invalid/releases/$($env:FAKE_RELEASE_TAG)"
+                    } | ConvertTo-Json -Compress
+                    exit 0
+                }
+
+                Write-Error "Unexpected fake gh invocation: $($CliArguments -join ' ')"
+                exit 1
+                """);
+            CreateToolLauncher(toolRoot, "gh", "fake-release-gh.ps1");
+        }
+    }
+
     private static Task<ProcessResult> RunVerifierAsync(
         string fakeGhRoot,
         string ghLog,
@@ -417,6 +1125,38 @@ public sealed class ReleaseStatusScriptTests
             arguments.Add(releaseVersion);
         }
         return RunProcessAsync("pwsh", environment, [.. arguments]);
+    }
+
+    private static void CreateToolLauncher(
+        string toolRoot,
+        string commandName,
+        string scriptName)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            File.WriteAllText(
+                Path.Combine(toolRoot, commandName + ".cmd"),
+                $"@echo off{Environment.NewLine}" +
+                $"pwsh -NoLogo -NoProfile -File \"%~dp0{scriptName}\" %*{Environment.NewLine}" +
+                $"exit /b %ERRORLEVEL%{Environment.NewLine}");
+            return;
+        }
+
+        string launcher = Path.Combine(toolRoot, commandName);
+        File.WriteAllText(
+            launcher,
+            "#!/usr/bin/env sh\n" +
+            "script_dir=\"$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\"\n" +
+            $"exec pwsh -NoLogo -NoProfile -File \"${{script_dir}}/{scriptName}\" \"$@\"\n");
+        File.SetUnixFileMode(
+            launcher,
+            UnixFileMode.UserRead |
+            UnixFileMode.UserWrite |
+            UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead |
+            UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead |
+            UnixFileMode.OtherExecute);
     }
 
     private static string CreateFakeGitHubCli(string temporaryRoot)

--- a/tests/CSharpDB.Migration.Files.Tests/CsvMigrationDataSourceTests.cs
+++ b/tests/CSharpDB.Migration.Files.Tests/CsvMigrationDataSourceTests.cs
@@ -225,7 +225,7 @@ public sealed class CsvMigrationDataSourceTests
 
             const string expectedCursor =
                 "csharpdb-csv-cursor-v1/1/1/" +
-                "a56108f642a77cca8f417c861631c0e2c73872b5f4d3bd168866ee1ffdc8af6f";
+                "f126b46ff7953b1507f762f505efd986daa549acb1952d99901a9b42ab92a912";
             Assert.True(
                 string.Equals(expectedCursor, first.NextCursor, StringComparison.Ordinal),
                 $"CSV cursor golden changed. Actual value: {first.NextCursor}");

--- a/tests/CSharpDB.Migration.MySql.Tests/MySqlCatalogBuilderTests.cs
+++ b/tests/CSharpDB.Migration.MySql.Tests/MySqlCatalogBuilderTests.cs
@@ -6,7 +6,7 @@ namespace CSharpDB.Migration.MySql.Tests;
 public sealed class MySqlCatalogBuilderTests
 {
     private const string GoldenCatalogDigest =
-        "4d49a3557299cbf4551e823c4f5d1c5677c1bff252079cd8aea11b745bfbadf5";
+        "dc68e460923a62eebcd3b2ea76d618aa9ba57d5b118dc38d770ab76e1d3de887";
     private const string GoldenSourceFingerprint =
         "sha256:3e8b79eed8a2f36c0962a6e252404180d715dbbaab46d1fec4f1af61b75e383c";
 

--- a/tests/CSharpDB.Migration.SqlServer.Tests/SqlServerCatalogBuilderTests.cs
+++ b/tests/CSharpDB.Migration.SqlServer.Tests/SqlServerCatalogBuilderTests.cs
@@ -6,7 +6,7 @@ namespace CSharpDB.Migration.SqlServer.Tests;
 public sealed partial class SqlServerCatalogBuilderTests
 {
     private const string GoldenCatalogDigest =
-        "d9c7afba06cec81ed5376dbfda4f6b45dd34571db6b785c261e163ce03cbba18";
+        "c010e86ad9ed442d4b55bb7a4bc49f560a318bd4673a760e73cbd01e7d9d8c57";
     private const string GoldenSourceFingerprint =
         "sha256:9ca68e4d38d4caa4d6feeb034355a7ad75da5af6c7456d9bdefa7270f9a92c21";
 

--- a/tests/CSharpDB.Migration.Tests/CSharpDbValidationActivationTests.cs
+++ b/tests/CSharpDB.Migration.Tests/CSharpDbValidationActivationTests.cs
@@ -250,7 +250,7 @@ public sealed class CSharpDbValidationActivationTests
 
         string expectedIdentity =
             $"staged-target:{GoldenTargetIdentity}:awaiting-validation:outcomes:" +
-            "3c41ab5e383a96e154e85a2c32df96d498cd983dd50a3f824fbdc1901f0a9a0c";
+            "fdc7e646b6b08df528d5ea75917a99604d0623adacb3820b18ffa6c41099c851";
         Assert.True(
             string.Equals(expectedIdentity, snapshot.SnapshotIdentity, StringComparison.Ordinal),
             $"Validation snapshot golden identity changed. Actual value: {snapshot.SnapshotIdentity}");

--- a/tests/CSharpDB.Migration.Tests/Fixtures/catalog-v1.golden.json
+++ b/tests/CSharpDB.Migration.Tests/Fixtures/catalog-v1.golden.json
@@ -1,9 +1,9 @@
 {
   "format": "csharpdb-migration-catalog/v1",
   "digestAlgorithm": "sha256",
-  "digest": "4573019633a62d256f1ef036e5fc273f5ab5e696b8f5580b4eea93e9a8dc4f13",
+  "digest": "c3a16a2ce334099c0aaead2f1f5b69a3d0a1a6b164a134ac73a04d5083f7490b",
   "payload": {
-    "targetCSharpDbVersion": "4.6.1",
+    "targetCSharpDbVersion": "4.6.2",
     "source": {
       "kind": "synthetic",
       "identity": "fixture:awkward-v1",

--- a/tests/CSharpDB.Migration.Tests/Fixtures/synthetic-planning-v1.golden.json
+++ b/tests/CSharpDB.Migration.Tests/Fixtures/synthetic-planning-v1.golden.json
@@ -1,5 +1,5 @@
 {
-  "catalogDigest": "e8571472a3c26eec60bbd5e6a9c3189c05a84549de00177d9a9df23e588e0367",
-  "preservePlanDigest": "abb3be1e1e0576cba493384e59aad2878e11df9f3d76c6667f6462c8c20e5b24",
-  "queryablePlanDigest": "550ecd009eda327bbb86cb9b8ae1eb693510b11fbee33d75b4fb3875020a8c0e"
+  "catalogDigest": "3b37e5f4d8c0232b5917db3ae34aa6cccec84812c20c49d0e50b1b1e41ea416a",
+  "preservePlanDigest": "004f35f92127d9c5c720bb21d7e47803f82be7903b9c5e932ebbeaea5495fa6e",
+  "queryablePlanDigest": "5ad185008bf8dccff5ae6e823e6ebc725e283abc71bef8ebe551d2a9ec74e199"
 }

--- a/tests/CSharpDB.Migration.Tests/MigrationPlannerTests.cs
+++ b/tests/CSharpDB.Migration.Tests/MigrationPlannerTests.cs
@@ -11,7 +11,7 @@ public sealed class MigrationPlannerTests
     {
         CSharpDbCapabilityCatalog capabilities = CSharpDbCapabilityCatalogLoader.LoadEmbedded();
 
-        Assert.Equal("4.6.1", capabilities.TargetCSharpDbVersion);
+        Assert.Equal("4.6.2", capabilities.TargetCSharpDbVersion);
         Assert.Equal("local-typed-engine", capabilities.Surface);
         Assert.Equal(SqlIdentifierRules.MaxLength, capabilities.MaxIdentifierLength);
         Assert.Equal(64, capabilities.Digest.Length);
@@ -49,9 +49,9 @@ public sealed class MigrationPlannerTests
     }
 
     [Fact]
-    public void EmbeddedCapabilities_AreBoundToThe461ReleaseAssembliesAndResource()
+    public void EmbeddedCapabilities_AreBoundToThe462ReleaseAssembliesAndResource()
     {
-        const string expectedVersion = "4.6.1";
+        const string expectedVersion = "4.6.2";
         Assembly migrationAssembly = typeof(CSharpDbCapabilityCatalogLoader).Assembly;
         Assembly primitivesAssembly = typeof(DbType).Assembly;
 
@@ -74,32 +74,38 @@ public sealed class MigrationPlannerTests
             CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.5.0");
         CSharpDbCapabilityCatalog previousRelease =
             CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.5.1");
+        CSharpDbCapabilityCatalog previousAttempt =
+            CSharpDbCapabilityCatalogLoader.LoadEmbedded("4.6.1");
         CSharpDbCapabilityCatalog current =
             CSharpDbCapabilityCatalogLoader.LoadEmbedded();
 
         Assert.Equal(
-            ["4.3.0", "4.4.0", "4.5.0", "4.5.1", "4.6.1"],
+            ["4.3.0", "4.4.0", "4.5.0", "4.5.1", "4.6.1", "4.6.2"],
             CSharpDbCapabilityCatalogLoader.SupportedTargetVersions);
         Assert.Equal("4.3.0", oldest.TargetCSharpDbVersion);
         Assert.Equal("4.4.0", previous.TargetCSharpDbVersion);
         Assert.Equal("4.5.0", tagged.TargetCSharpDbVersion);
         Assert.Equal("4.5.1", previousRelease.TargetCSharpDbVersion);
-        Assert.Equal("4.6.1", current.TargetCSharpDbVersion);
+        Assert.Equal("4.6.1", previousAttempt.TargetCSharpDbVersion);
+        Assert.Equal("4.6.2", current.TargetCSharpDbVersion);
         Assert.False(oldest.IsColumnType(DbType.Decimal));
         Assert.False(previous.IsColumnType(DbType.Decimal));
         Assert.True(tagged.IsColumnType(DbType.Decimal));
         Assert.True(previousRelease.IsColumnType(DbType.Decimal));
+        Assert.True(previousAttempt.IsColumnType(DbType.Decimal));
         Assert.True(current.IsColumnType(DbType.Decimal));
         Assert.False(oldest.EngineEnforcesMappedColumnType);
         Assert.False(previous.EngineEnforcesMappedColumnType);
         Assert.True(tagged.EngineEnforcesMappedColumnType);
         Assert.True(previousRelease.EngineEnforcesMappedColumnType);
+        Assert.True(previousAttempt.EngineEnforcesMappedColumnType);
         Assert.True(current.EngineEnforcesMappedColumnType);
         Assert.NotEqual(previous.Digest, current.Digest);
         Assert.NotEqual(tagged.Digest, current.Digest);
         Assert.NotEqual(previousRelease.Digest, current.Digest);
+        Assert.NotEqual(previousAttempt.Digest, current.Digest);
         Assert.Equal(
-            JsonSerializer.Serialize(previousRelease with
+            JsonSerializer.Serialize(previousAttempt with
             {
                 TargetCSharpDbVersion = current.TargetCSharpDbVersion,
             }),


### PR DESCRIPTION
## Summary

Prepare CSharpDB 4.6.2 as the recovery release and replace the fragile tag-first release path with one tag-last, retryable command.

The v4.6.1 release failed because the current benchmark harness was copied into the published v4.5.1 source tree and referenced the new `CSharpDB.Observability` project, which does not exist in that baseline. This PR adds a symmetric release-core benchmark profile and a PR-time build-only compatibility job that compiles the synchronized harness against both the published baseline and the candidate.

`Publish-ReleaseTag.ps1` now runs all reversible qualification, final bundle assembly, NuGet credential/absence preflight, and release metadata checks before creating the protected tag. Publication consumes the exact qualified bundle, stages and hash-verifies a draft GitHub Release, publishes packages in validated order, and can resume a partial attempt using the same immutable tag and qualification artifact.

The package, migration catalog, release notes, and recovery documentation are aligned at 4.6.2. The failed v4.6.0 and v4.6.1 tags remain immutable history; neither published packages or a GitHub Release.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

Recovery follow-up for the failed v4.6.1 release qualification.

## Testing

- [x] `dotnet build CSharpDB.slnx`
- [x] Relevant tests executed
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [x] Manual verification performed (if applicable)

Validation completed:

- Release workflow/publisher tests: 73/73 passed.
- Benchmark contract/qualification tests: 153/153 passed.
- Full migration project: 526/526 passed.
- Migration release packaging tests: 10/10 passed.
- Real build-only reconstruction against published v4.5.1 and current candidate: both succeeded with 0 warnings and 0 errors; no benchmark measurements were run.
- Full solution Release build: succeeded with 0 warnings and 0 errors.
- Documentation links/sitemap, YAML parsing, PowerShell parsing, and `git diff --check`: passed.
- Independent blocker-first release audit: no remaining release-only blocker.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

The intended post-merge release command is:

```powershell
.\scripts\Publish-ReleaseTag.ps1 -Version 4.6.2
```

No v4.6.2 tag has been created. The qualification bundle is retained for 90 days so an interrupted publication can resume without rebuilding or burning another version. NuGet duplicate handling is supported only inside the serialized publisher after the exact package set was proven absent immediately before tag creation.
