### PR TITLE
Fix CSharpDB 4.6.3 Windows API test cleanup

### DIFF
--- a/tests/CSharpDB.Api.Tests/ApiTestFileCleanup.cs
+++ b/tests/CSharpDB.Api.Tests/ApiTestFileCleanup.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+
+namespace CSharpDB.Api.Tests;
+
+internal static class ApiTestFileCleanup
+{
+    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(50);
+
+    // Call only after the client and factory have finished asynchronous disposal.
+    // Windows can still hold temporary file locks; permanent locks must fail cleanup.
+    internal static async ValueTask DeleteIfExistsAsync(string path)
+    {
+        if (!File.Exists(path))
+            return;
+
+        var stopwatch = Stopwatch.StartNew();
+        Exception? lastException = null;
+        while (true)
+        {
+            try
+            {
+                File.Delete(path);
+                return;
+            }
+            catch (IOException ex)
+            {
+                lastException = ex;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                lastException = ex;
+            }
+
+            if (!File.Exists(path))
+                return;
+
+            TimeSpan remaining = CleanupTimeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            // Teardown must run even if the test's cancellation token was cancelled.
+            await Task.Delay(remaining < RetryDelay ? remaining : RetryDelay, CancellationToken.None);
+        }
+
+        throw new IOException(
+            $"Failed to delete temporary database file '{path}' within the cleanup timeout ({CleanupTimeout}).",
+            lastException);
+    }
+}

