### PR TITLE
Fix CSharpDB 4.6.3 release qualification races

### DIFF
--- a/src/CSharpDB.Client/Internal/EngineTransportClient.cs
+++ b/src/CSharpDB.Client/Internal/EngineTransportClient.cs
@@ -1069,6 +1069,7 @@ internal sealed partial class EngineTransportClient :
 
     public async Task<IReadOnlyList<string>> GetCollectionNamesAsync(CancellationToken ct = default)
     {
+        using ClientLockLease clientLock = await AcquireClientLockAsync(ct);
         var db = await GetDatabaseAsync(ct);
         return db.GetCollectionNames()
             .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
@@ -1077,12 +1078,14 @@ internal sealed partial class EngineTransportClient :
 
     public async Task<int> GetCollectionCountAsync(string collectionName, CancellationToken ct = default)
     {
+        using ClientLockLease clientLock = await AcquireClientLockAsync(ct);
         var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(RequireIdentifier(collectionName, nameof(collectionName)), ct);
         return checked((int)await collection.CountAsync(ct));
     }
 
     public async Task<CollectionBrowseResult> BrowseCollectionAsync(string collectionName, int page = 1, int pageSize = 50, CancellationToken ct = default)
     {
+        using ClientLockLease clientLock = await AcquireClientLockAsync(ct);
         string normalizedName = RequireIdentifier(collectionName, nameof(collectionName));
         var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(normalizedName, ct);
         var documents = new List<CollectionDocument>();
@@ -1112,6 +1115,7 @@ internal sealed partial class EngineTransportClient :
 
     public async Task<JsonElement?> GetDocumentAsync(string collectionName, string key, CancellationToken ct = default)
     {
+        using ClientLockLease clientLock = await AcquireClientLockAsync(ct);
         var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(RequireIdentifier(collectionName, nameof(collectionName)), ct);
         var document = await collection.GetAsync(key, ct);
         return document.ValueKind == JsonValueKind.Undefined ? null : document;
@@ -1119,18 +1123,23 @@ internal sealed partial class EngineTransportClient :
 
     public async Task PutDocumentAsync(string collectionName, string key, JsonElement document, CancellationToken ct = default)
     {
+        // Keep collection creation and use inside the same admission boundary
+        // as startup metadata DDL, which can reload the shared catalog.
+        using ClientLockLease clientLock = await AcquireClientLockAsync(ct);
         var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(RequireIdentifier(collectionName, nameof(collectionName)), ct);
         await collection.PutAsync(key, document, ct);
     }
 
     public async Task<bool> DeleteDocumentAsync(string collectionName, string key, CancellationToken ct = default)
     {
+        using ClientLockLease clientLock = await AcquireClientLockAsync(ct);
         var collection = await (await GetDatabaseAsync(ct)).GetCollectionAsync<JsonElement>(RequireIdentifier(collectionName, nameof(collectionName)), ct);
         return await collection.DeleteAsync(key, ct);
     }
 
     public async Task DropCollectionAsync(string collectionName, CancellationToken ct = default)
     {
+        using ClientLockLease clientLock = await AcquireClientLockAsync(ct);
         string normalizedName = RequireIdentifier(collectionName, nameof(collectionName));
         await (await GetDatabaseAsync(ct)).DropCollectionAsync(normalizedName, ct);
     }

--- a/tests/CSharpDB.Benchmarks.Tests/HybridStorageModeQualificationTests.cs
+++ b/tests/CSharpDB.Benchmarks.Tests/HybridStorageModeQualificationTests.cs
@@ -887,15 +887,20 @@ public sealed class HybridStorageModeQualificationTests
         Assert.True(deadline.Token.IsCancellationRequested);
     }
 
-    [Fact]
-    public async Task ConcurrentPhase_PreCapReturnRemainsUnexpectedAfterDeadlineAdvances()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ConcurrentPhase_PreCapReturnRemainsUnexpectedAfterDeadlineAdvances(
+        bool runContinuationsAsynchronously)
     {
         TimeSpan phaseDuration = TimeSpan.FromSeconds(2);
         using var deadline = new ManualQualificationDeadline();
-        var readerStarted = new TaskCompletionSource(
+        var readerRegistered = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseReader = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
+            runContinuationsAsynchronously
+                ? TaskCreationOptions.RunContinuationsAsynchronously
+                : TaskCreationOptions.None);
 
         Task<HybridStorageModeBenchmark.ConcurrentReaderPhaseResult> phaseTask =
             HybridStorageModeBenchmark.RunConcurrentReaderPhaseCoreAsync(
@@ -906,15 +911,15 @@ public sealed class HybridStorageModeQualificationTests
                 minimumLatencySamples: 1,
                 maximumMeasuredDuration: phaseDuration,
                 failAtMaximum: true,
-                (_, _, _, _) =>
-                {
-                    readerStarted.TrySetResult();
-                    return releaseReader.Task;
-                },
+                (_, _, _, _) => releaseReader.Task,
                 deadline,
-                TimeSpan.FromMilliseconds(25));
+                BenchmarkTestWatchdog.SchedulingTimeout,
+                readerTaskAttached: _ => readerRegistered.TrySetResult());
 
-        await readerStarted.Task.WaitAsync(
+        // Returning a task from the reader delegate is not the same as the
+        // harness having registered it. Advance time only after registration,
+        // so this exercises a pre-cap completion rather than a startup race.
+        await readerRegistered.Task.WaitAsync(
             BenchmarkTestWatchdog.SchedulingTimeout,
             TestContext.Current.CancellationToken);
         deadline.AdvanceTo(TimeSpan.FromSeconds(1));

--- a/tests/CSharpDB.Benchmarks/Macro/HybridStorageModeBenchmark.cs
+++ b/tests/CSharpDB.Benchmarks/Macro/HybridStorageModeBenchmark.cs
@@ -723,7 +723,8 @@ public static class HybridStorageModeBenchmark
         IQualificationDeadline deadline,
         TimeSpan cancellationDrainTimeout,
         Func<Func<Task>, Task>? scheduleReader = null,
-        Action<Task>? detachedWorkRegistrar = null)
+        Action<Task>? detachedWorkRegistrar = null,
+        Action<int>? readerTaskAttached = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(benchmarkName);
         ArgumentOutOfRangeException.ThrowIfLessThan(readerCount, 1);
@@ -804,6 +805,7 @@ public static class HybridStorageModeBenchmark
                         CancellationToken.None,
                         TaskContinuationOptions.ExecuteSynchronously,
                         TaskScheduler.Default);
+                    readerTaskAttached?.Invoke(capturedReaderIndex);
                     try
                     {
                         await readerLoopTask.ConfigureAwait(false);

--- a/tests/CSharpDB.Daemon.Tests/GrpcClientTests.cs
+++ b/tests/CSharpDB.Daemon.Tests/GrpcClientTests.cs
@@ -1880,6 +1880,31 @@ public sealed class GrpcClientTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GrpcClient_CollectionWritesDuringStartup_PreserveAllDocuments()
+    {
+        using var transportClient = CreateGrpcHttpClient();
+        await using var client = CreateGrpcClient(transportClient);
+        using JsonDocument document = JsonDocument.Parse("""{"meta":{"score":9}}""");
+
+        // Do not wait for readiness: the first requests can overlap the host's
+        // GetInfoAsync catalog initialization, just as in the release failure.
+        Task[] writes = Enumerable.Range(0, 16)
+            .Select(index => client.PutDocumentAsync(
+                $"startup_docs_{index}", "one", document.RootElement, Ct))
+            .ToArray();
+        await Task.WhenAll(writes.Append(client.GetInfoAsync(Ct)));
+
+        for (int index = 0; index < writes.Length; index++)
+        {
+            string name = $"startup_docs_{index}";
+            JsonElement? fetched = await client.GetDocumentAsync(name, "one", Ct);
+            Assert.True(fetched.HasValue);
+            Assert.Equal(9, fetched.Value.GetProperty("meta").GetProperty("score").GetInt32());
+            Assert.Equal(1, await client.GetCollectionCountAsync(name, Ct));
+        }
+    }
+
+    [Fact]
     public async Task GrpcClient_ProcedureCrudAndValidation_WorkThroughTransport()
     {
         using var transportClient = CreateGrpcHttpClient();

--- a/tests/CSharpDB.Tests/ClientCollectionConcurrencyTests.cs
+++ b/tests/CSharpDB.Tests/ClientCollectionConcurrencyTests.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using System.Text.Json;
+using CSharpDB.Client.Internal;
+
+namespace CSharpDB.Tests;
+
+public sealed class ClientCollectionConcurrencyTests
+{
+    [Theory]
+    [InlineData("names")]
+    [InlineData("count")]
+    [InlineData("browse")]
+    [InlineData("get")]
+    [InlineData("put")]
+    [InlineData("delete")]
+    [InlineData("drop")]
+    public async Task CollectionOperations_WaitForCatalogOwner_AndHonorCancellation(string operation)
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await using var client = EngineTransportClient.CreatePrivateMemory(
+            "collection-concurrency", loadFromPath: null, directDatabaseOptions: null);
+        using JsonDocument document = JsonDocument.Parse("""{"name":"original"}""");
+        await client.GetInfoAsync(ct);
+        await client.PutDocumentAsync("docs", "one", document.RootElement, ct);
+
+        // Hold the same admission gate as GetInfoAsync's startup catalog DDL.
+        // In-memory operations otherwise complete synchronously, so no sleep or
+        // thread-pool timing is needed to expose a collection call bypassing it.
+        var gate = Assert.IsType<SemaphoreSlim>(typeof(EngineTransportClient)
+            .GetField("_lock", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client));
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        await gate.WaitAsync(ct);
+        Task? pending = null;
+        try
+        {
+            pending = InvokeOperationAsync(cancellation.Token);
+            Assert.False(pending.IsCompleted);
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            gate.Release();
+            if (pending is not null)
+            {
+                try
+                {
+                    await pending;
+                }
+                catch (OperationCanceledException)
+                {
+                    // The cancelled waiter must not prevent later operations.
+                }
+            }
+        }
+
+        JsonElement? retained = await client.GetDocumentAsync("docs", "one", ct);
+        Assert.True(retained.HasValue);
+        Assert.Equal("original", retained.Value.GetProperty("name").GetString());
+        Assert.Equal(1, await client.GetCollectionCountAsync("docs", ct));
+        await InvokeOperationAsync(ct);
+
+        Task InvokeOperationAsync(CancellationToken token) => operation switch
+        {
+            "names" => client.GetCollectionNamesAsync(token),
+            "count" => client.GetCollectionCountAsync("docs", token),
+            "browse" => client.BrowseCollectionAsync("docs", ct: token),
+            "get" => client.GetDocumentAsync("docs", "one", token),
+            "put" => client.PutDocumentAsync("docs", "two", document.RootElement, token),
+            "delete" => client.DeleteDocumentAsync("docs", "one", token),
+            "drop" => client.DropCollectionAsync("docs", token),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Fix the two issues exposed by [release qualification run 33936833544](https://github.com/MaxAkbar/CSharpDB/actions/runs/33936833544), without changing version **4.6.3**.

- Serialize all seven direct-client collection operations with the existing client admission lock. Startup `GetInfoAsync` creates internal catalogs while holding that lock; collection operations previously bypassed it and could overlap a shared-catalog reload. Keep collection creation and document access under the same lease.
- Fix the benchmark test's ordering: its old reader-start signal occurred before the harness attached the reader task. Wait for actual registration before forcing completion and deadline expiration, and cover both inline and asynchronously scheduled continuations.
- Add collection admission/cancellation regressions and a gRPC cold-start test with concurrent writes to 16 collections.

Only five files change. No engine format, schema DDL, release workflow, package version, or release-note file changes. The benchmark production deadlines and performance gates are unchanged; the non-timeout regression uses the existing scheduling watchdog for its drain.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

Follow-up to #67 and the failed 4.6.3 release qualification; no separate issue supplied.

## Testing

- [x] Before the client fix, all **7** new collection admission cases failed, proving they bypassed the lock.
- [x] After the client fix, all **7** admission/cancellation cases passed on Windows.
- [x] Windows core suite: **2,900 passed**, including the seven new regression cases. Two sample programs exited successfully but left build workers holding their output pipes; stopping only those verified orphan workers allowed the run to finish.
- [x] Windows and WSL/Linux benchmark suites: **154 passed on each platform**.
- [x] Original gRPC collection round-trip and new cold-start regression: **2 passed on each platform** after the fix.
- [x] WSL/Linux core: **2,900 passed**; API: **187 passed, 2 Windows-only skips**; Admin Forms: **554 passed**.
- [x] Windows API: **189 passed**; Admin Forms: **554 passed**.
- [x] All jobs passed in [CI run 33941733455](https://github.com/MaxAkbar/CSharpDB/actions/runs/33941733455): Windows/Ubuntu/macOS build-and-test, native AOT and host observability, release baseline compatibility, and package qualification. Hosted Windows and Ubuntu Daemon suites each passed all **247** tests, including the script fixtures below.
- [x] [Performance report job 33941733456](https://github.com/MaxAkbar/CSharpDB/actions/runs/33941733456) completed successfully. **This is not performance qualification:** its 46 comparison rows were all skipped by the existing machine-fingerprint policy; no regression pass is claimed.
- [ ] Local Windows Daemon full suite: **245 passed, 2 failed by timeout**, in the unchanged `Wrapper_ExecutesInterleavedSuitesAndRejectsDuplicateMedians` and `ExactMasterDurableRunner_StagesConditionsAndRetainsEveryScheduledRawRow` fixtures. Both passed in hosted Windows CI. The first local Daemon attempt was stopped after discovering the inherited desktop PATH exceeded cmd.exe's environment-value limit and prevented fake-tool shims from finding PowerShell. A process-local shorter PATH corrected tool discovery; no machine-wide or repository settings changed.
- [ ] WSL/Linux Daemon full suite: **241 passed, 6 failed by timeout** in unchanged release-script fixtures.
- [x] All six Linux timeout failures passed in a separate serialized check: **9 passed** including adjacent theory cases. No timeout limits were changed. This does not turn the earlier full local run into a clean pass.
- [x] `git diff --check` against the PR's exact main baseline `2690bf01`.
- [ ] Manual UI verification (not applicable).

The six local Linux timeout cases were `Wrapper_ExecutesInterleavedSuitesAndRejectsDuplicateMedians`, `ExactMasterDurableRunner_StagesConditionsAndRetainsEveryScheduledRawRow`, `SharedArtifactScenarioRunner_UsesOneCandidateArtifactForBothLabels`, `Publisher_FailedPublication_RetriesWithSameBoundQualificationId`, `Verifier_AcceptsLatestCanonicalStatusForExactCommit`, and the `success` case of `DurableRunner_MonitorAuditValidatesCoverageAndState`.

Hosted release qualification has not been rerun. All 15 PR checks are green, but the release publisher must still qualify the eventual merged commit before creating a tag or publishing packages.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] Existing 4.6.3 documentation and release notes are retained.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

The background publisher stopped at qualification. No 4.6.3 tag or GitHub Release was recreated. This PR does not dispatch publication or merge itself; qualification must run again against the eventual merged `main` commit.

The previous 4.6.3 release PR notes are reused below as historical context, not as changes newly introduced or tests rerun by this PR.

<details>
<summary>Previous 4.6.3 release notes reused from #66</summary>

Historical release-preparation snapshot: #66 has already merged. Its original validation and publication-state statements apply to that earlier PR; only the relative validation link below has been made absolute.

## Summary

Prepare CSharpDB **4.6.3** from the changes since published **v4.6.2**
(`e1c7ace998cf543f8f36af727abdd0024794a24a`). The implementation baseline for
this preparation is `95e5b136`; release metadata changes follow that commit.

- Evolve Admin's Data Model workspace into a relationship-aware modeler with
  curated sources, deterministic layouts, composite relationships, table groups,
  editable saved connector routes, diagram management, undo/redo, and exports.
- Inspect and stage supported schema edits, review exact SQL and dependencies,
  reject stale plans, and apply the reviewed batch transactionally on its route
  when the client supports that capability.
- Centralize internal-table classification and expose System Catalog and
  read-only Internal Storage views with logical-replacement mappings.
- Fix stale row counts during deletion and stale B+tree read-routing caches
  after committed leaf redistribution.
- Add modeler help/tutorials and refresh the changelog/downloads with release
  metadata guardrails. The plugin architecture remains a proposal only.
- Advance package identity and the migration archive default to 4.6.3; add its
  capability catalog without changing the immutable 4.6.2 and older catalogs.

`RELEASE_NOTES.md` contains only this release's changes. The website keeps
v4.6.3 labelled **Unreleased** and retains verified v4.6.2 stable downloads until
publication actually succeeds.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / maintenance
- [ ] Tests only

## Related Issues

No linked issue supplied. This PR delivers the Data Modeler and internal-storage
work completed on `version4.6.3`.

## Testing

Local validation completed on 2026-09-04 in isolated Windows and WSL/Linux
checkouts. Final results use the latest complete run of each affected project;
initial failures and reruns remain in the evidence.

- [x] `dotnet build CSharpDB.slnx` — Release builds on Windows and Linux, zero warnings/errors.
- [x] Relevant tests executed — all 25 solution test projects: Windows **7,235 passed / 4 skipped**; Linux **7,234 passed / 5 skipped**; zero remaining failures.
- [x] Failure-path tests executed (if applicable: cancellation, invalid/unsupported inputs, non-`DbException` paths)
- [ ] Manual verification performed (if applicable)

Also passed: all 49 modeler JavaScript tests on each platform, documentation
guardrails, package closure, EF version consistency, SQL Server/MySQL isolation,
Windows Access isolation, EF migration-tool checks, and published API/Daemon
smokes on Windows and Linux. Linux packing and qualification passed for all
18 candidate NuGet packages, including observability and EF package-only smokes.

The four opt-in live-provider fixtures were not configured; Linux additionally
skips one Windows-only Access worker test. No fresh manual browser walkthrough
was performed. Native checks remain with CI as requested. See
[the validation record](https://github.com/MaxAkbar/CSharpDB/blob/df6a2ee08757c44285d6676754be51c0860dde1c/docs/releases/v4.6.3-validation.md) for scope, corrections, evidence,
and remaining release gates.

## Checklist

- [x] I followed the project style and conventions.
- [x] I added or updated tests for behavior changes.
- [x] I covered both success and failure paths for changed behavior.
- [x] I updated docs for user-facing changes.
- [x] I verified no sensitive data was added.

## Notes for Reviewers

- Diagram JSON advances to version 5 with version-1–4 load migrations. Back up
  diagrams before upgrading; older Admin builds may not preserve newer metadata.
  Diagram storage remains database-local and route-local, with no backing-table
  schema or database file-format migration in this release.
- Removing cards, clearing a canvas, ungrouping, or deleting a diagram never
  drops database tables. Schema changes require review and application.
- Windows and WSL/Linux validation are local preflight checks, not the hosted
  release qualification. WSL does not cover macOS-specific behavior.
- NativeAOT/exported-symbol/trim checks were left to CI at the user's request.
  Hosted macOS, balanced previous-release performance qualification, and the
  complete clean-candidate release bundle/publishing gates remain required
  before publication.
- The preparation commit is pushed and this PR is open. No tag, GitHub Release,
  NuGet publication, or release-workflow dispatch has occurred. Use the existing
  tag-last release process after review/merge; do not change or recreate earlier
  tags.

</details>