--- a/tests/CSharpDB.Api.Tests/ApiTestFileCleanupTests.cs
+++ b/tests/CSharpDB.Api.Tests/ApiTestFileCleanupTests.cs
@@ -1,0 +1,29 @@
+namespace CSharpDB.Api.Tests;
+
+public sealed class ApiTestFileCleanupTests
+{
+    [Fact]
+    public async Task DeleteIfExistsAsync_PermanentLockFailsWithOriginalException()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "Windows prevents deleting open files.");
+        string path = Path.Combine(Path.GetTempPath(), $"csharpdb_api_cleanup_locked_{Guid.NewGuid():N}.db");
+        try
+        {
+            await using var lockStream = new FileStream(
+                path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+
+            IOException error = await Assert.ThrowsAsync<IOException>(() =>
+                ApiTestFileCleanup.DeleteIfExistsAsync(path).AsTask().WaitAsync(
+                    TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken));
+
+            Assert.Contains(path, error.Message, StringComparison.Ordinal);
+            Assert.Contains("cleanup timeout", error.Message, StringComparison.Ordinal);
+            Assert.IsType<IOException>(error.InnerException);
+            Assert.True(File.Exists(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/CSharpDB.Api.Tests/HttpTransportClientTests.cs
+++ b/tests/CSharpDB.Api.Tests/HttpTransportClientTests.cs
@@ -17,8 +17,6 @@ namespace CSharpDB.Api.Tests;
 
 public sealed class HttpTransportClientTests : IAsyncLifetime
 {
-    private static readonly TimeSpan FileCleanupTimeout = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan FileCleanupRetryDelay = TimeSpan.FromMilliseconds(50);
     private static readonly TimeSpan ReadinessTimeout = TimeSpan.FromSeconds(10);
 
     private string _dbPath = null!;
@@ -2437,44 +2435,8 @@ public sealed class HttpTransportClientTests : IAsyncLifetime
             });
     }
 
-    private static async ValueTask DeleteIfExistsAsync(string path)
-    {
-        if (!File.Exists(path))
-            return;
-
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        Exception? lastException = null;
-        while (true)
-        {
-            try
-            {
-                File.Delete(path);
-                return;
-            }
-            catch (IOException ex)
-            {
-                lastException = ex;
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                lastException = ex;
-            }
-
-            if (!File.Exists(path))
-                return;
-
-            TimeSpan remaining = FileCleanupTimeout - sw.Elapsed;
-            if (remaining <= TimeSpan.Zero)
-                break;
-
-            TimeSpan delay = remaining < FileCleanupRetryDelay
-                ? remaining
-                : FileCleanupRetryDelay;
-            await Task.Delay(delay, CancellationToken.None);
-        }
-
-        throw new IOException($"Failed to delete temporary database file '{path}' within the cleanup timeout.", lastException);
-    }
+    private static ValueTask DeleteIfExistsAsync(string path) =>
+        ApiTestFileCleanup.DeleteIfExistsAsync(path);
 
     private static async Task WaitForReadinessAsync(
         HttpClient httpClient,

--- a/tests/CSharpDB.Api.Tests/ProcedureApiTests.cs
+++ b/tests/CSharpDB.Api.Tests/ProcedureApiTests.cs
@@ -31,6 +31,39 @@ public sealed class ProcedureApiTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DeleteIfExistsAsync_RetriesPastLegacyTwoSecondWindowsLock()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(), "Windows prevents deleting open files.");
+        string path = Path.Combine(Path.GetTempPath(), $"csharpdb_api_proc_cleanup_{Guid.NewGuid():N}.db");
+        FileStream? lockStream = null;
+        Task? deletion = null;
+        try
+        {
+            lockStream = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+            deletion = DeleteIfExistsAsync(path).AsTask();
+
+            await Task.Delay(TimeSpan.FromMilliseconds(2250), Ct);
+            Assert.False(deletion.IsCompleted);
+
+            await lockStream.DisposeAsync();
+            lockStream = null;
+            await deletion.WaitAsync(TimeSpan.FromSeconds(10), Ct);
+            Assert.False(File.Exists(path));
+        }
+        finally
+        {
+            if (lockStream is not null)
+                await lockStream.DisposeAsync();
+            if (deletion is not null)
+            {
+                try { await deletion; }
+                catch (IOException) { } // Observe the failure without masking the assertion above.
+            }
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task ProcedureCrudAndExecute_HappyPath()
     {
         var create = new CreateProcedureRequest(
@@ -284,38 +317,6 @@ public sealed class ProcedureApiTests : IAsyncLifetime
         }
     }
 
-    private static async ValueTask DeleteIfExistsAsync(string path)
-    {
-        if (!File.Exists(path))
-            return;
-
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        Exception? lastException = null;
-        while (true)
-        {
-            try
-            {
-                File.Delete(path);
-                return;
-            }
-            catch (IOException ex) when (sw.Elapsed < TimeSpan.FromSeconds(2))
-            {
-                lastException = ex;
-            }
-            catch (UnauthorizedAccessException ex) when (sw.Elapsed < TimeSpan.FromSeconds(2))
-            {
-                lastException = ex;
-            }
-
-            if (!File.Exists(path))
-                return;
-
-            if (sw.Elapsed >= TimeSpan.FromSeconds(2))
-                break;
-
-            await Task.Delay(25);
-        }
-
-        throw new IOException($"Failed to delete temporary database file '{path}' within the cleanup timeout.", lastException);
-    }
+    private static ValueTask DeleteIfExistsAsync(string path) =>
+        ApiTestFileCleanup.DeleteIfExistsAsync(path);
 }


### PR DESCRIPTION
## Summary

Follow up on #66 to fix the Windows API test cleanup failure in [CI run 33919923543](https://github.com/MaxAkbar/CSharpDB/actions/runs/33919923543/job/101175663155).

- Share the existing bounded ten-second temporary-file cleanup policy between the HTTP transport and procedure test fixtures. The procedure fixture still used a two-second timeout.
- Keep asynchronous host disposal before cleanup, retry transient Windows locks, and fail with the original exception if a lock persists.
- Add regressions covering the procedure fixture's delayed lock release and the shared helper's permanent-lock failure.

**Version remains 4.6.3.** No version bump, release-note file changes, production changes, workflow changes, tags, or release publication. Only four API test files differ from `main`.

The previous release PR notes are reused below as historical context. The release features described there already landed in #66 and are not new changes in this PR.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / maintenance
- [x] Tests only

## Related Issues

Follow-up to #66; no separate issue supplied.

## Testing

Current fix validation on Windows:

- [ ] Full `dotnet build CSharpDB.slnx` rerun (not needed for this test-only change).
- [x] API test project built in Release configuration.
- [x] Reproduced the old two-second cleanup failure with the new delayed-lock regression before applying the fix.
- [x] Focused cleanup regressions: **3 passed, 0 failed**.
- [x] Complete API test project: **189 passed, 0 failed, 0 skipped**.
- [x] Failure-path coverage verifies persistent locks still fail with their original exception.
- [x] `git diff --check`.
- [ ] Manual verification (not applicable to test cleanup).

The clean PR branch has the same file tree as the tested fix on `version4.6.3`. Hosted CI will provide fresh Windows, Linux, and macOS verification. The older full-release validation numbers in the reused notes below are historical, not new test runs for this fix.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] No user-facing documentation changes are required for this test-only fix.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

The prior ten-second HTTP fixture fix in #64 did not cover the duplicate procedure fixture helper. Centralizing that policy prevents those fixtures from drifting again. Cleanup remains bounded: this does not suppress permanent file-lock failures.

This PR is based directly on current `main` and carries only the cleanup fix, avoiding the previously squash-merged release history.

<details>
<summary>Previous 4.6.3 PR notes, reused from #66</summary>

The following is the earlier release-preparation snapshot, including its original status and validation statements. Those statements describe #66 at creation time; #66 is now merged. Only its relative validation link has been made absolute.

## Summary

Prepare CSharpDB **4.6.3** from the changes since published **v4.6.2**
(`e1c7ace998cf543f8f36af727abdd0024794a24a`). The implementation baseline for
this preparation is `95e5b136`; release metadata changes follow that commit.

- Evolve Admin's Data Model workspace into a relationship-aware modeler with
  curated sources, deterministic layouts, composite relationships, table groups,
  editable saved connector routes, diagram management, undo/redo, and exports.
- Inspect and stage supported schema edits, review exact SQL and dependencies,
  reject stale plans, and apply the reviewed batch transactionally on its route
  when the client supports that capability.
- Centralize internal-table classification and expose System Catalog and
  read-only Internal Storage views with logical-replacement mappings.
- Fix stale row counts during deletion and stale B+tree read-routing caches
  after committed leaf redistribution.
- Add modeler help/tutorials and refresh the changelog/downloads with release
  metadata guardrails. The plugin architecture remains a proposal only.
- Advance package identity and the migration archive default to 4.6.3; add its
  capability catalog without changing the immutable 4.6.2 and older catalogs.

`RELEASE_NOTES.md` contains only this release's changes. The website keeps
v4.6.3 labelled **Unreleased** and retains verified v4.6.2 stable downloads until
publication actually succeeds.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

No linked issue supplied. This PR delivers the Data Modeler and internal-storage
work completed on `version4.6.3`.

## Testing

Local validation completed on 2026-09-04 in isolated Windows and WSL/Linux
checkouts. Final results use the latest complete run of each affected project;
initial failures and reruns remain in the evidence.

- [x] `dotnet build CSharpDB.slnx` — Release builds on Windows and Linux, zero warnings/errors.
- [x] Relevant tests executed — all 25 solution test projects: Windows **7,235 passed / 4 skipped**; Linux **7,234 passed / 5 skipped**; zero remaining failures.
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [ ] Manual verification performed (if applicable)

Also passed: all 49 modeler JavaScript tests on each platform, documentation
guardrails, package closure, EF version consistency, SQL Server/MySQL isolation,
Windows Access isolation, EF migration-tool checks, and published API/Daemon
smokes on Windows and Linux. Linux packing and qualification passed for all
18 candidate NuGet packages, including observability and EF package-only smokes.

The four opt-in live-provider fixtures were not configured; Linux additionally
skips one Windows-only Access worker test. No fresh manual browser walkthrough
was performed. Native checks remain with CI as requested. See
[the validation record](https://github.com/MaxAkbar/CSharpDB/blob/df6a2ee08757c44285d6676754be51c0860dde1c/docs/releases/v4.6.3-validation.md) for scope, corrections, evidence,
and remaining release gates.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- Diagram JSON advances to version 5 with version-1–4 load migrations. Back up
  diagrams before upgrading; older Admin builds may not preserve newer metadata.
  Diagram storage remains database-local and route-local, with no backing-table
  schema or database file-format migration in this release.
- Removing cards, clearing a canvas, ungrouping, or deleting a diagram never
  drops database tables. Schema changes require review and application.
- Windows and WSL/Linux validation are local preflight checks, not the hosted
  release qualification. WSL does not cover macOS-specific behavior.
- NativeAOT/exported-symbol/trim checks were left to CI at the user's request.
  Hosted macOS, balanced previous-release performance qualification, and the
  complete clean-candidate release bundle/publishing gates remain required
  before publication.
- The preparation commit is pushed and this PR is open. No tag, GitHub Release,
  NuGet publication, or release-workflow dispatch has occurred. Use the existing
  tag-last release process after review/merge; do not change or recreate earlier
  tags.

</details>

